### PR TITLE
Require image streams to declare a target to publish releases to

### DIFF
--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -45,11 +45,11 @@ func (c *Controller) releaseDefinition(is *imagev1.ImageStream) (*Release, bool,
 		}
 		return r, true, nil
 	default:
-		targetImageStream, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(c.releaseImageStream)
+		targetImageStream, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).Get(cfg.To)
 		if errors.IsNotFound(err) {
 			// TODO: something special here?
-			glog.V(2).Infof("The release image stream %s/%s does not exist", c.releaseNamespace, c.releaseImageStream)
-			return nil, false, terminalError{fmt.Errorf("the output release image stream %s/%s does not exist", c.releaseImageStream, is.Name)}
+			glog.V(2).Infof("The release image stream %s/%s does not exist", c.releaseNamespace, cfg.To)
+			return nil, false, terminalError{fmt.Errorf("the output release image stream %s/%s does not exist", c.releaseNamespace, cfg.To)}
 		}
 		if err != nil {
 			return nil, false, fmt.Errorf("unable to lookup release image stream: %v", err)
@@ -78,6 +78,9 @@ func (c *Controller) parseReleaseConfig(data string) (*ReleaseConfig, error) {
 	}
 	if len(cfg.Name) == 0 {
 		return nil, fmt.Errorf("release config must have a valid name")
+	}
+	if len(cfg.To) == 0 && cfg.As != releaseConfigModeStable {
+		return nil, fmt.Errorf("release must specify 'to' unless 'as' is 'Stable'")
 	}
 	for name, verify := range cfg.Verify {
 		if len(name) == 0 {

--- a/cmd/release-controller/sync_gc.go
+++ b/cmd/release-controller/sync_gc.go
@@ -37,13 +37,14 @@ func (c *Controller) garbageCollectSync() error {
 	active := sets.NewString()
 	targets := make(map[string]int64)
 	for _, imageStream := range imageStreams {
-		if imageStream.Name == c.releaseImageStream && imageStream.Namespace == c.releaseNamespace {
+		if _, ok := imageStream.Annotations[releaseAnnotationHasReleases]; ok {
 			for _, tag := range imageStream.Spec.Tags {
 				active.Insert(tag.Name)
 			}
 			targets[fmt.Sprintf("%s/%s", imageStream.Namespace, imageStream.Name)] = imageStream.Generation
 			continue
 		}
+
 		value, ok := imageStream.Annotations[releaseAnnotationConfig]
 		if !ok {
 			continue

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -32,13 +32,17 @@ type ReleaseConfig struct {
 	// to describe the purpose of this stream.
 	Message string `json:"message"`
 
-	// Input defines what this image stream provides. The default value is "Integration"
+	// As defines what this image stream provides. The default value is "Integration"
 	// and the images in the image stream will be used to build payloads. An optional
 	// mode is "Stable" and tags are assumed to be release payloads that should be promoted
 	// and published elsewhere. When choosing Stable, a user will tag a candidate release
 	// image in as a new tag to this image stream and the controller will rebuild and
 	// update the image with the appropriate name, metadata, and content.
 	As string `json:"as"`
+
+	// To is the image stream where release tags will be created when the As field is
+	// Integration. This field is ignored when As is Stable.
+	To string `json:"to"`
 
 	// ReferenceMode describes how the release image will refer to the origin. If empty
 	// or 'public' images will be copied and no source location will be preserved. If
@@ -213,6 +217,8 @@ const (
 	releaseAnnotationVerify            = "release.openshift.io/verify"
 	// if true, the release controller should rewrite this release tagged
 	releaseAnnotationRewrite = "release.openshift.io/rewrite"
+	// an image stream with this annotation holds release tags
+	releaseAnnotationHasReleases = "release.openshift.io/hasReleases"
 
 	releaseAnnotationReason  = "release.openshift.io/reason"
 	releaseAnnotationMessage = "release.openshift.io/message"


### PR DESCRIPTION
The explicit `to` field allows one controller to manage multiple
flows. For now we anticipate a single release stream, but in the
future it may make more sense to split. Use an annotation on the
target to trigger some kinds of resync. Rename the secret.