### PR TITLE
Save and restore upgrade graph state to a secret

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -207,10 +207,19 @@ func (c *Controller) findReleaseStreamTags(includeStableTags bool, tags ...strin
 func (c *Controller) userInterfaceHandler() http.Handler {
 	mux := mux.NewRouter()
 	mux.HandleFunc("/changelog", c.httpReleaseChangelog)
+	mux.HandleFunc("/archive/graph", c.httpGraphSave)
 	mux.HandleFunc("/releasetag/{tag}", c.httpReleaseInfo)
 	mux.HandleFunc("/releasestream/{release}/release/{tag}", c.httpReleaseInfo)
 	mux.HandleFunc("/", c.httpReleases)
 	return mux
+}
+
+func (c *Controller) httpGraphSave(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Encoding", "gzip")
+	if err := c.graph.Save(w); err != nil {
+		http.Error(w, fmt.Sprintf("unable to save graph: %v", err), http.StatusInternalServerError)
+	}
 }
 
 func (c *Controller) httpReleaseChangelog(w http.ResponseWriter, req *http.Request) {

--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -239,7 +239,7 @@ func links(tag imagev1.TagReference, release *Release) string {
 	buf := &bytes.Buffer{}
 	for _, key := range keys {
 		if s, ok := status[key]; ok {
-			if len(s.Url) > 0 {
+			if len(s.URL) > 0 {
 				switch s.State {
 				case releaseVerificationStateFailed:
 					buf.WriteString(" <a title=\"Failed\" class=\"text-danger\" href=\"")
@@ -248,7 +248,7 @@ func links(tag imagev1.TagReference, release *Release) string {
 				default:
 					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
 				}
-				buf.WriteString(template.HTMLEscapeString(s.Url))
+				buf.WriteString(template.HTMLEscapeString(s.URL))
 				buf.WriteString("\">")
 				buf.WriteString(template.HTMLEscapeString(key))
 				buf.WriteString("</a>")
@@ -297,7 +297,7 @@ func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *Release) 
 	buf := &bytes.Buffer{}
 	for _, key := range keys {
 		if s, ok := status[key]; ok {
-			if len(s.Url) > 0 {
+			if len(s.URL) > 0 {
 				switch s.State {
 				case releaseVerificationStateFailed:
 					buf.WriteString("<li><a class=\"text-danger\" href=\"")
@@ -306,7 +306,7 @@ func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *Release) 
 				default:
 					buf.WriteString("<li><a class=\"\" href=\"")
 				}
-				buf.WriteString(template.HTMLEscapeString(s.Url))
+				buf.WriteString(template.HTMLEscapeString(s.URL))
 				buf.WriteString("\">")
 				buf.WriteString(template.HTMLEscapeString(key))
 				switch s.State {

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -229,6 +229,10 @@ func (o *options) Run() error {
 	glog.Infof("Waiting for caches to sync")
 	cache.WaitForCacheSync(stopCh, hasSynced...)
 
+	// keep the graph in a more persistent form
+	ns, name := releaseNamespace, fmt.Sprintf("%s-upgrades", o.ReleaseImageStream)
+	go syncGraphToSecret(graph, o.DryRun, client.CoreV1().Secrets(ns), ns, name, stopCh)
+
 	go wait.Until(func() {
 		err := wait.ExponentialBackoff(wait.Backoff{
 			Steps:    3,

--- a/cmd/release-controller/prow.go
+++ b/cmd/release-controller/prow.go
@@ -15,11 +15,11 @@ func prowJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationSta
 	url, _, _ := unstructured.NestedString(obj.Object, "status", "url")
 	switch prowapiv1.ProwJobState(s) {
 	case prowapiv1.SuccessState:
-		return &VerificationStatus{State: releaseVerificationStateSucceeded, Url: url}, true
+		return &VerificationStatus{State: releaseVerificationStateSucceeded, URL: url}, true
 	case prowapiv1.FailureState, prowapiv1.ErrorState, prowapiv1.AbortedState:
-		return &VerificationStatus{State: releaseVerificationStateFailed, Url: url}, true
+		return &VerificationStatus{State: releaseVerificationStateFailed, URL: url}, true
 	case prowapiv1.TriggeredState, prowapiv1.PendingState, prowapiv1.ProwJobState(""):
-		return &VerificationStatus{State: releaseVerificationStatePending, Url: url}, true
+		return &VerificationStatus{State: releaseVerificationStatePending, URL: url}, true
 	default:
 		glog.Errorf("Unrecognized prow job state %q on job %s", s, obj.GetName())
 		return nil, false

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -49,7 +49,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 				return nil, fmt.Errorf("unexpected error accessing prow job definition")
 			}
 			if status.State == releaseVerificationStateSucceeded {
-				glog.V(2).Infof("Prow job %s for release %s succeeded, logs at %s", name, releaseTag.Name, status.Url)
+				glog.V(2).Infof("Prow job %s for release %s succeeded, logs at %s", name, releaseTag.Name, status.URL)
 			}
 			if verifyStatus == nil {
 				verifyStatus = make(VerificationStatusMap)

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -125,7 +125,7 @@ type ProwJobVerification struct {
 
 type VerificationStatus struct {
 	State string `json:"state"`
-	Url   string `json:"url"`
+	URL   string `json:"url"`
 }
 
 type VerificationStatusMap map[string]*VerificationStatus

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -1,10 +1,33 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"sort"
 	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	kv1core "k8s.io/client-go/kubernetes/typed/core/v1"
 )
+
+type UpgradeResult struct {
+	State string `json:"state"`
+	URL   string `json:"url"`
+}
+
+type UpgradeRecord struct {
+	From    string          `json:"from"`
+	To      string          `json:"to"`
+	Results []UpgradeResult `json:"results"`
+}
 
 type UpgradeGraph struct {
 	lock sync.Mutex
@@ -22,11 +45,6 @@ func NewUpgradeGraph() *UpgradeGraph {
 type upgradeEdge struct {
 	From string
 	To   string
-}
-
-type UpgradeResult struct {
-	State string
-	Url   string
 }
 
 type UpgradeHistory struct {
@@ -133,7 +151,10 @@ func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {
 
 	g.lock.Lock()
 	defer g.lock.Unlock()
+	g.addWithLock(fromTag, toTag, results...)
+}
 
+func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...UpgradeResult) {
 	to, ok := g.to[toTag]
 	if !ok {
 		to = make(map[string]*UpgradeHistory)
@@ -157,12 +178,12 @@ func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {
 		from.History = make(map[string]UpgradeResult)
 	}
 	for _, result := range results {
-		if len(result.Url) == 0 {
+		if len(result.URL) == 0 {
 			continue
 		}
-		existing, ok := from.History[result.Url]
+		existing, ok := from.History[result.URL]
 		if !ok || existing.State == releaseVerificationStatePending && result.State != releaseVerificationStatePending {
-			from.History[result.Url] = result
+			from.History[result.URL] = result
 			switch result.State {
 			case releaseVerificationStateFailed:
 				from.Failure++
@@ -171,4 +192,123 @@ func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {
 			}
 		}
 	}
+}
+
+func (g *UpgradeGraph) saveRecords() []UpgradeRecord {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	records := make([]UpgradeRecord, 0, len(g.to)*5)
+	for to, targets := range g.to {
+		for from, history := range targets {
+			record := UpgradeRecord{From: from, To: to, Results: make([]UpgradeResult, 0, len(history.History))}
+			for _, result := range history.History {
+				record.Results = append(record.Results, result)
+			}
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+func (g *UpgradeGraph) Save(w io.Writer) error {
+	records := g.saveRecords()
+
+	// put the records into a stable order
+	sort.Slice(records, func(i, j int) bool {
+		a, b := records[i], records[j]
+		if a.To == b.To {
+			return a.From < b.From
+		}
+		return a.To < b.To
+	})
+	for _, record := range records {
+		sort.Slice(record.Results, func(i, j int) bool {
+			return record.Results[i].URL < record.Results[j].URL
+		})
+	}
+
+	data, err := json.Marshal(records)
+	if err != nil {
+		return err
+	}
+	gw := gzip.NewWriter(w)
+	if _, err := gw.Write(data); err != nil {
+		return err
+	}
+	return gw.Close()
+}
+
+func (g *UpgradeGraph) Load(r io.Reader) error {
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	var records []UpgradeRecord
+	if err := json.NewDecoder(gr).Decode(&records); err != nil {
+		return err
+	}
+
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	for _, record := range records {
+		g.addWithLock(record.From, record.To, record.Results...)
+	}
+	return err
+}
+
+func syncGraphToSecret(graph *UpgradeGraph, dryRun bool, secretClient kv1core.SecretInterface, ns, name string, stopCh <-chan struct{}) {
+	// read initial state
+	wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+		secret, err := secretClient.Get(name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				glog.Errorf("No secret %s/%s exists to store upgrade state into", ns, name)
+				return false, nil
+			}
+			if errors.IsForbidden(err) {
+				glog.Errorf("Release controller doesn't have permission to get secret %s/%s to store upgrade state into", ns, name)
+				return false, nil
+			}
+			glog.Errorf("Can't load initial state from secret %s/%s: %v", ns, name, err)
+			return false, nil
+		}
+		if data := secret.Data["latest"]; len(data) > 0 {
+			if err := graph.Load(bytes.NewReader(data)); err != nil {
+				glog.Errorf("Can't load initial state from secret %s/%s: %v", ns, name, err)
+			}
+		}
+		return true, nil
+	}, stopCh)
+
+	if dryRun {
+		return
+	}
+
+	// wait a bit of time to let any other loops load what they can
+	time.Sleep(15 * time.Second)
+
+	// keep the secret up to date
+	buf := &bytes.Buffer{}
+	wait.Until(func() {
+		buf.Reset()
+		if err := graph.Save(buf); err != nil {
+			glog.Errorf("Unable to calculate graph state: %v", err)
+			return
+		}
+		secret, err := secretClient.Get(name, metav1.GetOptions{})
+		if err != nil {
+			glog.Errorf("Can't read latest secret %s/%s: %v", ns, name, err)
+			return
+		}
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+		secret.Data["latest"] = buf.Bytes()
+		if _, err := secretClient.Update(secret); err != nil {
+			glog.Errorf("Can't save state to secret %s/%s: %v", ns, name, err)
+		}
+		glog.V(2).Infof("Saved upgrade graph state to %s/%s", ns, name)
+	}, 5*time.Minute, stopCh)
 }


### PR DESCRIPTION
In order to keep state across multiple restarts, periodically snapshot the
upgrade graph state to a Kube secret and restore from it on startup. The
graph is gzipped (which is why we use a secret). A future commit should
prune / sort the graph to make it easier to restore.

Add `/archive/graph` to let a client dump the graph.