### PR TITLE
Importing a tag should preserve the pull location of the tag

### DIFF
--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -77,6 +77,9 @@ func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.Ta
 		releaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
 		releaseAnnotationRewrite:           "true",
 	}
+	if value, ok := tag.Annotations[releaseAnnotationMirrorImages]; ok {
+		origin.Annotations[releaseAnnotationMirrorImages] = value
+	}
 	origin.From = tag.From
 	origin.ImportPolicy = tag.ImportPolicy
 

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -233,10 +233,12 @@ const (
 	releaseAnnotationPhase             = "release.openshift.io/phase"
 	releaseAnnotationCreationTimestamp = "release.openshift.io/creationTimestamp"
 	releaseAnnotationVerify            = "release.openshift.io/verify"
-	// if true, the release controller should rewrite this release tagged
+	// if true, the release controller should rewrite this release
 	releaseAnnotationRewrite = "release.openshift.io/rewrite"
 	// an image stream with this annotation holds release tags
 	releaseAnnotationHasReleases = "release.openshift.io/hasReleases"
+	// if set, when rewriting a stable tag use the images locally
+	releaseAnnotationMirrorImages = "release.openshift.io/mirrorImages"
 
 	releaseAnnotationReason  = "release.openshift.io/reason"
 	releaseAnnotationMessage = "release.openshift.io/message"


### PR DESCRIPTION
Stable imports need to keep pull specs accurate. On import use
`oc adm release mirror --to-image-stream` to do that. Allow a
user to force rebuilding the payload to point to the mirror if
they set `release.openshift.io/mirrorImages` on the incoming tag
(mostly for CI use cases).