### PR TITLE
Only tags in the stable release are 'next' candidates

### DIFF
--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -44,7 +44,7 @@ func (c *Controller) createReleaseTag(release *Release, now time.Time, inputImag
 
 func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.TagReference) error {
 	var semanticTags []semver.Version
-	for _, tag := range release.Target.Spec.Tags {
+	for _, tag := range tagsForRelease(release) {
 		version, err := semver.Parse(tag.Name)
 		if err != nil {
 			continue


### PR DESCRIPTION
Side effect of collapsing stable and target into the same location.