### PR TITLE
Report links immediately instead of after job runs

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -107,10 +107,13 @@ func links(tag imagev1.TagReference, release *Release) string {
 	for _, key := range keys {
 		if s, ok := status[key]; ok {
 			if len(s.Url) > 0 {
-				if s.State == releaseVerificationStateFailed {
+				switch s.State {
+				case releaseVerificationStateFailed:
 					buf.WriteString(" <a title=\"Failed\" class=\"text-danger\" href=\"")
-				} else {
+				case releaseVerificationStateSucceeded:
 					buf.WriteString(" <a title=\"Succeeded\" class=\"text-success\" href=\"")
+				default:
+					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
 				}
 				buf.WriteString(template.HTMLEscapeString(s.Url))
 				buf.WriteString("\">")
@@ -118,10 +121,13 @@ func links(tag imagev1.TagReference, release *Release) string {
 				buf.WriteString("</a>")
 				continue
 			}
-			if s.State == releaseVerificationStateFailed {
+			switch s.State {
+			case releaseVerificationStateFailed:
 				buf.WriteString(" <span title=\"Failed\" class=\"text-danger\">")
-			} else {
+			case releaseVerificationStateSucceeded:
 				buf.WriteString(" <span title=\"Succeeded\" class=\"text-success\">")
+			default:
+				buf.WriteString(" <span title=\"Pending\" class=\"\">")
 			}
 			buf.WriteString(template.HTMLEscapeString(key))
 			buf.WriteString("</span>")

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -134,6 +134,7 @@ const (
 
 	releaseVerificationStateSucceeded = "Succeeded"
 	releaseVerificationStateFailed    = "Failed"
+	releaseVerificationStatePending   = "Pending"
 
 	// releaseAnnotationConfig is the JSON serialized representation of the ReleaseConfig
 	// struct. It is only accepted on image streams. An image stream with this annotation

--- a/pkg/prow/apiv1/types.go
+++ b/pkg/prow/apiv1/types.go
@@ -79,15 +79,15 @@ const (
 	// TriggeredState means the job has been created but not yet scheduled.
 	TriggeredState ProwJobState = "triggered"
 	// PendingState means the job is scheduled but not yet running.
-	PendingState = "pending"
+	PendingState ProwJobState = "pending"
 	// SuccessState means the job completed without error (exit 0)
-	SuccessState = "success"
+	SuccessState ProwJobState = "success"
 	// FailureState means the job completed with errors (exit non-zero)
-	FailureState = "failure"
+	FailureState ProwJobState = "failure"
 	// AbortedState means prow killed the job early (new commit pushed, perhaps).
-	AbortedState = "aborted"
+	AbortedState ProwJobState = "aborted"
 	// ErrorState means the job could not schedule (bad config, perhaps).
-	ErrorState = "error"
+	ErrorState ProwJobState = "error"
 )
 
 // ProwJobAgent specifies the controller (such as plank or jenkins-agent) that runs the job.


### PR DESCRIPTION
We write the verification status eagerly, using a new 'Pending' state
to represent jobs in progress. Avoid calling update if we make no
changes to a tag. Report the pending state in the release status page.