### PR TITLE
[WIP] Include 'digest' in release stream JSON

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -280,10 +280,12 @@ func (c *Controller) apiReleaseLatest(w http.ResponseWriter, req *http.Request) 
 	}
 
 	downloadURL, _ := c.urlForArtifacts(latest.Name)
+	digest, _ := c.digestForArtifacts(latest.Name)
 	resp := LatestAccepted{
 		Name:        latest.Name,
 		PullSpec:    findPublicImagePullSpec(r.Target, latest.Name),
 		DownloadURL: downloadURL,
+		Digest:      digest,
 	}
 
 	switch req.URL.Query().Get("format") {
@@ -296,6 +298,9 @@ func (c *Controller) apiReleaseLatest(w http.ResponseWriter, req *http.Request) 
 	case "name":
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintln(w, resp.Name)
+	case "digest":
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, resp.Digest)
 	case "", "json":
 		data, err := json.MarshalIndent(&resp, "", "  ")
 		if err != nil {
@@ -307,7 +312,7 @@ func (c *Controller) apiReleaseLatest(w http.ResponseWriter, req *http.Request) 
 		w.Write(data)
 		fmt.Fprintln(w)
 	default:
-		http.Error(w, fmt.Sprintf(("error: Must specify one of '', 'json', 'pullSpec', 'name', or 'downloadURL")), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf(("error: Must specify one of '', 'json', 'pullSpec', 'name', 'downloadURL', or 'digest'")), http.StatusBadRequest)
 	}
 }
 

--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -39,6 +39,7 @@ type LatestAccepted struct {
 	Name        string `json:"name"`
 	PullSpec    string `json:"pullSpec"`
 	DownloadURL string `json:"downloadURL"`
+	Digest      string `json:"digest"`
 }
 
 type ReleaseStreamTag struct {


### PR DESCRIPTION
Automating release signing will be simpler if the release stream
includes the digest information as well.

Work in progress. I'm not sure what to do about `digest, _ := c.digestForArtifacts(latest.Name)`

I could use some help with that part.