### PR TITLE
Tighten the upgrade cell width for more upgrades

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -77,9 +77,11 @@ const releasePageHtml = `
 	height: 16px;
 	display: block;
 }
-.upgrade-track {
-	width: 20px;
+td.upgrade-track {
+	width: 16px;
 	position: relative;
+	padding-left: 2px;
+	padding-right: 2px;
 }
 </style>
 <div class="row">


### PR DESCRIPTION
We sometimes peak around 12 concurrent updates