### PR TITLE
Display the upgrade graph alongside the list

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -95,6 +95,8 @@ type Controller struct {
 
 	releaseInfo ReleaseInfo
 
+	graph *UpgradeGraph
+
 	// parsedReleaseConfigCache caches the parsed release config object for any release
 	// config serialized json.
 	parsedReleaseConfigCache *lru.Cache
@@ -112,6 +114,7 @@ func NewController(
 	releaseNamespace string,
 	jobNamespace string,
 	releaseInfo ReleaseInfo,
+	graph *UpgradeGraph,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -149,6 +152,8 @@ func NewController(
 		jobNamespace:       jobNamespace,
 
 		releaseInfo: releaseInfo,
+
+		graph: graph,
 
 		parsedReleaseConfigCache: parsedReleaseConfigCache,
 	}

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -17,7 +14,6 @@ import (
 	"github.com/gorilla/mux"
 	blackfriday "gopkg.in/russross/blackfriday.v2"
 
-	imagev1 "github.com/openshift/api/image/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -41,18 +37,70 @@ const htmlPageEnd = `
 
 const releasePageHtml = `
 <h1>Release Status</h1>
+<style>
+.upgrade-track-line {
+	position: absolute;
+	top: 0;
+	bottom: -1px;
+	left: 7px;
+	width: 0;
+	display: inline-block;
+	border-left: 2px solid #000;
+	display: none;
+	z-index: 200;
+}
+.upgrade-track-dot {
+	display: inline-block;
+	position: absolute;
+	top: 15px;
+	left: 2px;
+	width: 12px;
+	height: 12px;
+	background: #fff;
+	z-index: 300;
+	cursor: pointer;
+}
+.upgrade-track-dot {
+	border: 2px solid #000;
+	border-radius: 50%;
+}
+.upgrade-track-line.start {
+	top: 18px;
+	height: 31px;
+	display: block;
+}
+.upgrade-track-line.middle {
+	display: block;
+}
+.upgrade-track-line.end {
+	top: -1px;
+	height: 16px;
+	display: block;
+}
+.upgrade-track {
+	width: 20px;
+	position: relative;
+}
+</style>
 <div class="row">
 <div class="col">
 {{ range .Streams }}
 		<h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}">{{ .Release.Config.Name }}</h2>
 		{{ publishDescription . }}
+		{{ $upgrades := .Upgrades }}
 		<table class="table">
 			<thead>
-				<tr><th title="The name and version of the release image (as well as the tag it is published under)">Name</th><th title="The release moves through these stages:&#10;&#10;Pending - still creating release image&#10;Ready - release image created&#10;Accepted - all tests pass&#10;Rejected - some tests failed&#10;Failed - Could not create release image">Phase</th><th>Started</th><th title="All tests must pass for a candidate to be marked accepted">Tests</th></tr>
+				<tr>
+					<th title="The name and version of the release image (as well as the tag it is published under)">Name</th>
+					<th title="The release moves through these stages:&#10;&#10;Pending - still creating release image&#10;Ready - release image created&#10;Accepted - all tests pass&#10;Rejected - some tests failed&#10;Failed - Could not create release image">Phase</th>
+					<th>Started</th>
+					<th title="All tests must pass for a candidate to be marked accepted">Tests</th>
+					<th colspan="{{ inc $upgrades.Width }}">Upgrades</th>
+				</tr>
 			</thead>
 			<tbody>
 		{{ $release := .Release }}
-		{{ range .Tags }}
+		{{ range $index, $tag := .Tags }}
 			{{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
 			<tr class="{{ phaseAlert . }}">
 				{{ if canLink . }}
@@ -63,6 +111,7 @@ const releasePageHtml = `
 				{{ phaseCell . }}
 				<td title="{{ $created }}">{{ since $created }}</td>
 				<td>{{ links . $release }}</td>
+				{{ upgradeCells $upgrades $index }}
 			</tr>
 		{{ end }}
 			</tbody>
@@ -78,185 +127,6 @@ const releaseInfoPageHtml = `
 {{ $created := index .Tag.Annotations "release.openshift.io/creationTimestamp" }}
 <p>Created: <span>{{ since $created }}</span></p>
 `
-
-func phaseCell(tag imagev1.TagReference) string {
-	phase := tag.Annotations[releaseAnnotationPhase]
-	switch phase {
-	case releasePhaseRejected:
-		return fmt.Sprintf("<td title=\"%s\">%s (%s)</td>",
-			template.HTMLEscapeString(tag.Annotations[releaseAnnotationMessage]),
-			template.HTMLEscapeString(phase),
-			template.HTMLEscapeString(tag.Annotations[releaseAnnotationReason]),
-		)
-	}
-	return "<td>" + template.HTMLEscapeString(phase) + "</td>"
-}
-
-func phaseAlert(tag imagev1.TagReference) string {
-	phase := tag.Annotations[releaseAnnotationPhase]
-	switch phase {
-	case releasePhasePending:
-		return ""
-	case releasePhaseReady:
-		return ""
-	case releasePhaseAccepted:
-		return "alert-success"
-	case releasePhaseFailed:
-		return "alert-danger"
-	case releasePhaseRejected:
-		return "alert-danger"
-	default:
-		return "alert-danger"
-	}
-}
-
-func canLink(tag imagev1.TagReference) bool {
-	return tag.Annotations[releaseAnnotationPhase] != releasePhasePending
-}
-
-func links(tag imagev1.TagReference, release *Release) string {
-	links := tag.Annotations[releaseAnnotationVerify]
-	if len(links) == 0 {
-		return ""
-	}
-	var status VerificationStatusMap
-	if err := json.Unmarshal([]byte(links), &status); err != nil {
-		return "error"
-	}
-	keys := make([]string, 0, len(release.Config.Verify))
-	for k := range release.Config.Verify {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	buf := &bytes.Buffer{}
-	for _, key := range keys {
-		if s, ok := status[key]; ok {
-			if len(s.Url) > 0 {
-				switch s.State {
-				case releaseVerificationStateFailed:
-					buf.WriteString(" <a title=\"Failed\" class=\"text-danger\" href=\"")
-				case releaseVerificationStateSucceeded:
-					buf.WriteString(" <a title=\"Succeeded\" class=\"text-success\" href=\"")
-				default:
-					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
-				}
-				buf.WriteString(template.HTMLEscapeString(s.Url))
-				buf.WriteString("\">")
-				buf.WriteString(template.HTMLEscapeString(key))
-				buf.WriteString("</a>")
-				continue
-			}
-			switch s.State {
-			case releaseVerificationStateFailed:
-				buf.WriteString(" <span title=\"Failed\" class=\"text-danger\">")
-			case releaseVerificationStateSucceeded:
-				buf.WriteString(" <span title=\"Succeeded\" class=\"text-success\">")
-			default:
-				buf.WriteString(" <span title=\"Pending\" class=\"\">")
-			}
-			buf.WriteString(template.HTMLEscapeString(key))
-			buf.WriteString("</span>")
-			continue
-		}
-		buf.WriteString(" <span title=\"Pending\">")
-		buf.WriteString(template.HTMLEscapeString(key))
-		buf.WriteString("</span>")
-	}
-	return buf.String()
-}
-
-func extendedLinks(tag imagev1.TagReference, release *Release) string {
-	links := tag.Annotations[releaseAnnotationVerify]
-	if len(links) == 0 {
-		return ""
-	}
-	var status VerificationStatusMap
-	if err := json.Unmarshal([]byte(links), &status); err != nil {
-		return "error"
-	}
-	keys := make([]string, 0, len(release.Config.Verify))
-	for k := range release.Config.Verify {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	buf := &bytes.Buffer{}
-	for _, key := range keys {
-		if s, ok := status[key]; ok {
-			if len(s.Url) > 0 {
-				switch s.State {
-				case releaseVerificationStateFailed:
-					buf.WriteString("<li><a class=\"text-danger\" href=\"")
-				case releaseVerificationStateSucceeded:
-					buf.WriteString("<li><a class=\"text-success\" href=\"")
-				default:
-					buf.WriteString("<li><a class=\"\" href=\"")
-				}
-				buf.WriteString(template.HTMLEscapeString(s.Url))
-				buf.WriteString("\">")
-				buf.WriteString(template.HTMLEscapeString(key))
-				switch s.State {
-				case releaseVerificationStateFailed:
-					buf.WriteString(" Failed")
-				case releaseVerificationStateSucceeded:
-					buf.WriteString(" Succeeded")
-				default:
-					buf.WriteString(" Pending")
-				}
-				buf.WriteString("</a>")
-				if pj := release.Config.Verify[key].ProwJob; pj != nil {
-					buf.WriteString(" ")
-					buf.WriteString(pj.Name)
-				}
-				continue
-			}
-			switch s.State {
-			case releaseVerificationStateFailed:
-				buf.WriteString("<li><span class=\"text-danger\">")
-			case releaseVerificationStateSucceeded:
-				buf.WriteString("<li><span class=\"text-success\">")
-			default:
-				buf.WriteString("<li><span class=\"\">")
-			}
-			buf.WriteString(template.HTMLEscapeString(key))
-			switch s.State {
-			case releaseVerificationStateFailed:
-				buf.WriteString(" Failed")
-			case releaseVerificationStateSucceeded:
-				buf.WriteString(" Succeeded")
-			default:
-				buf.WriteString(" Pending")
-			}
-			buf.WriteString("</span>")
-			if pj := release.Config.Verify[key].ProwJob; pj != nil {
-				buf.WriteString(" ")
-				buf.WriteString(pj.Name)
-			}
-			continue
-		}
-		buf.WriteString("<li><span title=\"Pending\">")
-		buf.WriteString(template.HTMLEscapeString(key))
-		buf.WriteString("</span>")
-	}
-	return buf.String()
-}
-
-type ReleasePage struct {
-	Streams []ReleaseStream
-}
-
-type ReleaseStream struct {
-	Release *Release
-	Tags    []*imagev1.TagReference
-}
-
-type ReleaseStreamTag struct {
-	Release  *Release
-	Tag      *imagev1.TagReference
-	Previous *imagev1.TagReference
-	Older    []*imagev1.TagReference
-}
 
 func (c *Controller) findReleaseStreamTags(tags ...string) (map[string]*ReleaseStreamTag, bool) {
 	needed := make(map[string]*ReleaseStreamTag)
@@ -294,40 +164,6 @@ func (c *Controller) findReleaseStreamTags(tags ...string) (map[string]*ReleaseS
 		}
 	}
 	return needed, remaining == 0
-}
-
-func hasPublishTag(config *ReleaseConfig) (string, bool) {
-	for _, v := range config.Publish {
-		if v.TagRef != nil {
-			return v.TagRef.Name, true
-		}
-	}
-	return "", false
-}
-
-func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReference, release *Release) *imagev1.TagReference {
-	if len(older) == 0 {
-		return nil
-	}
-	if name, ok := hasPublishTag(release.Config); ok {
-		if published := findSpecTag(release.Target.Spec.Tags, name); published != nil && published.From != nil {
-			target := published.From.Name
-			for _, old := range older {
-				if old.Name == target {
-					return old
-				}
-			}
-		}
-	}
-	for _, old := range older {
-		if old.Annotations[releaseAnnotationPhase] == releasePhaseAccepted {
-			return old
-		}
-	}
-	for _, old := range older {
-		return old
-	}
-	return nil
 }
 
 func (c *Controller) userInterfaceHandler() http.Handler {
@@ -400,10 +236,6 @@ func (c *Controller) httpReleaseChangelog(w http.ResponseWriter, req *http.Reque
 	fmt.Fprintln(w, out)
 }
 
-type nopFlusher struct{}
-
-func (_ nopFlusher) Flush() {}
-
 func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
@@ -469,7 +301,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			flusher.Flush()
 			select {
 			case render = <-ch:
-			case <-time.After(10 * time.Second):
+			case <-time.After(15 * time.Second):
 				render.err = fmt.Errorf("the changelog is still loading, if this is the first access it may take several minutes to clone all repositories")
 			}
 			fmt.Fprintf(w, `<style>#loading{display: none;}</style>`)
@@ -493,10 +325,12 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				}
 				return ""
 			},
-			"phaseCell":  phaseCell,
-			"phaseAlert": phaseAlert,
-			"canLink":    canLink,
-			"links":      links,
+			"phaseCell":    phaseCell,
+			"phaseAlert":   phaseAlert,
+			"canLink":      canLink,
+			"links":        links,
+			"inc":          func(i int) int { return i + 1 },
+			"upgradeCells": upgradeCells,
 			"since": func(utcDate string) string {
 				t, err := time.Parse(time.RFC3339, utcDate)
 				if err != nil {
@@ -510,41 +344,6 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
 	if err := releasePage.Execute(w, info); err != nil {
 		glog.Errorf("Unable to render page: %v", err)
-	}
-}
-
-func renderChangelog(w io.Writer, markdown string, pull, tag string, info *ReleaseStreamTag) {
-	result := blackfriday.Run([]byte(markdown))
-
-	// minor changelog styling tweaks
-	fmt.Fprintf(w, `
-<style>
-	h1 { font-size: 2rem; margin-bottom: 1rem }
-	h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 1rem  }
-	h3 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 1rem  }
-	h4 { font-size: 1.2rem; margin-top: 2rem; margin-bottom: 1rem  }
-	h3 a { text-transform: uppercase; font-size: 1rem; }
-</style>
-`)
-
-	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
-	w.Write(result)
-
-	fmt.Fprintln(w, "<hr>")
-	fmt.Fprintf(w, `<p>Pull spec: <code>%s:%s</code></p>`, pull, tag)
-
-	fmt.Fprintf(w, `<p>Tests:</p><ul>%s</ul>`, extendedLinks(*info.Tag, info.Release))
-
-	if len(info.Older) > 0 {
-		var options []string
-		for _, tag := range info.Older {
-			var selected string
-			if tag.Name == info.Previous.Name {
-				selected = `selected="true"`
-			}
-			options = append(options, fmt.Sprintf(`<option %s>%s</option>`, selected, tag.Name))
-		}
-		fmt.Fprintf(w, `<p><form class="form-inline" method="GET"><a href="/changelog?from=%s&to=%s">View changelog in Markdown</a><span>&nbsp;or&nbsp;</span><label for="from">change previous release:&nbsp;</label><select id="from" class="form-control" name="from">%s</select> <input class="btn btn-link" type="submit" value="Compare"></form></p>`, info.Previous.Name, info.Tag.Name, strings.Join(options, ""))
 	}
 }
 
@@ -588,10 +387,12 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 				sort.Strings(out)
 				return fmt.Sprintf("<p>%s</p>\n", strings.Join(out, ", "))
 			},
-			"phaseCell":  phaseCell,
-			"phaseAlert": phaseAlert,
-			"canLink":    canLink,
-			"links":      links,
+			"phaseCell":    phaseCell,
+			"phaseAlert":   phaseAlert,
+			"canLink":      canLink,
+			"links":        links,
+			"inc":          func(i int) int { return i + 1 },
+			"upgradeCells": upgradeCells,
 			"since": func(utcDate string) string {
 				t, err := time.Parse(time.RFC3339, utcDate)
 				if err != nil {
@@ -617,6 +418,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 			Release: r,
 			Tags:    tagsForRelease(r),
 		}
+		s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph)
 		page.Streams = append(page.Streams, s)
 	}
 

--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/blang/semver"
+
+	blackfriday "gopkg.in/russross/blackfriday.v2"
+
+	imagev1 "github.com/openshift/api/image/v1"
+)
+
+type ReleasePage struct {
+	Streams []ReleaseStream
+}
+
+type ReleaseStream struct {
+	Release *Release
+	Tags    []*imagev1.TagReference
+
+	Upgrades *ReleaseUpgrades
+}
+
+type ReleaseStreamTag struct {
+	Release  *Release
+	Tag      *imagev1.TagReference
+	Previous *imagev1.TagReference
+	Older    []*imagev1.TagReference
+}
+
+type ReleaseUpgrades struct {
+	Width int
+	Tags  []ReleaseTagUpgrade
+}
+
+type ReleaseTagUpgrade struct {
+	Internal []UpgradeSummary
+	External []UpgradeSummary
+	Visual   []ReleaseTagUpgradeVisual
+}
+
+type ReleaseTagUpgradeVisual struct {
+	Begin, Current, End *UpgradeSummary
+}
+
+func phaseCell(tag imagev1.TagReference) string {
+	phase := tag.Annotations[releaseAnnotationPhase]
+	switch phase {
+	case releasePhaseRejected:
+		return fmt.Sprintf("<td title=\"%s\">%s (%s)</td>",
+			template.HTMLEscapeString(tag.Annotations[releaseAnnotationMessage]),
+			template.HTMLEscapeString(phase),
+			template.HTMLEscapeString(tag.Annotations[releaseAnnotationReason]),
+		)
+	}
+	return "<td>" + template.HTMLEscapeString(phase) + "</td>"
+}
+
+func phaseAlert(tag imagev1.TagReference) string {
+	phase := tag.Annotations[releaseAnnotationPhase]
+	switch phase {
+	case releasePhasePending:
+		return ""
+	case releasePhaseReady:
+		return ""
+	case releasePhaseAccepted:
+		return "alert-success"
+	case releasePhaseFailed:
+		return "alert-danger"
+	case releasePhaseRejected:
+		return "alert-danger"
+	default:
+		return "alert-danger"
+	}
+}
+
+func styleForUpgrade(upgrade *UpgradeSummary) string {
+	if upgrade.Total == 0 {
+		return ""
+	}
+	if upgrade.Success > 0 {
+		return "border-color: #28a745"
+	}
+	return "border-color: #dc3545"
+}
+
+func upgradeCells(upgrades *ReleaseUpgrades, index int) string {
+	buf := &bytes.Buffer{}
+	for _, visual := range upgrades.Tags[index].Visual {
+		buf.WriteString(`<td class="upgrade-track">`)
+		switch {
+		case visual.Current != nil:
+			style := styleForUpgrade(visual.Current)
+			fmt.Fprintf(buf, `<span title="%s" style="%s" class="upgrade-track-line middle"></span>`, fmt.Sprintf("%d/%d succeeded", visual.Current.Success, visual.Current.Total), style)
+		case visual.Begin != nil && visual.End != nil:
+			style := styleForUpgrade(visual.Begin)
+			fmt.Fprintf(buf, `<span title="%s" style="%s" class="upgrade-track-dot"></span>`, fmt.Sprintf("%d/%d succeeded", visual.Begin.Success, visual.Begin.Total), style)
+			fmt.Fprintf(buf, `<span style="%s" class="upgrade-track-line middle"></span>`, style)
+		case visual.Begin != nil:
+			style := styleForUpgrade(visual.Begin)
+			fmt.Fprintf(buf, `<span title="%s" style="%s" class="upgrade-track-dot"></span>`, fmt.Sprintf("%d/%d succeeded", visual.Begin.Success, visual.Begin.Total), style)
+			fmt.Fprintf(buf, `<span style="%s" class="upgrade-track-line start"></span>`, style)
+		case visual.End != nil:
+			style := styleForUpgrade(visual.End)
+			fmt.Fprintf(buf, `<span title="%s" style="%s" class="upgrade-track-dot"></span>`, fmt.Sprintf("%d/%d succeeded", visual.End.Success, visual.End.Total), style)
+			fmt.Fprintf(buf, `<span style="%s" class="upgrade-track-line end"></span>`, style)
+		}
+		buf.WriteString(`</td>`)
+	}
+	remaining := upgrades.Width - len(upgrades.Tags[index].Visual)
+	if remaining > 0 {
+		buf.WriteString(fmt.Sprintf(`<td colspan="%d"></td>`, remaining))
+	}
+	buf.WriteString(`<td>`)
+	for _, external := range upgrades.Tags[index].External {
+		buf.WriteString(fmt.Sprintf(`<span>%s</span> `, external.From))
+	}
+	buf.WriteString(`</td>`)
+	return buf.String()
+}
+
+func canLink(tag imagev1.TagReference) bool {
+	return tag.Annotations[releaseAnnotationPhase] != releasePhasePending
+}
+
+func links(tag imagev1.TagReference, release *Release) string {
+	links := tag.Annotations[releaseAnnotationVerify]
+	if len(links) == 0 {
+		return ""
+	}
+	var status VerificationStatusMap
+	if err := json.Unmarshal([]byte(links), &status); err != nil {
+		return "error"
+	}
+	keys := make([]string, 0, len(release.Config.Verify))
+	for k, v := range release.Config.Verify {
+		if v.ProwJob != nil && v.ProwJob.Upgrade {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf := &bytes.Buffer{}
+	for _, key := range keys {
+		if s, ok := status[key]; ok {
+			if len(s.Url) > 0 {
+				switch s.State {
+				case releaseVerificationStateFailed:
+					buf.WriteString(" <a title=\"Failed\" class=\"text-danger\" href=\"")
+				case releaseVerificationStateSucceeded:
+					buf.WriteString(" <a title=\"Succeeded\" class=\"text-success\" href=\"")
+				default:
+					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
+				}
+				buf.WriteString(template.HTMLEscapeString(s.Url))
+				buf.WriteString("\">")
+				buf.WriteString(template.HTMLEscapeString(key))
+				buf.WriteString("</a>")
+				continue
+			}
+			switch s.State {
+			case releaseVerificationStateFailed:
+				buf.WriteString(" <span title=\"Failed\" class=\"text-danger\">")
+			case releaseVerificationStateSucceeded:
+				buf.WriteString(" <span title=\"Succeeded\" class=\"text-success\">")
+			default:
+				buf.WriteString(" <span title=\"Pending\" class=\"\">")
+			}
+			buf.WriteString(template.HTMLEscapeString(key))
+			buf.WriteString("</span>")
+			continue
+		}
+		buf.WriteString(" <span title=\"Pending\">")
+		buf.WriteString(template.HTMLEscapeString(key))
+		buf.WriteString("</span>")
+	}
+	return buf.String()
+}
+
+func extendedLinks(tag imagev1.TagReference, release *Release) string {
+	links := tag.Annotations[releaseAnnotationVerify]
+	if len(links) == 0 {
+		return ""
+	}
+	var status VerificationStatusMap
+	if err := json.Unmarshal([]byte(links), &status); err != nil {
+		return "error"
+	}
+	keys := make([]string, 0, len(release.Config.Verify))
+	for k := range release.Config.Verify {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf := &bytes.Buffer{}
+	for _, key := range keys {
+		if s, ok := status[key]; ok {
+			if len(s.Url) > 0 {
+				switch s.State {
+				case releaseVerificationStateFailed:
+					buf.WriteString("<li><a class=\"text-danger\" href=\"")
+				case releaseVerificationStateSucceeded:
+					buf.WriteString("<li><a class=\"text-success\" href=\"")
+				default:
+					buf.WriteString("<li><a class=\"\" href=\"")
+				}
+				buf.WriteString(template.HTMLEscapeString(s.Url))
+				buf.WriteString("\">")
+				buf.WriteString(template.HTMLEscapeString(key))
+				switch s.State {
+				case releaseVerificationStateFailed:
+					buf.WriteString(" Failed")
+				case releaseVerificationStateSucceeded:
+					buf.WriteString(" Succeeded")
+				default:
+					buf.WriteString(" Pending")
+				}
+				buf.WriteString("</a>")
+				if pj := release.Config.Verify[key].ProwJob; pj != nil {
+					buf.WriteString(" ")
+					buf.WriteString(pj.Name)
+				}
+				continue
+			}
+			switch s.State {
+			case releaseVerificationStateFailed:
+				buf.WriteString("<li><span class=\"text-danger\">")
+			case releaseVerificationStateSucceeded:
+				buf.WriteString("<li><span class=\"text-success\">")
+			default:
+				buf.WriteString("<li><span class=\"\">")
+			}
+			buf.WriteString(template.HTMLEscapeString(key))
+			switch s.State {
+			case releaseVerificationStateFailed:
+				buf.WriteString(" Failed")
+			case releaseVerificationStateSucceeded:
+				buf.WriteString(" Succeeded")
+			default:
+				buf.WriteString(" Pending")
+			}
+			buf.WriteString("</span>")
+			if pj := release.Config.Verify[key].ProwJob; pj != nil {
+				buf.WriteString(" ")
+				buf.WriteString(pj.Name)
+			}
+			continue
+		}
+		buf.WriteString("<li><span title=\"Pending\">")
+		buf.WriteString(template.HTMLEscapeString(key))
+		buf.WriteString("</span>")
+	}
+	return buf.String()
+}
+
+func hasPublishTag(config *ReleaseConfig) (string, bool) {
+	for _, v := range config.Publish {
+		if v.TagRef != nil {
+			return v.TagRef.Name, true
+		}
+	}
+	return "", false
+}
+
+func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReference, release *Release) *imagev1.TagReference {
+	if len(older) == 0 {
+		return nil
+	}
+	if name, ok := hasPublishTag(release.Config); ok {
+		if published := findSpecTag(release.Target.Spec.Tags, name); published != nil && published.From != nil {
+			target := published.From.Name
+			for _, old := range older {
+				if old.Name == target {
+					return old
+				}
+			}
+		}
+	}
+	for _, old := range older {
+		if old.Annotations[releaseAnnotationPhase] == releasePhaseAccepted {
+			return old
+		}
+	}
+	for _, old := range older {
+		return old
+	}
+	return nil
+}
+
+type nopFlusher struct{}
+
+func (_ nopFlusher) Flush() {}
+
+func renderChangelog(w io.Writer, markdown string, pull, tag string, info *ReleaseStreamTag) {
+	result := blackfriday.Run([]byte(markdown))
+
+	// minor changelog styling tweaks
+	fmt.Fprintf(w, `
+<style>
+	h1 { font-size: 2rem; margin-bottom: 1rem }
+	h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 1rem  }
+	h3 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 1rem  }
+	h4 { font-size: 1.2rem; margin-top: 2rem; margin-bottom: 1rem  }
+	h3 a { text-transform: uppercase; font-size: 1rem; }
+</style>
+`)
+
+	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
+	w.Write(result)
+
+	fmt.Fprintln(w, "<hr>")
+	fmt.Fprintf(w, `<p>Pull spec: <code>%s:%s</code></p>`, pull, tag)
+
+	fmt.Fprintf(w, `<p>Tests:</p><ul>%s</ul>`, extendedLinks(*info.Tag, info.Release))
+
+	if len(info.Older) > 0 {
+		var options []string
+		for _, tag := range info.Older {
+			var selected string
+			if tag.Name == info.Previous.Name {
+				selected = `selected="true"`
+			}
+			options = append(options, fmt.Sprintf(`<option %s>%s</option>`, selected, tag.Name))
+		}
+		fmt.Fprintf(w, `<p><form class="form-inline" method="GET"><a href="/changelog?from=%s&to=%s">View changelog in Markdown</a><span>&nbsp;or&nbsp;</span><label for="from">change previous release:&nbsp;</label><select id="from" class="form-control" name="from">%s</select> <input class="btn btn-link" type="submit" value="Compare"></form></p>`, info.Previous.Name, info.Tag.Name, strings.Join(options, ""))
+	}
+}
+
+func calculateReleaseUpgrades(release *Release, tags []*imagev1.TagReference, graph *UpgradeGraph) *ReleaseUpgrades {
+	tagNames := make([]string, 0, len(tags))
+	internalTags := make(map[string]int)
+	for i, tag := range tags {
+		internalTags[tag.Name] = i
+		tagNames = append(tagNames, tag.Name)
+	}
+	tagUpgrades := make([]ReleaseTagUpgrade, 0, len(tags))
+	maxWidth := 0
+
+	// calculate inbound and output edges to each row, materialize them as a
+	// tabular form with indicators whether a row is starting, continuing, or
+	// ending
+	var visual []ReleaseTagUpgradeVisual
+	summaries := graph.SummarizeUpgradesTo(tagNames...)
+	for _, name := range tagNames {
+		var internal, external []UpgradeSummary
+		internal, summaries = takeUpgradesTo(summaries, name)
+		internal, external = takeUpgradesFromNames(internal, internalTags)
+		sort.Slice(internal, func(i, j int) bool {
+			return internalTags[internal[i].From] < internalTags[internal[j].From]
+		})
+		sort.Sort(newNewestSemVerFromSummaries(external))
+		tagUpgrade := ReleaseTagUpgrade{}
+		if len(internal) > 0 {
+			tagUpgrade.Internal = internal
+		}
+		if len(external) > 0 {
+			tagUpgrade.External = external
+		}
+
+		// mark the end of any current row
+		for i, row := range visual {
+			current := row.Current
+			if current == nil || current.From != name {
+				continue
+			}
+			visual[i].End = current
+			visual[i].Current = nil
+		}
+
+		// try to place each internal in the first available position on the row
+	Internal:
+		for i := range internal {
+			for j, row := range visual {
+				if row.Begin != nil || row.Current != nil {
+					continue
+				}
+				// don't join columns of different status
+				if last := row.End; last != nil && (last.Success > 0) != (internal[i].Success > 0) {
+					continue
+				}
+				visual[j].Begin = &internal[i]
+				continue Internal
+			}
+			visual = append(visual, ReleaseTagUpgradeVisual{Begin: &internal[i]})
+		}
+		if len(visual) > maxWidth {
+			maxWidth = len(visual)
+		}
+
+		// copy the row
+		if len(visual) > 0 {
+			tagUpgrade.Visual = make([]ReleaseTagUpgradeVisual, len(visual))
+			copy(tagUpgrade.Visual, visual)
+		}
+		tagUpgrades = append(tagUpgrades, tagUpgrade)
+
+		// set up the row for the next iteration
+		for i := range visual {
+			b := visual[i].Begin
+			if b == nil {
+				b = visual[i].Current
+			}
+			visual[i] = ReleaseTagUpgradeVisual{Current: b}
+		}
+		for i := len(visual) - 1; i >= 0; i-- {
+			row := visual[i]
+			if row.Current == nil {
+				visual = visual[:i]
+				continue
+			}
+			break
+		}
+	}
+
+	return &ReleaseUpgrades{
+		Width: maxWidth,
+		Tags:  tagUpgrades,
+	}
+}
+
+// takeUpgradesTo returns all leading summaries with To equal to tag, and the rest of the
+// slice.
+func takeUpgradesTo(summaries []UpgradeSummary, tag string) ([]UpgradeSummary, []UpgradeSummary) {
+	for i, summary := range summaries {
+		if summary.To == tag {
+			continue
+		}
+		return summaries[:i], summaries[i:]
+	}
+	return summaries, nil
+}
+
+// takeUpgradesFromNames splits the provided summaries slice into two slices - those with Froms
+// in names and those without.
+func takeUpgradesFromNames(summaries []UpgradeSummary, names map[string]int) (withNames []UpgradeSummary, withoutNames []UpgradeSummary) {
+	for i := range summaries {
+		if _, ok := names[summaries[i].From]; ok {
+			continue
+		}
+		left := make([]UpgradeSummary, 0, len(summaries)-i)
+		var right []UpgradeSummary
+		for _, summary := range summaries[i:] {
+			if _, ok := names[summaries[i].From]; ok {
+				left = append(left, summary)
+			} else {
+				right = append(right, summary)
+			}
+		}
+		return left, right
+	}
+	return summaries, nil
+}
+
+type newestSemVerFromSummaries struct {
+	versions  []semver.Version
+	summaries []UpgradeSummary
+}
+
+func newNewestSemVerFromSummaries(summaries []UpgradeSummary) newestSemVerFromSummaries {
+	versions := make([]semver.Version, len(summaries))
+	for i, summary := range summaries {
+		if v, err := semver.Parse(summary.From); err != nil {
+			versions[i] = v
+		}
+	}
+	return newestSemVerFromSummaries{
+		versions:  versions,
+		summaries: summaries,
+	}
+}
+
+func (s newestSemVerFromSummaries) Less(i, j int) bool {
+	c := s.versions[i].Compare(s.versions[j])
+	if c > 0 {
+		return true
+	}
+	if c < 0 {
+		return false
+	}
+	return s.summaries[i].From > s.summaries[j].From
+}
+func (s newestSemVerFromSummaries) Swap(i, j int) {
+	s.summaries[i], s.summaries[j] = s.summaries[j], s.summaries[i]
+	s.versions[i], s.versions[j] = s.versions[j], s.versions[i]
+}
+func (s newestSemVerFromSummaries) Len() int { return len(s.summaries) }

--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	imagev1 "github.com/openshift/api/image/v1"
+)
+
+func Test_calculateReleaseUpgrades(t *testing.T) {
+	tests := []struct {
+		name    string
+		release *Release
+		tags    []*imagev1.TagReference
+		graph   func() *UpgradeGraph
+		want    *ReleaseUpgrades
+		wantFn  func() *ReleaseUpgrades
+	}{
+		{
+			tags: []*imagev1.TagReference{},
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				return g
+			},
+			want: &ReleaseUpgrades{
+				Width: 0,
+				Tags:  []ReleaseTagUpgrade{},
+			},
+		},
+		{
+			tags: []*imagev1.TagReference{
+				{Name: "4.0.1"},
+				{Name: "4.0.0"},
+			},
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				return g
+			},
+			want: &ReleaseUpgrades{
+				Width: 0,
+				Tags: []ReleaseTagUpgrade{
+					{},
+					{},
+				},
+			},
+		},
+		{
+			tags: []*imagev1.TagReference{
+				{Name: "4.0.1"},
+				{Name: "4.0.0"},
+				{Name: "4.0.0-9"},
+			},
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				g.Add("4.0.0", "4.0.1", UpgradeResult{State: releaseVerificationStateFailed, Url: "https://test.com/1"})
+				return g
+			},
+			wantFn: func() *ReleaseUpgrades {
+				internal0 := []UpgradeSummary{{From: "4.0.0", To: "4.0.1", Success: 0, Failure: 1, Total: 1}}
+				u := &ReleaseUpgrades{
+					Width: 1,
+					Tags: []ReleaseTagUpgrade{
+						{
+							Internal: internal0,
+							Visual: []ReleaseTagUpgradeVisual{
+								{Begin: &internal0[0]},
+							},
+						},
+						{
+							Visual: []ReleaseTagUpgradeVisual{
+								{End: &internal0[0]},
+							},
+						},
+						{},
+					},
+				}
+				return u
+			},
+		},
+		{
+			tags: []*imagev1.TagReference{
+				{Name: "4.0.5"},
+				{Name: "4.0.4"},
+				{Name: "4.0.3"},
+				{Name: "4.0.2"},
+				{Name: "4.0.1"},
+			},
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				g.Add("4.0.4", "4.0.5", UpgradeResult{State: releaseVerificationStateFailed, Url: "https://test.com/1"})
+				g.Add("4.0.3", "4.0.5", UpgradeResult{State: releaseVerificationStateSucceeded, Url: "https://test.com/2"})
+				g.Add("4.0.0", "4.0.2", UpgradeResult{State: releaseVerificationStateSucceeded, Url: "https://test.com/2"})
+				return g
+			},
+			wantFn: func() *ReleaseUpgrades {
+				internal0 := []UpgradeSummary{
+					{From: "4.0.4", To: "4.0.5", Success: 0, Failure: 1, Total: 1},
+					{From: "4.0.3", To: "4.0.5", Success: 1, Failure: 0, Total: 1},
+				}
+				u := &ReleaseUpgrades{
+					Width: 2,
+					Tags: []ReleaseTagUpgrade{
+						{
+							Internal: internal0,
+							Visual: []ReleaseTagUpgradeVisual{
+								{Begin: &internal0[0]},
+								{Begin: &internal0[1]},
+							},
+						},
+						{
+							Visual: []ReleaseTagUpgradeVisual{
+								{End: &internal0[0]},
+								{Current: &internal0[1]},
+							},
+						},
+						{
+							Visual: []ReleaseTagUpgradeVisual{
+								{},
+								{End: &internal0[1]},
+							},
+						},
+						{
+							External: []UpgradeSummary{{From: "4.0.0", To: "4.0.2", Success: 1, Total: 1}},
+						},
+						{},
+					},
+				}
+				return u
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantFn != nil {
+				tt.want = tt.wantFn()
+			}
+			if got := calculateReleaseUpgrades(tt.release, tt.tags, tt.graph()); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%s", diff.ObjectReflectDiff(tt.want, got))
+			}
+		})
+	}
+}

--- a/cmd/release-controller/prow.go
+++ b/cmd/release-controller/prow.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	prowapiv1 "github.com/openshift/release-controller/pkg/prow/apiv1"
+)
+
+func prowJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationStatus, bool) {
+	s, _, err := unstructured.NestedString(obj.Object, "status", "state")
+	if err != nil {
+		return nil, false
+	}
+	url, _, _ := unstructured.NestedString(obj.Object, "status", "url")
+	switch prowapiv1.ProwJobState(s) {
+	case prowapiv1.SuccessState:
+		return &VerificationStatus{State: releaseVerificationStateSucceeded, Url: url}, true
+	case prowapiv1.FailureState, prowapiv1.ErrorState, prowapiv1.AbortedState:
+		return &VerificationStatus{State: releaseVerificationStateFailed, Url: url}, true
+	case prowapiv1.TriggeredState, prowapiv1.PendingState, prowapiv1.ProwJobState(""):
+		return &VerificationStatus{State: releaseVerificationStatePending, Url: url}, true
+	default:
+		glog.Errorf("Unrecognized prow job state %q on job %s", s, obj.GetName())
+		return nil, false
+	}
+}

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -195,6 +195,9 @@ const (
 
 	releaseAnnotationReason  = "release.openshift.io/reason"
 	releaseAnnotationMessage = "release.openshift.io/message"
+
+	releaseAnnotationFromTag = "release.openshift.io/from-tag"
+	releaseAnnotationToTag   = "release.openshift.io/to-tag"
 )
 
 type Duration time.Duration

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type UpgradeGraph struct {
+	lock sync.Mutex
+	to   map[string]map[string]*UpgradeHistory
+	from map[string]sets.String
+}
+
+func NewUpgradeGraph() *UpgradeGraph {
+	return &UpgradeGraph{
+		to:   make(map[string]map[string]*UpgradeHistory),
+		from: make(map[string]sets.String),
+	}
+}
+
+type upgradeEdge struct {
+	From string
+	To   string
+}
+
+type UpgradeResult struct {
+	State string
+	Url   string
+}
+
+type UpgradeHistory struct {
+	From string
+	To   string
+
+	Success int
+	Failure int
+	History map[string]UpgradeResult
+}
+
+type UpgradeSummary struct {
+	From string
+	To   string
+
+	Success int
+	Failure int
+	Total   int
+}
+
+func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []UpgradeSummary {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	summaries := make([]UpgradeSummary, 0, len(toNames)*2)
+	for _, to := range toNames {
+		for _, h := range g.to[to] {
+			summaries = append(summaries, UpgradeSummary{
+				From:    h.From,
+				To:      to,
+				Success: h.Success,
+				Failure: h.Failure,
+				Total:   len(h.History),
+			})
+		}
+	}
+	return summaries
+}
+
+func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {
+	if len(results) == 0 || len(fromTag) == 0 || len(toTag) == 0 {
+		return
+	}
+
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	to, ok := g.to[toTag]
+	if !ok {
+		to = make(map[string]*UpgradeHistory)
+		g.to[toTag] = to
+	}
+	from, ok := to[fromTag]
+	if !ok {
+		from = &UpgradeHistory{
+			From: fromTag,
+			To:   toTag,
+		}
+		to[fromTag] = from
+		set, ok := g.from[fromTag]
+		if !ok {
+			set = sets.NewString()
+			g.from[fromTag] = set
+		}
+		set.Insert(toTag)
+	}
+	if from.History == nil {
+		from.History = make(map[string]UpgradeResult)
+	}
+	for _, result := range results {
+		if len(result.Url) == 0 {
+			continue
+		}
+		existing, ok := from.History[result.Url]
+		if !ok || existing.State == releaseVerificationStatePending && result.State != releaseVerificationStatePending {
+			from.History[result.Url] = result
+			switch result.State {
+			case releaseVerificationStateFailed:
+				from.Failure++
+			case releaseVerificationStateSucceeded:
+				from.Success++
+			}
+		}
+	}
+}


### PR DESCRIPTION
Track information from upgrade prowjobs and display them in the graph.
Shows visual connections between graph elements. Does not persist the
graph at the current time.