### PR TITLE
External edges cause some upgrade edges to be omitted visually

### DIFF
--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -442,6 +442,14 @@ type nopFlusher struct{}
 
 func (_ nopFlusher) Flush() {}
 
+func upgradeSummaryToString(history []UpgradeHistory) string {
+	var out []string
+	for _, h := range history {
+		out = append(out, fmt.Sprintf("%s->%s", h.From, h.To))
+	}
+	return strings.Join(out, ",")
+}
+
 func calculateReleaseUpgrades(release *Release, tags []*imagev1.TagReference, graph *UpgradeGraph) *ReleaseUpgrades {
 	tagNames := make([]string, 0, len(tags))
 	internalTags := make(map[string]int)
@@ -567,7 +575,8 @@ func takeUpgradesFromNames(summaries []UpgradeHistory, names map[string]int) (wi
 		if _, ok := names[summaries[i].From]; ok {
 			continue
 		}
-		left := make([]UpgradeHistory, 0, len(summaries)-i)
+		left := make([]UpgradeHistory, i, len(summaries))
+		copy(left, summaries[:i])
 		var right []UpgradeHistory
 		for _, summary := range summaries[i:] {
 			if _, ok := names[summaries[i].From]; ok {

--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -131,6 +131,59 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				return u
 			},
 		},
+
+		{
+			tags: []*imagev1.TagReference{
+				{Name: "4.1.0-0.test-10"},
+				{Name: "4.1.0-0.test-09"},
+				{Name: "4.1.0-0.test-08"},
+				{Name: "4.1.0-0.test-07"},
+				{Name: "4.1.0-0.test-06"},
+			},
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				g.Add("4.1.0-0.test-08", "4.1.0-0.test-09", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.1.0-0.test-07", "4.1.0-0.test-08", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.1.0-rc.0", "4.1.0-0.test-08", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				return g
+			},
+			wantFn: func() *ReleaseUpgrades {
+				internal0 := []UpgradeHistory{
+					{From: "4.1.0-0.test-08", To: "4.1.0-0.test-09", Success: 0, Failure: 1, Total: 1},
+				}
+				internal1 := []UpgradeHistory{
+					{From: "4.1.0-0.test-07", To: "4.1.0-0.test-08", Success: 1, Failure: 0, Total: 1},
+				}
+				u := &ReleaseUpgrades{
+					Width: 2,
+					Tags: []ReleaseTagUpgrade{
+						{},
+						{
+							Internal: internal0,
+							Visual: []ReleaseTagUpgradeVisual{
+								{Begin: &internal0[0]},
+							},
+						},
+						{
+							Internal: internal1,
+							Visual: []ReleaseTagUpgradeVisual{
+								{End: &internal0[0]},
+								{Begin: &internal1[0]},
+							},
+							External: []UpgradeHistory{{From: "4.1.0-rc.0", To: "4.1.0-0.test-08", Success: 1, Total: 1}},
+						},
+						{
+							Visual: []ReleaseTagUpgradeVisual{
+								{},
+								{End: &internal1[0]},
+							},
+						},
+						{},
+					},
+				}
+				return u
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -188,4 +241,50 @@ func TestSemVer(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("%s", x.String())
+}
+
+func Test_takeUpgradesFromNames(t *testing.T) {
+	tests := []struct {
+		name             string
+		summaries        []UpgradeHistory
+		names            map[string]int
+		wantWithNames    []UpgradeHistory
+		wantWithoutNames []UpgradeHistory
+	}{
+		{
+			summaries: []UpgradeHistory{
+				{From: "a", To: "c"},
+				{From: "b", To: "c"},
+			},
+			names: map[string]int{"a": 1, "c": 3},
+			wantWithNames: []UpgradeHistory{
+				{From: "a", To: "c"},
+			},
+			wantWithoutNames: []UpgradeHistory{
+				{From: "b", To: "c"},
+			},
+		},
+		{
+			summaries: []UpgradeHistory{
+				{From: "a", To: "c"},
+				{From: "b", To: "c"},
+			},
+			names: map[string]int{"a": 1, "b": 2, "c": 3},
+			wantWithNames: []UpgradeHistory{
+				{From: "a", To: "c"},
+				{From: "b", To: "c"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWithNames, gotWithoutNames := takeUpgradesFromNames(tt.summaries, tt.names)
+			if !reflect.DeepEqual(gotWithNames, tt.wantWithNames) {
+				t.Errorf("takeUpgradesFromNames() gotWithNames = %v, want %v", gotWithNames, tt.wantWithNames)
+			}
+			if !reflect.DeepEqual(gotWithoutNames, tt.wantWithoutNames) {
+				t.Errorf("takeUpgradesFromNames() gotWithoutNames = %v, want %v", gotWithoutNames, tt.wantWithoutNames)
+			}
+		})
+	}
 }


### PR DESCRIPTION
If a tag has both an internal From and an external From upgrade
edge (4.1.0-0.ci-xxxx AND 4.1.0-rc.5) the first internal edges are
lost.

Correct the logic that ignored the first set of internal edges and
add unit tests.