### PR TITLE
Switch back to 'payload' in the fake image graph

### DIFF
--- a/cmd/release-controller/graph.go
+++ b/cmd/release-controller/graph.go
@@ -10,7 +10,7 @@ import (
 
 type ReleaseNode struct {
 	Version string `json:"version"`
-	Image   string `json:"image"`
+	Payload string `json:"payload"`
 }
 
 type ReleaseEdge []int
@@ -46,7 +46,7 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 		for _, tag := range s.Tags {
 			nodes = append(nodes, ReleaseNode{
 				Version: tag.Name,
-				Image:   s.Release.Target.Status.PublicDockerImageRepository + ":" + tag.Name,
+				Payload: s.Release.Target.Status.PublicDockerImageRepository + ":" + tag.Name,
 			})
 		}
 		sort.Slice(nodes, func(i, j int) bool {


### PR DESCRIPTION
CVO and Cincinnati v1 reverted to using generic 'payload'.