### PR TITLE
Mount secrets in for accessing protected repositories

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -462,7 +462,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			select {
 			case render = <-ch:
 			case <-time.After(10 * time.Second):
-				render.err = fmt.Errorf("Change log took too long to generate, retry in a few minutes")
+				render.err = fmt.Errorf("the changelog is still loading, if this is the first access it may take several minutes to clone all repositories")
 			}
 			fmt.Fprintf(w, `<style>#loading{display: none;}</style>`)
 			flusher.Flush()
@@ -473,7 +473,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// if we don't get a valid result within limits, just show the simpler informational view
-		fmt.Fprintf(w, `<p class="alert alert-danger">%s</p>`, fmt.Sprintf("Unable to show changelog, will show simpler view: %s", render.err))
+		fmt.Fprintf(w, `<p class="alert alert-danger">%s</p>`, fmt.Sprintf("Unable to show full changelog: %s", render.err))
 	}
 
 	now := time.Now()

--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -175,6 +175,24 @@ func findTagReference(is *imagev1.ImageStream, name string) *imagev1.TagReferenc
 	return nil
 }
 
+func findImagePullSpec(is *imagev1.ImageStream, name string) string {
+	for i := range is.Status.Tags {
+		tag := &is.Status.Tags[i]
+		if tag.Tag == name {
+			if len(tag.Items) == 0 {
+				if specTag := findSpecTag(is.Spec.Tags, name); specTag != nil {
+					if from := specTag.From; from != nil && from.Kind == "DockerImage" {
+						return from.Name
+					}
+				}
+				return ""
+			}
+			return tag.Items[0].DockerImageReference
+		}
+	}
+	return ""
+}
+
 func tagsForRelease(release *Release) []*imagev1.TagReference {
 	tags := make([]*imagev1.TagReference, 0, len(release.Target.Spec.Tags))
 	for i := range release.Target.Spec.Tags {


### PR DESCRIPTION
Mount the `git-credentials` secret from the release job namespace
into the pod for use with cloning protected repos.

Load the most recent tagged 'tests' image from the first release
stream in the release namespace (4.0.0-0.ci for release-ocp) and
update it every few hours to avoid having to periodically update
the operator.