### PR TITLE
Create the mirror in the release namespace

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -289,6 +289,9 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 		}
 
 		job, err := c.ensureReleaseJob(release, tag.Name, mirror)
+		if err != nil {
+			return nil, err
+		}
 		success, complete := jobIsComplete(job)
 		switch {
 		case !complete:

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -388,7 +388,7 @@ func (c *Controller) syncReady(release *Release, readyReleaseTags []*imagev1.Tag
 			acceptedReleaseTags = append(acceptedReleaseTags, tag)
 		}
 	}
-	sort.Slice(acceptedReleaseTags, func(i, j int) bool { return acceptedReleaseTags[i].Name > acceptedReleaseTags[j].Name })
+	sort.Sort(tagReferencesByAge(acceptedReleaseTags))
 	return acceptedReleaseTags, nil
 }
 


### PR DESCRIPTION
Makes it more accessible and ensures the images are pullable by the same
clients.