### PR TITLE
Ensure controllers don't fight over shared prow jobs

### DIFF
--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -26,6 +26,9 @@ func (c *Controller) releaseDefinition(is *imagev1.ImageStream) (*Release, bool,
 		return nil, false, terminalError{err}
 	}
 
+	// TODO: require release config to point to a particular image stream, and then we should ignore image streams
+	//   that don't target c.releaseImageStream (so we can run separate controllers)
+
 	targetImageStream, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(c.releaseImageStream)
 	if errors.IsNotFound(err) {
 		// TODO: something special here?

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -113,6 +113,7 @@ const (
 	releaseAnnotationGeneration        = "release.openshift.io/generation"
 	releaseAnnotationSource            = "release.openshift.io/source"
 	releaseAnnotationName              = "release.openshift.io/name"
+	releaseAnnotationReleaseTag        = "release.openshift.io/releaseTag"
 	releaseAnnotationImageHash         = "release.openshift.io/hash"
 	releaseAnnotationPhase             = "release.openshift.io/phase"
 	releaseAnnotationCreationTimestamp = "release.openshift.io/creationTimestamp"


### PR DESCRIPTION
Only process image streams in the release namespace.  This was causing panics when testing on the api.ci cluster because neither controller could see the release tags the others create that were referenced by the prow jobs in the ci namespace.

Because ProwJobs are shared, we can see triggers in other namespaces that
we won't be able to access. Only queue the release namespace.

Also, clean up the mirror so that we can make it match our output. Mirror should be `<source>-<date>` so that it sorts with the source

    name    = v4.0 
    source  = origin-v4.0 
    mirror  = origin-v4.0-20180919010102
    tag     = v4.0-20180919010102 
    promote = v4.0