### PR TITLE
Set the release tag input hash *after* we mirror

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -55,7 +55,11 @@ const releasePageHtml = `
 		{{ range .Tags }}
 			{{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
 			<tr class="{{ phaseAlert . }}">
+				{{ if canLink . }}
 				<td><a href="/releasestream/{{ $release.Config.Name }}/release/{{ .Name }}">{{ .Name }}</a></td>
+				{{ else }}
+				<td>{{ .Name }}</td>
+				{{ end }}
 				{{ phaseCell . }}
 				<td title="{{ $created }}">{{ since $created }}</td>
 				<td>{{ links . $release }}</td>
@@ -104,6 +108,10 @@ func phaseAlert(tag imagev1.TagReference) string {
 	default:
 		return "alert-danger"
 	}
+}
+
+func canLink(tag imagev1.TagReference) bool {
+	return tag.Annotations[releaseAnnotationPhase] != releasePhasePending
 }
 
 func links(tag imagev1.TagReference, release *Release) string {
@@ -487,6 +495,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			},
 			"phaseCell":  phaseCell,
 			"phaseAlert": phaseAlert,
+			"canLink":    canLink,
 			"links":      links,
 			"since": func(utcDate string) string {
 				t, err := time.Parse(time.RFC3339, utcDate)
@@ -581,6 +590,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 			},
 			"phaseCell":  phaseCell,
 			"phaseAlert": phaseAlert,
+			"canLink":    canLink,
 			"links":      links,
 			"since": func(utcDate string) string {
 				t, err := time.Parse(time.RFC3339, utcDate)

--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -101,8 +101,8 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string) (string, error) {
 		Stdin:  nil,
 		Stderr: errOut,
 	}); err != nil {
-		glog.V(4).Infof("Failed to generate changelog:\n$ %s\n%s\n%s", strings.Join(cmd, " "), errOut.String(), out.String())
-		return "", fmt.Errorf("could not run remote command: %v", err)
+		glog.V(4).Infof("Failed to generate changelog: %v\n$ %s\n%s\n%s", err, strings.Join(cmd, " "), errOut.String(), out.String())
+		return "", fmt.Errorf("could not generate a changelog: %v", err)
 	}
 
 	return out.String(), nil
@@ -192,6 +192,8 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 						Image: image,
 						Env: []corev1.EnvVar{
 							{Name: "HOME", Value: "/tmp"},
+							{Name: "GIT_COMMITTER_NAME", Value: "test"},
+							{Name: "GIT_COMMITTER_EMAIL", Value: "test@test.com"},
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{Name: "git", MountPath: "/tmp/git/"},
@@ -210,6 +212,8 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 							trap 'kill $(jobs -p); exit 0' TERM
 
 							git config --global credential.helper store
+							git config --global user.name test
+							git config --global user.email test@test.com
 							oc registry login
 							while true; do
 								sleep 180 & wait


### PR DESCRIPTION
If the hash changed between our read and write times the job would hang.
Instead, fill the hash after we mirror.

Fix a wierd failure to fetch.