### PR TITLE
Show partial progression when changelogs are being generated

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -394,6 +395,10 @@ func (c *Controller) httpReleaseChangelog(w http.ResponseWriter, req *http.Reque
 	fmt.Fprintln(w, out)
 }
 
+type nopFlusher struct{}
+
+func (_ nopFlusher) Flush() {}
+
 func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
@@ -417,49 +422,62 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		info.Previous = tags[from].Tag
 	}
 
-	if pull := info.Release.Target.Status.PublicDockerImageRepository; info.Previous != nil && len(pull) > 0 {
-		out, err := c.releaseInfo.ChangeLog(pull+":"+info.Previous.Name, pull+":"+info.Tag.Name)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Internal error\n%v", err), http.StatusInternalServerError)
-			return
-		}
-
-		// replace references to the previous version with links
-		rePrevious, err := regexp.Compile(fmt.Sprintf(`(\W)%s(\W)`, regexp.QuoteMeta(info.Previous.Name)))
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Internal error\n%v", err), http.StatusInternalServerError)
-			return
-		}
-		out = rePrevious.ReplaceAllString(out, fmt.Sprintf("$1[%s](/releasestream/%s/release/%s)$2", info.Previous.Name, info.Release.Config.Name, info.Previous.Name))
-
-		result := blackfriday.Run([]byte(out))
-
-		w.Header().Set("Content-Type", "text/html;charset=UTF-8")
-		fmt.Fprintf(w, htmlPageStart, fmt.Sprintf("Release %s", tag))
-		fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
-		w.Write(result)
-
-		fmt.Fprintln(w, "<hr>")
-		fmt.Fprintf(w, `<p>Pull spec: <code>%s:%s</code></p>`, pull, tag)
-
-		fmt.Fprintf(w, `<p>Tests:</p><ul>%s</ul>`, extendedLinks(*info.Tag, info.Release))
-
-		if len(info.Older) > 0 {
-			var options []string
-			for _, tag := range info.Older {
-				var selected string
-				if tag.Name == info.Previous.Name {
-					selected = `selected="true"`
-				}
-				options = append(options, fmt.Sprintf(`<option %s>%s</option>`, selected, tag.Name))
-			}
-			fmt.Fprintf(w, `<p><form class="form-inline" method="GET"><a href="/changelog?from=%s&to=%s">View changelog in Markdown</a><span>&nbsp;or&nbsp;</span><label for="from">change previous release:&nbsp;</label><select id="from" class="form-control" name="from">%s</select> <input class="btn btn-link" type="submit" value="Compare"></form></p>`, info.Previous.Name, info.Tag.Name, strings.Join(options, ""))
-		}
-		fmt.Fprintln(w, htmlPageEnd)
-		return
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		flusher = nopFlusher{}
 	}
 
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
+	fmt.Fprintf(w, htmlPageStart, fmt.Sprintf("Release %s", tag))
+	defer func() { fmt.Fprintln(w, htmlPageEnd) }()
+
+	if pull := info.Release.Target.Status.PublicDockerImageRepository; info.Previous != nil && len(pull) > 0 {
+		type renderResult struct {
+			out string
+			err error
+		}
+		ch := make(chan renderResult)
+
+		// run the changelog in a goroutine because it may take significant time
+		go func() {
+			out, err := c.releaseInfo.ChangeLog(pull+":"+info.Previous.Name, pull+":"+info.Tag.Name)
+			if err != nil {
+				ch <- renderResult{err: err}
+				return
+			}
+
+			// replace references to the previous version with links
+			rePrevious, err := regexp.Compile(fmt.Sprintf(`(\W)%s(\W)`, regexp.QuoteMeta(info.Previous.Name)))
+			if err != nil {
+				ch <- renderResult{err: err}
+				return
+			}
+			out = rePrevious.ReplaceAllString(out, fmt.Sprintf("$1[%s](/releasestream/%s/release/%s)$2", info.Previous.Name, info.Release.Config.Name, info.Previous.Name))
+			ch <- renderResult{out: out}
+		}()
+
+		var render renderResult
+		select {
+		case render = <-ch:
+		case <-time.After(500 * time.Millisecond):
+			fmt.Fprintf(w, `<p id="loading" class="alert alert-info">Loading changelog, this may take a while ...</p>`)
+			flusher.Flush()
+			select {
+			case render = <-ch:
+			case <-time.After(10 * time.Second):
+				render.err = fmt.Errorf("Change log took too long to generate, retry in a few minutes")
+			}
+			fmt.Fprintf(w, `<style>#loading{display: none;}</style>`)
+			flusher.Flush()
+		}
+		if render.err == nil {
+			renderChangelog(w, render.out, pull, tag, info)
+			return
+		}
+
+		// if we don't get a valid result within limits, just show the simpler informational view
+		fmt.Fprintf(w, `<p class="alert alert-danger">%s</p>`, fmt.Sprintf("Unable to show changelog, will show simpler view: %s", render.err))
+	}
 
 	now := time.Now()
 	var releasePage = template.Must(template.New("releaseInfoPage").Funcs(
@@ -483,11 +501,45 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		},
 	).Parse(releaseInfoPageHtml))
 
-	fmt.Fprintf(w, htmlPageStart, fmt.Sprintf("Release %s", tag))
+	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
 	if err := releasePage.Execute(w, info); err != nil {
 		glog.Errorf("Unable to render page: %v", err)
 	}
-	fmt.Fprintln(w, htmlPageEnd)
+}
+
+func renderChangelog(w io.Writer, markdown string, pull, tag string, info *ReleaseStreamTag) {
+	result := blackfriday.Run([]byte(markdown))
+
+	// minor changelog styling tweaks
+	fmt.Fprintf(w, `
+<style>
+	h1 { font-size: 2rem; margin-bottom: 1rem }
+	h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 1rem  }
+	h3 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 1rem  }
+	h4 { font-size: 1.2rem; margin-top: 2rem; margin-bottom: 1rem  }
+	h3 a { text-transform: uppercase; font-size: 1rem; }
+</style>
+`)
+
+	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
+	w.Write(result)
+
+	fmt.Fprintln(w, "<hr>")
+	fmt.Fprintf(w, `<p>Pull spec: <code>%s:%s</code></p>`, pull, tag)
+
+	fmt.Fprintf(w, `<p>Tests:</p><ul>%s</ul>`, extendedLinks(*info.Tag, info.Release))
+
+	if len(info.Older) > 0 {
+		var options []string
+		for _, tag := range info.Older {
+			var selected string
+			if tag.Name == info.Previous.Name {
+				selected = `selected="true"`
+			}
+			options = append(options, fmt.Sprintf(`<option %s>%s</option>`, selected, tag.Name))
+		}
+		fmt.Fprintf(w, `<p><form class="form-inline" method="GET"><a href="/changelog?from=%s&to=%s">View changelog in Markdown</a><span>&nbsp;or&nbsp;</span><label for="from">change previous release:&nbsp;</label><select id="from" class="form-control" name="from">%s</select> <input class="btn btn-link" type="submit" value="Compare"></form></p>`, info.Previous.Name, info.Tag.Name, strings.Join(options, ""))
+	}
 }
 
 func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Display a loading banner at 500ms, an error at 10s, fallthrough to
the generic layout, and tweak styles.