### PR TITLE
Link upgrade graph links to the details page

### DIFF
--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -35,25 +35,18 @@ type UpgradeHistory struct {
 
 	Success int
 	Failure int
+	Total   int
+
 	History map[string]UpgradeResult
 }
 
-type UpgradeSummary struct {
-	From string
-	To   string
-
-	Success int
-	Failure int
-	Total   int
-}
-
-func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []UpgradeSummary {
+func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]UpgradeSummary, 0, len(toNames)*2)
+	summaries := make([]UpgradeHistory, 0, len(toNames)*2)
 	for _, to := range toNames {
 		for _, h := range g.to[to] {
-			summaries = append(summaries, UpgradeSummary{
+			summaries = append(summaries, UpgradeHistory{
 				From:    h.From,
 				To:      to,
 				Success: h.Success,
@@ -65,14 +58,14 @@ func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []UpgradeSummary {
 	return summaries
 }
 
-func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []UpgradeSummary {
+func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]UpgradeSummary, 0, len(fromNames)*2)
+	summaries := make([]UpgradeHistory, 0, len(fromNames)*2)
 	for _, from := range fromNames {
 		for to := range g.from[from] {
 			for _, h := range g.to[to] {
-				summaries = append(summaries, UpgradeSummary{
+				summaries = append(summaries, UpgradeHistory{
 					From:    from,
 					To:      to,
 					Success: h.Success,
@@ -83,6 +76,54 @@ func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []UpgradeSumma
 		}
 	}
 	return summaries
+}
+
+func (g *UpgradeGraph) UpgradesTo(toNames ...string) []UpgradeHistory {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	summaries := make([]UpgradeHistory, 0, len(toNames)*2)
+	for _, to := range toNames {
+		for _, h := range g.to[to] {
+			summaries = append(summaries, UpgradeHistory{
+				From:    h.From,
+				To:      to,
+				Success: h.Success,
+				Failure: h.Failure,
+				Total:   len(h.History),
+				History: copyHistory(h.History),
+			})
+		}
+	}
+	return summaries
+}
+
+func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []UpgradeHistory {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	summaries := make([]UpgradeHistory, 0, len(fromNames)*2)
+	for _, from := range fromNames {
+		for to := range g.from[from] {
+			for _, h := range g.to[to] {
+				summaries = append(summaries, UpgradeHistory{
+					From:    from,
+					To:      to,
+					Success: h.Success,
+					Failure: h.Failure,
+					Total:   len(h.History),
+					History: copyHistory(h.History),
+				})
+			}
+		}
+	}
+	return summaries
+}
+
+func copyHistory(h map[string]UpgradeResult) map[string]UpgradeResult {
+	copied := make(map[string]UpgradeResult, len(h))
+	for k, v := range h {
+		copied[k] = v
+	}
+	return copied
 }
 
 func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {


### PR DESCRIPTION
Reorder changelog to better reflect priority - tests and upgrades,
then changelog. Make the connection between upgrades and changelog
clearer.