### PR TITLE
Grab termination message from failed pods, not pending pods

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -369,7 +369,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 			return nil
 		case !success:
 			// try to get the last termination message
-			log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "build", false)
+			log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "status.phase=Failed", "build", false)
 			if err := c.transitionReleasePhaseFailure(release, []string{releasePhasePending}, releasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
 				return err
 			}


### PR DESCRIPTION
Pending was only used in the specific case of looking up an init
container message, whereas here we want only Failed pods.