### PR TITLE
Sync all verification jobs, not just the first

### DIFF
--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -187,3 +187,24 @@ func tagsForRelease(release *Release) []*imagev1.TagReference {
 	sort.Sort(tagReferencesByAge(tags))
 	return tags
 }
+
+func stringSliceContains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func findTagReferencesByPhase(release *Release, phases ...string) []*imagev1.TagReference {
+	var tags []*imagev1.TagReference
+	for i := range release.Target.Spec.Tags {
+		tag := &release.Target.Spec.Tags[i]
+		if stringSliceContains(phases, tag.Annotations[releaseAnnotationPhase]) {
+			tags = append(tags, tag)
+		}
+	}
+	sort.Sort(tagReferencesByAge(tags))
+	return tags
+}

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -99,7 +99,10 @@ func (m VerificationStatusMap) Failures() ([]string, bool) {
 
 func (m VerificationStatusMap) Incomplete(required map[string]ReleaseVerification) ([]string, bool) {
 	var names []string
-	for name := range required {
+	for name, definition := range required {
+		if definition.Disabled {
+			continue
+		}
 		if s, ok := m[name]; !ok || s.State != releaseVerificationStateSucceeded {
 			names = append(names, name)
 		}


### PR DESCRIPTION
Slightly simplify how tags are synced. Ensure disabled jobs aren't
considered as incomplete.