### PR TITLE
Support prow directories by refreshing prow config

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -183,7 +183,7 @@ func addReleaseEnvToProwJobSpec(spec *prowapiv1.ProwJobSpec, release *Release, m
 	return true, nil
 }
 
-func hasProwJob(config *prowapiv1.Config, name string) (*prowapiv1.PeriodicConfig, bool) {
+func hasProwJob(config *prowapiv1.Config, name string) (*prowapiv1.Periodic, bool) {
 	for i := range config.Periodics {
 		if config.Periodics[i].Name == name {
 			return &config.Periodics[i], true
@@ -192,7 +192,7 @@ func hasProwJob(config *prowapiv1.Config, name string) (*prowapiv1.PeriodicConfi
 	return nil, false
 }
 
-func prowSpecForPeriodicConfig(config *prowapiv1.PeriodicConfig, decorationConfig *prowapiv1.DecorationConfig) *prowapiv1.ProwJobSpec {
+func prowSpecForPeriodicConfig(config *prowapiv1.Periodic, decorationConfig *prowapiv1.DecorationConfig) *prowapiv1.ProwJobSpec {
 	spec := &prowapiv1.ProwJobSpec{
 		Type:  prowapiv1.PeriodicJob,
 		Job:   config.Name,
@@ -208,7 +208,8 @@ func prowSpecForPeriodicConfig(config *prowapiv1.PeriodicConfig, decorationConfi
 	} else {
 		spec.DecorationConfig = &prowapiv1.DecorationConfig{}
 	}
-	spec.DecorationConfig.SkipCloning = true
+	isTrue := true
+	spec.DecorationConfig.SkipCloning = &isTrue
 
 	return spec
 }

--- a/pkg/prow/apiv1/agent.go
+++ b/pkg/prow/apiv1/agent.go
@@ -1,65 +1,38 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-// taken from test-infra/prow/config
-
 package apiv1
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
 
-	"github.com/ghodss/yaml"
-	"github.com/golang/glog"
+	"github.com/sirupsen/logrus"
 )
 
-// Load reads the decoration_config from prowConfigPath and periodics from
-// the provided job config, or returns an error.
-func Load(prowConfigPath, jobConfigPath string) (*Config, error) {
-	c := &Config{}
-	for _, path := range []string{prowConfigPath, jobConfigPath} {
-		data, err := ioutil.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
-		if err := yaml.Unmarshal(data, c); err != nil {
-			return nil, err
-		}
-	}
-	return c, nil
+// Delta represents the before and after states of a Config change detected by the Agent.
+type Delta struct {
+	Before, After Config
 }
+
+// DeltaChan is a channel to receive config delta events when config changes.
+type DeltaChan = chan<- Delta
 
 // Agent watches a path and automatically loads the config stored
 // therein.
 type Agent struct {
-	sync.Mutex
-	c *Config
+	mut           sync.RWMutex // do not export Lock, etc methods
+	c             *Config
+	subscriptions []DeltaChan
 }
 
 // Start will begin polling the config file at the path. If the first load
-// fails, Start with return the error and abort. Future load failures will log
+// fails, Start will return the error and abort. Future load failures will log
 // the failure message but continue attempting to load.
 func (ca *Agent) Start(prowConfig, jobConfig string) error {
 	c, err := Load(prowConfig, jobConfig)
 	if err != nil {
 		return err
 	}
-	ca.c = c
+	ca.Set(c)
 	go func() {
 		var lastModTime time.Time
 		// Rarely, if two changes happen in the same second, mtime will
@@ -70,22 +43,25 @@ func (ca *Agent) Start(prowConfig, jobConfig string) error {
 			if skips < 600 {
 				// Check if the file changed to see if it needs to be re-read.
 				// os.Stat follows symbolic links, which is how ConfigMaps work.
-				prowStat, err := os.Stat(jobConfig)
+				prowStat, err := os.Stat(prowConfig)
 				if err != nil {
-					glog.Errorf("Error loading prow config: %v", err)
+					logrus.WithField("prowConfig", prowConfig).WithError(err).Error("Error loading prow config.")
 					continue
 				}
 
 				recentModTime := prowStat.ModTime()
 
-				jobConfigStat, err := os.Stat(jobConfig)
-				if err != nil {
-					glog.Errorf("Error loading job config: %v", err)
-					continue
-				}
+				// TODO(krzyzacy): allow empty jobConfig till fully migrate config to subdirs
+				if jobConfig != "" {
+					jobConfigStat, err := os.Stat(jobConfig)
+					if err != nil {
+						logrus.WithField("jobConfig", jobConfig).WithError(err).Error("Error loading job configs.")
+						continue
+					}
 
-				if jobConfigStat.ModTime().After(recentModTime) {
-					recentModTime = jobConfigStat.ModTime()
+					if jobConfigStat.ModTime().After(recentModTime) {
+						recentModTime = jobConfigStat.ModTime()
+					}
 				}
 
 				if !recentModTime.After(lastModTime) {
@@ -95,28 +71,58 @@ func (ca *Agent) Start(prowConfig, jobConfig string) error {
 				lastModTime = recentModTime
 			}
 			if c, err := Load(prowConfig, jobConfig); err != nil {
-				glog.Errorf("Error loading config: %v", err)
+				logrus.WithField("prowConfig", prowConfig).
+					WithField("jobConfig", jobConfig).
+					WithError(err).Error("Error loading config.")
 			} else {
 				skips = 0
-				ca.Lock()
-				ca.c = c
-				ca.Unlock()
+				ca.Set(c)
 			}
 		}
 	}()
 	return nil
 }
 
+// Subscribe registers the channel for messages on config reload.
+// The caller can expect a copy of the previous and current config
+// to be sent down the subscribed channel when a new configuration
+// is loaded.
+func (ca *Agent) Subscribe(subscription DeltaChan) {
+	ca.mut.Lock()
+	defer ca.mut.Unlock()
+	ca.subscriptions = append(ca.subscriptions, subscription)
+}
+
+// Getter returns the current Config in a thread-safe manner.
+type Getter func() *Config
+
 // Config returns the latest config. Do not modify the config.
 func (ca *Agent) Config() *Config {
-	ca.Lock()
-	defer ca.Unlock()
+	ca.mut.RLock()
+	defer ca.mut.RUnlock()
 	return ca.c
 }
 
 // Set sets the config. Useful for testing.
 func (ca *Agent) Set(c *Config) {
-	ca.Lock()
-	defer ca.Unlock()
+	ca.mut.Lock()
+	defer ca.mut.Unlock()
+	var oldConfig Config
+	if ca.c != nil {
+		oldConfig = *ca.c
+	}
+	delta := Delta{oldConfig, *c}
 	ca.c = c
+	for _, subscription := range ca.subscriptions {
+		go func(sub DeltaChan) { // wait a minute to send each event
+			end := time.NewTimer(time.Minute)
+			select {
+			case sub <- delta:
+			case <-end.C:
+			}
+			if !end.Stop() { // prevent new events
+				<-end.C // drain the pending event
+			}
+		}(subscription)
+	}
 }

--- a/pkg/prow/apiv1/consts.go
+++ b/pkg/prow/apiv1/consts.go
@@ -1,0 +1,34 @@
+package apiv1
+
+const (
+	// CreatedByProw is added on resources created by prow.
+	// Since resources often live in another cluster/namespace,
+	// the k8s garbage collector would immediately delete these
+	// resources
+	// TODO: Namespace this label.
+	CreatedByProw = "created-by-prow"
+	// ProwJobTypeLabel is added in resources created by prow and
+	// carries the job type (presubmit, postsubmit, periodic, batch)
+	// that the pod is running.
+	ProwJobTypeLabel = "prow.k8s.io/type"
+	// ProwJobIDLabel is added in resources created by prow and
+	// carries the ID of the ProwJob that the pod is fulfilling.
+	// We also name resources after the ProwJob that spawned them but
+	// this allows for multiple resources to be linked to one
+	// ProwJob.
+	ProwJobIDLabel = "prow.k8s.io/id"
+	// ProwJobAnnotation is added in resources created by prow and
+	// carries the name of the job that the pod is running. Since
+	// job names can be arbitrarily long, this is added as
+	// an annotation instead of a label.
+	ProwJobAnnotation = "prow.k8s.io/job"
+	// OrgLabel is added in resources created by prow and
+	// carries the org associated with the job, eg kubernetes-sigs.
+	OrgLabel = "prow.k8s.io/refs.org"
+	// RepoLabel is added in resources created by prow and
+	// carries the repo associated with the job, eg test-infra
+	RepoLabel = "prow.k8s.io/refs.repo"
+	// PullLabel is added in resources created by prow and
+	// carries the PR number associated with the job, eg 321.
+	PullLabel = "prow.k8s.io/refs.pull"
+)

--- a/pkg/prow/apiv1/jobspec.go
+++ b/pkg/prow/apiv1/jobspec.go
@@ -1,0 +1,161 @@
+package apiv1
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// JobSpec is the full downward API that we expose to
+// jobs that realize a ProwJob. We will provide this
+// data to jobs with environment variables in two ways:
+//  - the full spec, in serialized JSON in one variable
+//  - individual fields of the spec in their own variables
+type JobSpec struct {
+	Type      ProwJobType `json:"type,omitempty"`
+	Job       string      `json:"job,omitempty"`
+	BuildID   string      `json:"buildid,omitempty"`
+	ProwJobID string      `json:"prowjobid,omitempty"`
+
+	// refs & extra_refs from the full spec
+	Refs      *Refs   `json:"refs,omitempty"`
+	ExtraRefs []*Refs `json:"extra_refs,omitempty"`
+
+	// we need to keep track of the agent until we
+	// migrate everyone away from using the $BUILD_NUMBER
+	// environment variable
+	agent ProwJobAgent
+}
+
+// NewJobSpec converts a prowapi.ProwJobSpec invocation into a JobSpec
+func NewJobSpec(spec ProwJobSpec, buildID, prowJobID string) JobSpec {
+	return JobSpec{
+		Type:      spec.Type,
+		Job:       spec.Job,
+		BuildID:   buildID,
+		ProwJobID: prowJobID,
+		Refs:      spec.Refs,
+		ExtraRefs: spec.ExtraRefs,
+		agent:     spec.Agent,
+	}
+}
+
+// ResolveSpecFromEnv will determine the Refs being
+// tested in by parsing Prow environment variable contents
+func ResolveSpecFromEnv() (*JobSpec, error) {
+	specEnv, ok := os.LookupEnv(JobSpecEnv)
+	if !ok {
+		return nil, fmt.Errorf("$%s unset", JobSpecEnv)
+	}
+
+	spec := &JobSpec{}
+	if err := json.Unmarshal([]byte(specEnv), spec); err != nil {
+		return nil, fmt.Errorf("malformed $%s: %v", JobSpecEnv, err)
+	}
+
+	return spec, nil
+}
+
+const (
+	// JobSpecEnv is the name that contains JobSpec marshaled into a string.
+	JobSpecEnv = "JOB_SPEC"
+
+	jobNameEnv   = "JOB_NAME"
+	jobTypeEnv   = "JOB_TYPE"
+	prowJobIDEnv = "PROW_JOB_ID"
+
+	buildIDEnv     = "BUILD_ID"
+	prowBuildIDEnv = "BUILD_NUMBER" // Deprecated, will be removed in the future.
+
+	repoOwnerEnv   = "REPO_OWNER"
+	repoNameEnv    = "REPO_NAME"
+	pullBaseRefEnv = "PULL_BASE_REF"
+	pullBaseShaEnv = "PULL_BASE_SHA"
+	pullRefsEnv    = "PULL_REFS"
+	pullNumberEnv  = "PULL_NUMBER"
+	pullPullShaEnv = "PULL_PULL_SHA"
+)
+
+// EnvForSpec returns a mapping of environment variables
+// to their values that should be available for a job spec
+func EnvForSpec(spec JobSpec) (map[string]string, error) {
+	env := map[string]string{
+		jobNameEnv:   spec.Job,
+		buildIDEnv:   spec.BuildID,
+		prowJobIDEnv: spec.ProwJobID,
+		jobTypeEnv:   string(spec.Type),
+	}
+
+	// for backwards compatibility, we provide the build ID
+	// in both $BUILD_ID and $BUILD_NUMBER for Prow agents
+	// and in both $buildId and $BUILD_NUMBER for Jenkins
+	if spec.agent == KubernetesAgent {
+		env[prowBuildIDEnv] = spec.BuildID
+	}
+
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return env, fmt.Errorf("failed to marshal job spec: %v", err)
+	}
+	env[JobSpecEnv] = string(raw)
+
+	if spec.Type == PeriodicJob {
+		return env, nil
+	}
+
+	env[repoOwnerEnv] = spec.Refs.Org
+	env[repoNameEnv] = spec.Refs.Repo
+	env[pullBaseRefEnv] = spec.Refs.BaseRef
+	env[pullBaseShaEnv] = spec.Refs.BaseSHA
+	env[pullRefsEnv] = spec.Refs.String()
+
+	if spec.Type == PostsubmitJob || spec.Type == BatchJob {
+		return env, nil
+	}
+
+	env[pullNumberEnv] = strconv.Itoa(spec.Refs.Pulls[0].Number)
+	env[pullPullShaEnv] = spec.Refs.Pulls[0].SHA
+	return env, nil
+}
+
+// EnvForType returns the slice of environment variables to export for jobType
+func EnvForType(jobType ProwJobType) []string {
+	baseEnv := []string{jobNameEnv, JobSpecEnv, jobTypeEnv, prowJobIDEnv, buildIDEnv, prowBuildIDEnv}
+	refsEnv := []string{repoOwnerEnv, repoNameEnv, pullBaseRefEnv, pullBaseShaEnv, pullRefsEnv}
+	pullEnv := []string{pullNumberEnv, pullPullShaEnv}
+
+	switch jobType {
+	case PeriodicJob:
+		return baseEnv
+	case PostsubmitJob, BatchJob:
+		return append(baseEnv, refsEnv...)
+	case PresubmitJob:
+		return append(append(baseEnv, refsEnv...), pullEnv...)
+	default:
+		return []string{}
+	}
+}
+
+// getRevisionFromRef returns a ref or sha from a refs object
+func getRevisionFromRef(refs *Refs) string {
+	if len(refs.Pulls) > 0 {
+		return refs.Pulls[0].SHA
+	}
+
+	if refs.BaseSHA != "" {
+		return refs.BaseSHA
+	}
+
+	return refs.BaseRef
+}
+
+// GetRevisionFromSpec returns a main ref or sha from a spec object
+func GetRevisionFromSpec(spec *JobSpec) string {
+	if spec.Refs != nil {
+		return getRevisionFromRef(spec.Refs)
+	} else if len(spec.ExtraRefs) > 0 {
+		return getRevisionFromRef(spec.ExtraRefs[0])
+	}
+	return ""
+}

--- a/pkg/prow/apiv1/load.go
+++ b/pkg/prow/apiv1/load.go
@@ -1,0 +1,613 @@
+package apiv1
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	// DefaultJobTimeout represents the default deadline for a prow job.
+	DefaultJobTimeout = 24 * time.Hour
+)
+
+// Load loads and parses the config at path.
+func Load(prowConfig, jobConfig string) (c *Config, err error) {
+	// we never want config loading to take down the prow components
+	defer func() {
+		if r := recover(); r != nil {
+			c, err = nil, fmt.Errorf("panic loading config: %v", r)
+		}
+	}()
+	c, err = loadConfig(prowConfig, jobConfig)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.finalizeJobConfig(); err != nil {
+		return nil, err
+	}
+	if err := c.validateComponentConfig(); err != nil {
+		return nil, err
+	}
+	if err := c.validateJobConfig(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// loadConfig loads one or multiple config files and returns a config object.
+func loadConfig(prowConfig, jobConfig string) (*Config, error) {
+	stat, err := os.Stat(prowConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.IsDir() {
+		return nil, fmt.Errorf("prowConfig cannot be a dir - %s", prowConfig)
+	}
+
+	var nc Config
+	if err := yamlToConfig(prowConfig, &nc); err != nil {
+		return nil, err
+	}
+	if err := parseProwConfig(&nc); err != nil {
+		return nil, err
+	}
+
+	// TODO(krzyzacy): temporary allow empty jobconfig
+	//                 also temporary allow job config in prow config
+	if jobConfig == "" {
+		return &nc, nil
+	}
+
+	stat, err = os.Stat(jobConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if !stat.IsDir() {
+		// still support a single file
+		var jc JobConfig
+		if err := yamlToConfig(jobConfig, &jc); err != nil {
+			return nil, err
+		}
+		if err := nc.mergeJobConfig(jc); err != nil {
+			return nil, err
+		}
+		return &nc, nil
+	}
+
+	// we need to ensure all config files have unique basenames,
+	// since updateconfig plugin will use basename as a key in the configmap
+	uniqueBasenames := sets.String{}
+
+	err = filepath.Walk(jobConfig, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			logrus.WithError(err).Errorf("walking path %q.", path)
+			// bad file should not stop us from parsing the directory
+			return nil
+		}
+
+		if strings.HasPrefix(info.Name(), "..") {
+			// kubernetes volumes also include files we
+			// should not look be looking into for keys
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".yml" {
+			return nil
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		base := filepath.Base(path)
+		if uniqueBasenames.Has(base) {
+			return fmt.Errorf("duplicated basename is not allowed: %s", base)
+		}
+		uniqueBasenames.Insert(base)
+
+		var subConfig JobConfig
+		if err := yamlToConfig(path, &subConfig); err != nil {
+			return err
+		}
+		return nc.mergeJobConfig(subConfig)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &nc, nil
+}
+
+// yamlToConfig converts a yaml file into a Config object
+func yamlToConfig(path string, nc interface{}) error {
+	b, err := ReadFileMaybeGZIP(path)
+	if err != nil {
+		return fmt.Errorf("error reading %s: %v", path, err)
+	}
+	if err := yaml.Unmarshal(b, nc); err != nil {
+		return fmt.Errorf("error unmarshaling %s: %v", path, err)
+	}
+	var jc *JobConfig
+	switch v := nc.(type) {
+	case *JobConfig:
+		jc = v
+	case *Config:
+		jc = &v.JobConfig
+	}
+
+	var fix func(*Periodic)
+	fix = func(job *Periodic) {
+		job.SourcePath = path
+	}
+	for i := range jc.Periodics {
+		fix(&jc.Periodics[i])
+	}
+	return nil
+}
+
+// ReadFileMaybeGZIP wraps ioutil.ReadFile, returning the decompressed contents
+// if the file is gzipped, or otherwise the raw contents
+func ReadFileMaybeGZIP(path string) ([]byte, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// check if file contains gzip header: http://www.zlib.org/rfc-gzip.html
+	if !bytes.HasPrefix(b, []byte("\x1F\x8B")) {
+		// go ahead and return the contents if not gzipped
+		return b, nil
+	}
+	// otherwise decode
+	gzipReader, err := gzip.NewReader(bytes.NewBuffer(b))
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(gzipReader)
+}
+
+// mergeConfig merges two JobConfig together
+// It will try to merge:
+//	- Presubmits
+//	- Postsubmits
+// 	- Periodics
+//	- PodPresets
+func (c *Config) mergeJobConfig(jc JobConfig) error {
+	// Merge everything
+	// *** Presets ***
+	// c.Presets = append(c.Presets, jc.Presets...)
+
+	// validate no duplicated preset key-value pairs
+	// validLabels := map[string]bool{}
+	// for _, preset := range c.Presets {
+	// 	for label, val := range preset.Labels {
+	// 		pair := label + ":" + val
+	// 		if _, ok := validLabels[pair]; ok {
+	// 			return fmt.Errorf("duplicated preset 'label:value' pair : %s", pair)
+	// 		}
+	// 		validLabels[pair] = true
+	// 	}
+	// }
+
+	// *** Periodics ***
+	c.Periodics = append(c.Periodics, jc.Periodics...)
+
+	// *** Presubmits ***
+	// if c.Presubmits == nil {
+	// 	c.Presubmits = make(map[string][]Presubmit)
+	// }
+	// for repo, jobs := range jc.Presubmits {
+	// 	c.Presubmits[repo] = append(c.Presubmits[repo], jobs...)
+	// }
+
+	// *** Postsubmits ***
+	// if c.Postsubmits == nil {
+	// 	c.Postsubmits = make(map[string][]Postsubmit)
+	// }
+	// for repo, jobs := range jc.Postsubmits {
+	// 	c.Postsubmits[repo] = append(c.Postsubmits[repo], jobs...)
+	// }
+
+	return nil
+}
+
+func setPeriodicDecorationDefaults(c *Config, ps *Periodic) {
+	if ps.Decorate {
+		ps.DecorationConfig = ps.DecorationConfig.ApplyDefault(c.Plank.DefaultDecorationConfig)
+	}
+}
+
+// finalizeJobConfig mutates and fixes entries for jobspecs
+func (c *Config) finalizeJobConfig() error {
+	if c.decorationRequested() {
+		if c.Plank.DefaultDecorationConfig == nil {
+			return errors.New("no default decoration config provided for plank")
+		}
+		if c.Plank.DefaultDecorationConfig.UtilityImages == nil {
+			return errors.New("no default decoration image pull specs provided for plank")
+		}
+		if c.Plank.DefaultDecorationConfig.GCSConfiguration == nil {
+			return errors.New("no default GCS decoration config provided for plank")
+		}
+		if c.Plank.DefaultDecorationConfig.GCSCredentialsSecret == "" {
+			return errors.New("no default GCS credentials secret provided for plank")
+		}
+
+		for i := range c.Periodics {
+			setPeriodicDecorationDefaults(c, &c.Periodics[i])
+		}
+	}
+
+	c.defaultPeriodicFields(c.Periodics)
+
+	for _, v := range c.AllPeriodics() {
+		if err := resolvePresets(v.Name, v.Labels, v.Spec, c.Presets); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateComponentConfig validates the infrastructure component configuration
+func (c *Config) validateComponentConfig() error {
+	if c.Plank.JobURLPrefix != "" && c.Plank.JobURLPrefixConfig["*"] != "" {
+		return errors.New(`Planks job_url_prefix must be unset when job_url_prefix_config["*"] is set. The former is deprecated, use the latter`)
+	}
+	for k, v := range c.Plank.JobURLPrefixConfig {
+		if _, err := url.Parse(v); err != nil {
+			return fmt.Errorf(`Invalid value for Planks job_url_prefix_config["%s"]: %v`, k, err)
+		}
+	}
+	return nil
+}
+
+var jobNameRegex = regexp.MustCompile(`^[A-Za-z0-9-._]+$`)
+
+func validateJobBase(v JobBase, jobType ProwJobType, podNamespace string) error {
+	if !jobNameRegex.MatchString(v.Name) {
+		return fmt.Errorf("name: must match regex %q", jobNameRegex.String())
+	}
+	// Ensure max_concurrency is non-negative.
+	if v.MaxConcurrency < 0 {
+		return fmt.Errorf("max_concurrency: %d must be a non-negative number", v.MaxConcurrency)
+	}
+	if err := validateAgent(v, podNamespace); err != nil {
+		return err
+	}
+	if err := validatePodSpec(jobType, v.Spec); err != nil {
+		return err
+	}
+	if err := validateLabels(v.Labels); err != nil {
+		return err
+	}
+	if v.Spec == nil || len(v.Spec.Containers) == 0 {
+		return nil // knative-build and jenkins jobs have no spec
+	}
+	return validateDecoration(v.Spec.Containers[0], v.DecorationConfig)
+}
+
+// validateJobConfig validates if all the jobspecs/presets are valid
+// if you are mutating the jobs, please add it to finalizeJobConfig above
+func (c *Config) validateJobConfig() error {
+	type orgRepoJobName struct {
+		orgRepo, jobName string
+	}
+
+	// validate no duplicated periodics
+	validPeriodics := sets.NewString()
+	// Ensure that the periodic durations are valid and specs exist.
+	for _, p := range c.AllPeriodics() {
+		if validPeriodics.Has(p.Name) {
+			return fmt.Errorf("duplicated periodic job : %s", p.Name)
+		}
+		validPeriodics.Insert(p.Name)
+		if err := validateJobBase(p.JobBase, PeriodicJob, c.PodNamespace); err != nil {
+			return fmt.Errorf("invalid periodic job %s: %v", p.Name, err)
+		}
+	}
+	// Set the interval on the periodic jobs. It doesn't make sense to do this
+	// for child jobs.
+	for j, p := range c.Periodics {
+		if p.Cron != "" && p.Interval != "" {
+			return fmt.Errorf("cron and interval cannot be both set in periodic %s", p.Name)
+		} else if p.Cron == "" && p.Interval == "" {
+			return fmt.Errorf("cron and interval cannot be both empty in periodic %s", p.Name)
+		} else if p.Cron != "" {
+			// if _, err := cron.Parse(p.Cron); err != nil {
+			// 	return fmt.Errorf("invalid cron string %s in periodic %s: %v", p.Cron, p.Name, err)
+			// }
+		} else {
+			d, err := time.ParseDuration(c.Periodics[j].Interval)
+			if err != nil {
+				return fmt.Errorf("cannot parse duration for %s: %v", c.Periodics[j].Name, err)
+			}
+			c.Periodics[j].interval = d
+		}
+	}
+
+	return nil
+}
+
+// ConfigPath returns the value for the component's configPath if provided
+// explicityly or default otherwise.
+func ConfigPath(value string) string {
+
+	// TODO: require setting this explicitly
+	defaultConfigPath := "/etc/config/config.yaml"
+
+	if value != "" {
+		return value
+	}
+	logrus.Warningf("defaulting to %s until 15 July 2019, please migrate", defaultConfigPath)
+	return defaultConfigPath
+}
+
+func parseProwConfig(c *Config) error {
+	if err := ValidateController(&c.Plank.Controller); err != nil {
+		return fmt.Errorf("validating plank config: %v", err)
+	}
+
+	if c.Plank.PodPendingTimeoutString == "" {
+		c.Plank.PodPendingTimeout = 24 * time.Hour
+	} else {
+		podPendingTimeout, err := time.ParseDuration(c.Plank.PodPendingTimeoutString)
+		if err != nil {
+			return fmt.Errorf("cannot parse duration for plank.pod_pending_timeout: %v", err)
+		}
+		c.Plank.PodPendingTimeout = podPendingTimeout
+	}
+
+	if c.ProwJobNamespace == "" {
+		c.ProwJobNamespace = "default"
+	}
+	if c.PodNamespace == "" {
+		c.PodNamespace = "default"
+	}
+
+	if c.Plank.JobURLPrefixConfig == nil {
+		c.Plank.JobURLPrefixConfig = map[string]string{}
+	}
+	if c.Plank.JobURLPrefix != "" && c.Plank.JobURLPrefixConfig["*"] == "" {
+		c.Plank.JobURLPrefixConfig["*"] = c.Plank.JobURLPrefix
+		// Set JobURLPrefix to an empty string to indicate we've moved
+		// it to JobURLPrefixConfig["*"] without overwriting the latter
+		// so validation succeeds
+		c.Plank.JobURLPrefix = ""
+	}
+
+	if c.GitHubOptions.LinkURLFromConfig == "" {
+		c.GitHubOptions.LinkURLFromConfig = "https://github.com"
+	}
+	linkURL, err := url.Parse(c.GitHubOptions.LinkURLFromConfig)
+	if err != nil {
+		return fmt.Errorf("unable to parse github.link_url, might not be a valid url: %v", err)
+	}
+	c.GitHubOptions.LinkURL = linkURL
+
+	if c.StatusErrorLink == "" {
+		c.StatusErrorLink = "https://github.com/kubernetes/test-infra/issues"
+	}
+
+	if c.LogLevel == "" {
+		c.LogLevel = "info"
+	}
+	lvl, err := logrus.ParseLevel(c.LogLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(lvl)
+
+	// Avoid using a job timeout of infinity by setting the default value to 24 hours
+	if c.DefaultJobTimeout == 0 {
+		c.DefaultJobTimeout = DefaultJobTimeout
+	}
+
+	return nil
+}
+
+func (c *JobConfig) decorationRequested() bool {
+	for i := range c.Periodics {
+		if c.Periodics[i].Decorate {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validateLabels(labels map[string]string) error {
+	for label, value := range labels {
+		for _, prowLabel := range Labels() {
+			if label == prowLabel {
+				return fmt.Errorf("label %s is reserved for decoration", label)
+			}
+		}
+		if errs := validation.IsQualifiedName(label); len(errs) != 0 {
+			return fmt.Errorf("invalid label %s: %v", label, errs)
+		}
+		if errs := validation.IsValidLabelValue(labels[label]); len(errs) != 0 {
+			return fmt.Errorf("label %s has invalid value %s: %v", label, value, errs)
+		}
+	}
+	return nil
+}
+
+func validateAgent(v JobBase, podNamespace string) error {
+	k := string(KubernetesAgent)
+	b := string(KnativeBuildAgent)
+	j := string(JenkinsAgent)
+	agents := sets.NewString(k, b, j)
+	agent := v.Agent
+	switch {
+	case !agents.Has(agent):
+		return fmt.Errorf("agent must be one of %s (found %q)", strings.Join(agents.List(), ", "), agent)
+	case v.Spec != nil && agent != k:
+		return fmt.Errorf("job specs require agent: %s (found %q)", k, agent)
+	case agent == k && v.Spec == nil:
+		return errors.New("kubernetes jobs require a spec")
+	case v.DecorationConfig != nil && agent != k && agent != b:
+		// TODO(fejta): only source decoration supported...
+		return fmt.Errorf("decoration requires agent: %s or %s (found %q)", k, b, agent)
+	case v.ErrorOnEviction && agent != k:
+		return fmt.Errorf("error_on_eviction only applies to agent: %s (found %q)", k, agent)
+	case v.Namespace == nil || *v.Namespace == "":
+		return fmt.Errorf("failed to default namespace")
+	case *v.Namespace != podNamespace && agent != b:
+		// TODO(fejta): update plank to allow this (depends on client change)
+		return fmt.Errorf("namespace customization requires agent: %s (found %q)", b, agent)
+	}
+	return nil
+}
+
+func validateDecoration(container v1.Container, config *DecorationConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	if err := config.Validate(); err != nil {
+		return fmt.Errorf("invalid decoration config: %v", err)
+	}
+	var args []string
+	args = append(append(args, container.Command...), container.Args...)
+	if len(args) == 0 || args[0] == "" {
+		return errors.New("decorated job containers must specify command and/or args")
+	}
+	return nil
+}
+
+func resolvePresets(name string, labels map[string]string, spec *v1.PodSpec, presets []Preset) error {
+	for _, preset := range presets {
+		if spec != nil {
+			if err := mergePreset(preset, labels, spec.Containers, &spec.Volumes); err != nil {
+				return fmt.Errorf("job %s failed to merge presets for podspec: %v", name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validatePodSpec(jobType ProwJobType, spec *v1.PodSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	if len(spec.InitContainers) != 0 {
+		return errors.New("pod spec may not use init containers")
+	}
+
+	if n := len(spec.Containers); n != 1 {
+		return fmt.Errorf("pod spec must specify exactly 1 container, found: %d", n)
+	}
+
+	for _, env := range spec.Containers[0].Env {
+		for _, prowEnv := range EnvForType(jobType) {
+			if env.Name == prowEnv {
+				// TODO(fejta): consider allowing this
+				return fmt.Errorf("env %s is reserved", env.Name)
+			}
+		}
+	}
+
+	for _, mount := range spec.Containers[0].VolumeMounts {
+		for _, prowMount := range VolumeMounts() {
+			if mount.Name == prowMount {
+				return fmt.Errorf("volumeMount name %s is reserved for decoration", prowMount)
+			}
+		}
+		for _, prowMountPath := range VolumeMountPaths() {
+			if strings.HasPrefix(mount.MountPath, prowMountPath) || strings.HasPrefix(prowMountPath, mount.MountPath) {
+				return fmt.Errorf("mount %s at %s conflicts with decoration mount at %s", mount.Name, mount.MountPath, prowMountPath)
+			}
+		}
+	}
+
+	for _, volume := range spec.Volumes {
+		for _, prowVolume := range VolumeMounts() {
+			if volume.Name == prowVolume {
+				return fmt.Errorf("volume %s is a reserved for decoration", volume.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateController validates the provided controller config.
+func ValidateController(c *Controller) error {
+	urlTmpl, err := template.New("JobURL").Parse(c.JobURLTemplateString)
+	if err != nil {
+		return fmt.Errorf("parsing template: %v", err)
+	}
+	c.JobURLTemplate = urlTmpl
+
+	reportTmpl, err := template.New("Report").Parse(c.ReportTemplateString)
+	if err != nil {
+		return fmt.Errorf("parsing template: %v", err)
+	}
+	c.ReportTemplate = reportTmpl
+	if c.MaxConcurrency < 0 {
+		return fmt.Errorf("controller has invalid max_concurrency (%d), it needs to be a non-negative number", c.MaxConcurrency)
+	}
+	if c.MaxGoroutines == 0 {
+		c.MaxGoroutines = 20
+	}
+	if c.MaxGoroutines <= 0 {
+		return fmt.Errorf("controller has invalid max_goroutines (%d), it needs to be a positive number", c.MaxGoroutines)
+	}
+	return nil
+}
+
+// DefaultTriggerFor returns the default regexp string used to match comments
+// that should trigger the job with this name.
+func DefaultTriggerFor(name string) string {
+	return fmt.Sprintf(`(?m)^/test( | .* )%s,?($|\s.*)`, name)
+}
+
+// DefaultRerunCommandFor returns the default rerun command for the job with
+// this name.
+func DefaultRerunCommandFor(name string) string {
+	return fmt.Sprintf("/test %s", name)
+}
+
+// defaultJobBase configures common parameters, currently Agent and Namespace.
+func (c *ProwConfig) defaultJobBase(base *JobBase) {
+	if base.Agent == "" { // Use kubernetes by default
+		base.Agent = string(KubernetesAgent)
+	}
+	if base.Namespace == nil || *base.Namespace == "" {
+		s := c.PodNamespace
+		base.Namespace = &s
+	}
+	if base.Cluster == "" {
+		base.Cluster = "default"
+	}
+}
+
+func (c *ProwConfig) defaultPeriodicFields(js []Periodic) {
+	for i := range js {
+		c.defaultJobBase(&js[i].JobBase)
+	}
+}

--- a/pkg/prow/apiv1/podspec.go
+++ b/pkg/prow/apiv1/podspec.go
@@ -1,0 +1,30 @@
+package apiv1
+
+const (
+	logMountName            = "logs"
+	logMountPath            = "/logs"
+	artifactsEnv            = "ARTIFACTS"
+	artifactsPath           = logMountPath + "/artifacts"
+	codeMountName           = "code"
+	codeMountPath           = "/home/prow/go"
+	gopathEnv               = "GOPATH"
+	toolsMountName          = "tools"
+	toolsMountPath          = "/tools"
+	gcsCredentialsMountName = "gcs-credentials"
+	gcsCredentialsMountPath = "/secrets/gcs"
+)
+
+// Labels returns a string slice with label consts from kube.
+func Labels() []string {
+	return []string{ProwJobTypeLabel, CreatedByProw, ProwJobIDLabel}
+}
+
+// VolumeMounts returns a string slice with *MountName consts in it.
+func VolumeMounts() []string {
+	return []string{logMountName, codeMountName, toolsMountName, gcsCredentialsMountName}
+}
+
+// VolumeMountPaths returns a string slice with *MountPath consts in it.
+func VolumeMountPaths() []string {
+	return []string{logMountPath, codeMountPath, toolsMountPath, gcsCredentialsMountPath}
+}

--- a/pkg/prow/apiv1/types.go
+++ b/pkg/prow/apiv1/types.go
@@ -19,41 +19,279 @@ limitations under the License.
 package apiv1
 
 import (
+	"errors"
 	"fmt"
+	"html/template"
+	"net/url"
 	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Config loads a subset of the Prow config definition.
+// Config is a read-only snapshot of the config.
 type Config struct {
+	JobConfig
+	ProwConfig
+}
+
+// CJobonfig loads a subset of the Prow config definition.
+type JobConfig struct {
+	// Presets apply to all job types.
+	Presets []Preset `json:"presets,omitempty"`
+	// Full repo name (such as "kubernetes/kubernetes") -> list of jobs.
+	// Presubmits  map[string][]Presubmit  `json:"presubmits,omitempty"`
+	// Postsubmits map[string][]Postsubmit `json:"postsubmits,omitempty"`
+	// Periodics are not associated with any repo.
+	Periodics []Periodic `json:"periodics,omitempty"`
+}
+
+// AllPeriodics returns all prow periodic jobs.
+func (c *JobConfig) AllPeriodics() []Periodic {
+	var listPeriodic func(ps []Periodic) []Periodic
+	listPeriodic = func(ps []Periodic) []Periodic {
+		var res []Periodic
+		for _, p := range ps {
+			res = append(res, p)
+		}
+		return res
+	}
+
+	return listPeriodic(c.Periodics)
+}
+
+type ProwConfig struct {
 	// Plank is the default plank configuration.
-	Plank PlankConfig `json:"plank"`
+	Plank Plank `json:"plank"`
+	// ProwJobNamespace is the namespace in the cluster that prow
+	// components will use for looking up ProwJobs. The namespace
+	// needs to exist and will not be created by prow.
+	// Defaults to "default".
+	ProwJobNamespace string `json:"prowjob_namespace,omitempty"`
+	// PodNamespace is the namespace in the cluster that prow
+	// components will use for looking up Pods owned by ProwJobs.
+	// The namespace needs to exist and will not be created by prow.
+	// Defaults to "default".
+	PodNamespace string `json:"pod_namespace,omitempty"`
 
-	// Periodics uses the definitions of periodic jobs to invoke
-	// special actions. Only a subset of fields is supported.
-	Periodics []PeriodicConfig `json:"periodics"`
+	// LogLevel enables dynamically updating the log level of the
+	// standard logger that is used by all prow components.
+	//
+	// Valid values:
+	//
+	// "debug", "info", "warn", "warning", "error", "fatal", "panic"
+	//
+	// Defaults to "info".
+	LogLevel string `json:"log_level,omitempty"`
+
+	// GitHubOptions allows users to control how prow applications display GitHub website links.
+	GitHubOptions GitHubOptions `json:"github,omitempty"`
+
+	// StatusErrorLink is the url that will be used for jenkins prowJobs that can't be
+	// found, or have another generic issue. The default that will be used if this is not set
+	// is: https://github.com/kubernetes/test-infra/issues
+	StatusErrorLink string `json:"status_error_link,omitempty"`
+
+	// DefaultJobTimeout this is default deadline for prow jobs. This value is used when
+	// no timeout is configured at the job level. This value is set to 24 hours.
+	DefaultJobTimeout time.Duration `json:"default_job_timeout,omitempty"`
 }
 
-type PlankConfig struct {
-	// DecorationConfig holds configuration options for
-	// decorating PodSpecs that users provide.
+// GitHubOptions allows users to control how prow applications display GitHub website links.
+type GitHubOptions struct {
+	// LinkURLFromConfig is the string representation of the link_url config parameter.
+	// This config parameter allows users to override the default GitHub link url for all plugins.
+	// If this option is not set, we assume "https://github.com".
+	LinkURLFromConfig string `json:"link_url,omitempty"`
+
+	// LinkURL is the url representation of LinkURLFromConfig. This variable should be used
+	// in all places internally.
+	LinkURL *url.URL
+}
+
+// Controller holds configuration applicable to all agent-specific
+// prow controllers.
+type Controller struct {
+	// JobURLTemplateString compiles into JobURLTemplate at load time.
+	JobURLTemplateString string `json:"job_url_template,omitempty"`
+	// JobURLTemplate is compiled at load time from JobURLTemplateString. It
+	// will be passed a ProwJob and is used to set the URL for the
+	// "Details" link on GitHub as well as the link from deck.
+	JobURLTemplate *template.Template `json:"-"`
+
+	// ReportTemplateString compiles into ReportTemplate at load time.
+	ReportTemplateString string `json:"report_template,omitempty"`
+	// ReportTemplate is compiled at load time from ReportTemplateString. It
+	// will be passed a ProwJob and can provide an optional blurb below
+	// the test failures comment.
+	ReportTemplate *template.Template `json:"-"`
+
+	// MaxConcurrency is the maximum number of tests running concurrently that
+	// will be allowed by the controller. 0 implies no limit.
+	MaxConcurrency int `json:"max_concurrency,omitempty"`
+
+	// MaxGoroutines is the maximum number of goroutines spawned inside the
+	// controller to handle tests. Defaults to 20. Needs to be a positive
+	// number.
+	MaxGoroutines int `json:"max_goroutines,omitempty"`
+
+	// AllowCancellations enables aborting presubmit jobs for commits that
+	// have been superseded by newer commits in GitHub pull requests.
+	AllowCancellations bool `json:"allow_cancellations,omitempty"`
+}
+
+// Plank is config for the plank controller.
+type Plank struct {
+	Controller `json:",inline"`
+	// PodPendingTimeoutString compiles into PodPendingTimeout at load time.
+	PodPendingTimeoutString string `json:"pod_pending_timeout,omitempty"`
+	// PodPendingTimeout is after how long the controller will perform a garbage
+	// collection on pending pods. Defaults to one day.
+	PodPendingTimeout time.Duration `json:"-"`
+	// DefaultDecorationConfig are defaults for shared fields for ProwJobs
+	// that request to have their PodSpecs decorated
 	DefaultDecorationConfig *DecorationConfig `json:"default_decoration_config,omitempty"`
+	// Deprecated, use JobURLPrefixConfig instead
+	// JobURLPrefix is the host and path prefix under
+	// which job details will be viewable
+	// TODO @alvaroaleman: Remove in September 2019
+	JobURLPrefix string `json:"job_url_prefix,omitempty"`
+	// JobURLPrefixConfig is the host and path prefix under which job details
+	// will be viewable. Use `org/repo`, `org` or `*`as key and an url as value
+	JobURLPrefixConfig map[string]string `json:"job_url_prefix_config,omitempty"`
 }
 
-// PeriodicConfig is a subset of the configuration of a periodic job.
-type PeriodicConfig struct {
+func (p Plank) GetJobURLPrefix(refs *Refs) string {
+	if refs == nil {
+		return p.JobURLPrefixConfig["*"]
+	}
+	if p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", refs.Org, refs.Repo)] != "" {
+		return p.JobURLPrefixConfig[fmt.Sprintf("%s/%s", refs.Org, refs.Repo)]
+	}
+	if p.JobURLPrefixConfig[refs.Org] != "" {
+		return p.JobURLPrefixConfig[refs.Org]
+	}
+	return p.JobURLPrefixConfig["*"]
+}
+
+// Preset is intended to match the k8s' PodPreset feature, and may be removed
+// if that feature goes beta.
+type Preset struct {
+	Labels       map[string]string `json:"labels"`
+	Env          []v1.EnvVar       `json:"env"`
+	Volumes      []v1.Volume       `json:"volumes"`
+	VolumeMounts []v1.VolumeMount  `json:"volumeMounts"`
+}
+
+func mergePreset(preset Preset, labels map[string]string, containers []v1.Container, volumes *[]v1.Volume) error {
+	for l, v := range preset.Labels {
+		if v2, ok := labels[l]; !ok || v2 != v {
+			return nil
+		}
+	}
+	for _, e1 := range preset.Env {
+		for i := range containers {
+			for _, e2 := range containers[i].Env {
+				if e1.Name == e2.Name {
+					return fmt.Errorf("env var duplicated in pod spec: %s", e1.Name)
+				}
+			}
+			containers[i].Env = append(containers[i].Env, e1)
+		}
+	}
+	for _, v1 := range preset.Volumes {
+		for _, v2 := range *volumes {
+			if v1.Name == v2.Name {
+				return fmt.Errorf("volume duplicated in pod spec: %s", v1.Name)
+			}
+		}
+		*volumes = append(*volumes, v1)
+	}
+	for _, vm1 := range preset.VolumeMounts {
+		for i := range containers {
+			for _, vm2 := range containers[i].VolumeMounts {
+				if vm1.Name == vm2.Name {
+					return fmt.Errorf("volume mount duplicated in pod spec: %s", vm1.Name)
+				}
+			}
+			containers[i].VolumeMounts = append(containers[i].VolumeMounts, vm1)
+		}
+	}
+	return nil
+}
+
+// JobBase contains attributes common to all job types
+type JobBase struct {
+	// The name of the job. Must match regex [A-Za-z0-9-._]+
+	// e.g. pull-test-infra-bazel-build
 	Name string `json:"name"`
-	// Labels are added in prowjobs created for this job.
+	// Labels are added to prowjobs and pods created for this job.
 	Labels map[string]string `json:"labels,omitempty"`
+	// MaximumConcurrency of this job, 0 implies no limit.
+	MaxConcurrency int `json:"max_concurrency,omitempty"`
 	// Agent that will take care of running this job.
 	Agent string `json:"agent"`
-	// Kubernetes pod spec.
-	Spec *corev1.PodSpec `json:"spec,omitempty"`
+	// Cluster is the alias of the cluster to run this job in.
+	// (Default: kube.DefaultClusterAlias)
+	Cluster string `json:"cluster,omitempty"`
+	// Namespace is the namespace in which pods schedule.
+	//   nil: results in config.PodNamespace (aka pod default)
+	//   empty: results in config.ProwJobNamespace (aka same as prowjob)
+	Namespace *string `json:"namespace,omitempty"`
+	// ErrorOnEviction indicates that the ProwJob should be completed and given
+	// the ErrorState status if the pod that is executing the job is evicted.
+	// If this field is unspecified or false, a new pod will be created to replace
+	// the evicted one.
+	ErrorOnEviction bool `json:"error_on_eviction,omitempty"`
+	// SourcePath contains the path where this job is defined
+	SourcePath string `json:"-"`
+	// Spec is the Kubernetes pod spec used if Agent is kubernetes.
+	Spec *v1.PodSpec `json:"spec,omitempty"`
+
+	UtilityConfig
+}
+
+// UtilityConfig holds decoration metadata, such as how to clone and additional containers/etc
+type UtilityConfig struct {
+	// Decorate determines if we decorate the PodSpec or not
+	Decorate bool `json:"decorate,omitempty"`
+
+	// PathAlias is the location under <root-dir>/src
+	// where the repository under test is cloned. If this
+	// is not set, <root-dir>/src/github.com/org/repo will
+	// be used as the default.
+	PathAlias string `json:"path_alias,omitempty"`
+	// CloneURI is the URI that is used to clone the
+	// repository. If unset, will default to
+	// `https://github.com/org/repo.git`.
+	CloneURI string `json:"clone_uri,omitempty"`
+	// SkipSubmodules determines if submodules should be
+	// cloned when the job is run. Defaults to true.
+	SkipSubmodules bool `json:"skip_submodules,omitempty"`
+
+	// ExtraRefs are auxiliary repositories that
+	// need to be cloned, determined from config
+	ExtraRefs []Refs `json:"extra_refs,omitempty"`
+
+	// DecorationConfig holds configuration options for
+	// decorating PodSpecs that users provide
+	DecorationConfig *DecorationConfig `json:"decoration_config,omitempty"`
+}
+
+// Periodic is a subset of the configuration of a periodic job.
+type Periodic struct {
+	JobBase
+
+	// (deprecated)Interval to wait between two runs of the job.
+	Interval string `json:"interval"`
+	// Cron representation of job trigger time
+	Cron string `json:"cron"`
 	// Tags for config entries
 	Tags []string `json:"tags,omitempty"`
+
+	interval time.Duration
 }
 
 // ProwJobType specifies how the job is triggered.
@@ -188,17 +426,123 @@ type DecorationConfig struct {
 	// artifacts to GCS from a job.
 	GCSConfiguration *GCSConfiguration `json:"gcs_configuration,omitempty"`
 	// GCSCredentialsSecret is the name of the Kubernetes secret
-	// that holds GCS push credentials
+	// that holds GCS push credentials.
 	GCSCredentialsSecret string `json:"gcs_credentials_secret,omitempty"`
 	// SSHKeySecrets are the names of Kubernetes secrets that contain
-	// SSK keys which should be used during the cloning process
+	// SSK keys which should be used during the cloning process.
 	SSHKeySecrets []string `json:"ssh_key_secrets,omitempty"`
+	// SSHHostFingerprints are the fingerprints of known SSH hosts
+	// that the cloning process can trust.
+	// Create with ssh-keyscan [-t rsa] host
+	SSHHostFingerprints []string `json:"ssh_host_fingerprints,omitempty"`
 	// SkipCloning determines if we should clone source code in the
 	// initcontainers for jobs that specify refs
-	SkipCloning bool `json:"skip_cloning,omitempty"`
+	SkipCloning *bool `json:"skip_cloning,omitempty"`
 	// CookieFileSecret is the name of a kubernetes secret that contains
 	// a git http.cookiefile, which should be used during the cloning process.
 	CookiefileSecret string `json:"cookiefile_secret,omitempty"`
+}
+
+// ApplyDefault applies the defaults for the ProwJob decoration. If a field has a zero value, it
+// replaces that with the value set in def.
+func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig {
+	if d == nil && def == nil {
+		return nil
+	}
+	var merged DecorationConfig
+	if d != nil {
+		merged = *d
+	} else {
+		merged = *def
+	}
+	if d == nil || def == nil {
+		return &merged
+	}
+	merged.UtilityImages = merged.UtilityImages.ApplyDefault(def.UtilityImages)
+	merged.GCSConfiguration = merged.GCSConfiguration.ApplyDefault(def.GCSConfiguration)
+
+	if merged.Timeout == 0 {
+		merged.Timeout = def.Timeout
+	}
+	if merged.GracePeriod == 0 {
+		merged.GracePeriod = def.GracePeriod
+	}
+	if merged.GCSCredentialsSecret == "" {
+		merged.GCSCredentialsSecret = def.GCSCredentialsSecret
+	}
+	if len(merged.SSHKeySecrets) == 0 {
+		merged.SSHKeySecrets = def.SSHKeySecrets
+	}
+	if len(merged.SSHHostFingerprints) == 0 {
+		merged.SSHHostFingerprints = def.SSHHostFingerprints
+	}
+	if merged.SkipCloning == nil {
+		merged.SkipCloning = def.SkipCloning
+	}
+	if merged.CookiefileSecret == "" {
+		merged.CookiefileSecret = def.CookiefileSecret
+	}
+
+	return &merged
+}
+
+// Validate ensures all the values set in the DecorationConfig are valid.
+func (d *DecorationConfig) Validate() error {
+	if d.UtilityImages == nil {
+		return errors.New("utility image config is not specified")
+	}
+	var missing []string
+	if d.UtilityImages.CloneRefs == "" {
+		missing = append(missing, "clonerefs")
+	}
+	if d.UtilityImages.InitUpload == "" {
+		missing = append(missing, "initupload")
+	}
+	if d.UtilityImages.Entrypoint == "" {
+		missing = append(missing, "entrypoint")
+	}
+	if d.UtilityImages.Sidecar == "" {
+		missing = append(missing, "sidecar")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("the following utility images are not specified: %q", missing)
+	}
+
+	if d.GCSConfiguration == nil {
+		return errors.New("GCS upload configuration is not specified")
+	}
+	if d.GCSCredentialsSecret == "" {
+		return errors.New("GCS upload credential secret is not specified")
+	}
+	if err := d.GCSConfiguration.Validate(); err != nil {
+		return fmt.Errorf("GCS configuration is invalid: %v", err)
+	}
+	return nil
+}
+
+// ApplyDefault applies the defaults for the UtilityImages decorations. If a field has a zero value,
+// it replaces that with the value set in def.
+func (u *UtilityImages) ApplyDefault(def *UtilityImages) *UtilityImages {
+	if u == nil {
+		return def
+	} else if def == nil {
+		return u
+	}
+
+	merged := *u
+	if merged.CloneRefs == "" {
+		merged.CloneRefs = def.CloneRefs
+	}
+	if merged.InitUpload == "" {
+		merged.InitUpload = def.InitUpload
+	}
+	if merged.Entrypoint == "" {
+		merged.Entrypoint = def.Entrypoint
+	}
+	if merged.Sidecar == "" {
+		merged.Sidecar = def.Sidecar
+	}
+	return &merged
 }
 
 // UtilityImages holds pull specs for the utility images
@@ -239,6 +583,51 @@ type GCSConfiguration struct {
 	// DefaultRepo is omitted from GCS paths when using the
 	// legacy or simple strategy
 	DefaultRepo string `json:"default_repo,omitempty"`
+}
+
+// ApplyDefault applies the defaults for GCSConfiguration decorations. If a field has a zero value,
+// it replaces that with the value set in def.
+func (g *GCSConfiguration) ApplyDefault(def *GCSConfiguration) *GCSConfiguration {
+	if g == nil && def == nil {
+		return nil
+	}
+	var merged GCSConfiguration
+	if g != nil {
+		merged = *g
+	} else {
+		merged = *def
+	}
+	if g == nil || def == nil {
+		return &merged
+	}
+
+	if merged.Bucket == "" {
+		merged.Bucket = def.Bucket
+	}
+	if merged.PathPrefix == "" {
+		merged.PathPrefix = def.PathPrefix
+	}
+	if merged.PathStrategy == "" {
+		merged.PathStrategy = def.PathStrategy
+	}
+	if merged.DefaultOrg == "" {
+		merged.DefaultOrg = def.DefaultOrg
+	}
+	if merged.DefaultRepo == "" {
+		merged.DefaultRepo = def.DefaultRepo
+	}
+	return &merged
+}
+
+// Validate ensures all the values set in the GCSConfiguration are valid.
+func (g *GCSConfiguration) Validate() error {
+	if g.PathStrategy != PathStrategyLegacy && g.PathStrategy != PathStrategyExplicit && g.PathStrategy != PathStrategySingle {
+		return fmt.Errorf("gcs_path_strategy must be one of %q, %q, or %q", PathStrategyLegacy, PathStrategyExplicit, PathStrategySingle)
+	}
+	if g.PathStrategy != PathStrategyExplicit && (g.DefaultOrg == "" || g.DefaultRepo == "") {
+		return fmt.Errorf("default org and repo must be provided for GCS strategy %q", g.PathStrategy)
+	}
+	return nil
 }
 
 // ProwJobStatus provides runtime metadata, such as when it finished, whether it is running, etc.


### PR DESCRIPTION
Pull in incrementally more of the prow object and copy more code.
Still not including periodics/postsubmits. This will allow us to pull
from a config map directory, not just a single file.