### PR TITLE
Take the target image stream as an argument rather than hardcode

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -33,9 +33,10 @@ import (
 )
 
 type options struct {
-	ReleaseNamespace string
-	JobNamespace     string
-	ProwNamespace    string
+	ReleaseNamespace   string
+	JobNamespace       string
+	ProwNamespace      string
+	ReleaseImageStream string
 
 	ProwConfigPath string
 	JobConfigPath  string
@@ -46,7 +47,9 @@ func main() {
 	original.Set("alsologtostderr", "true")
 	original.Set("v", "2")
 
-	opt := &options{}
+	opt := &options{
+		ReleaseImageStream: "release",
+	}
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, arguments []string) {
 			if err := opt.Run(); err != nil {
@@ -55,6 +58,7 @@ func main() {
 		},
 	}
 	flag := cmd.Flags()
+	flag.StringVar(&opt.ReleaseImageStream, "to", opt.ReleaseImageStream, "The image stream in the release namespace to push releases to.")
 	flag.StringVar(&opt.JobNamespace, "job-namespace", opt.JobNamespace, "The namespace to execute jobs and hold temporary objects.")
 	flag.StringVar(&opt.ReleaseNamespace, "release-namespace", opt.ReleaseNamespace, "The namespace where the releases will be published to.")
 	flag.StringVar(&opt.ProwNamespace, "prow-namespace", opt.ProwNamespace, "The namespace where the Prow jobs will be created (defaults to --job-namespace).")
@@ -127,6 +131,7 @@ func (o *options) Run() error {
 		jobs,
 		configAgent,
 		prowClient.Namespace(o.ProwNamespace),
+		o.ReleaseImageStream,
 		o.ReleaseNamespace,
 		o.JobNamespace,
 	)

--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -26,11 +26,11 @@ func (c *Controller) releaseDefinition(is *imagev1.ImageStream) (*Release, bool,
 		return nil, false, terminalError{err}
 	}
 
-	targetImageStream, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(releaseImageStreamName)
+	targetImageStream, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(c.releaseImageStream)
 	if errors.IsNotFound(err) {
 		// TODO: something special here?
-		glog.V(2).Infof("The release image stream %s/%s does not exist", c.releaseNamespace, releaseImageStreamName)
-		return nil, false, terminalError{fmt.Errorf("the output release image stream %s/%s does not exist", releaseImageStreamName, is.Name)}
+		glog.V(2).Infof("The release image stream %s/%s does not exist", c.releaseNamespace, c.releaseImageStream)
+		return nil, false, terminalError{fmt.Errorf("the output release image stream %s/%s does not exist", c.releaseImageStream, is.Name)}
 	}
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to lookup release image stream: %v", err)

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -695,7 +695,7 @@ func (c *Controller) ensureTagPointsToRelease(release *Release, to, from string)
 }
 
 func (c *Controller) garbageCollectUnreferencedObjects() error {
-	is, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(releaseImageStreamName)
+	is, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(c.releaseImageStream)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -77,13 +77,6 @@ type ProwJobVerification struct {
 }
 
 const (
-	// releaseImageStreamName is the hardcoded image stream that release images will
-	// be pushed to.
-	// TODO: make configurable
-	releaseImageStreamName = "release"
-)
-
-const (
 	// releasePhasePending is assigned to release tags that are waiting for an update
 	// payload image to be created and pushed.
 	//


### PR DESCRIPTION
We will push origin and ocp releases to separate image streams.