### PR TITLE
Fix another bug in external name splitting

### DIFF
--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -585,8 +585,8 @@ func takeUpgradesFromNames(summaries []UpgradeHistory, names map[string]int) (wi
 		left := make([]UpgradeHistory, i, len(summaries))
 		copy(left, summaries[:i])
 		var right []UpgradeHistory
-		for _, summary := range summaries[i:] {
-			if _, ok := names[summaries[i].From]; ok {
+		for j, summary := range summaries[i:] {
+			if _, ok := names[summaries[i+j].From]; ok {
 				left = append(left, summary)
 			} else {
 				right = append(right, summary)

--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -275,6 +275,19 @@ func Test_takeUpgradesFromNames(t *testing.T) {
 				{From: "b", To: "c"},
 			},
 		},
+		{
+			summaries: []UpgradeHistory{
+				{From: "a", To: "c"},
+				{From: "b", To: "c"},
+			},
+			names: map[string]int{"b": 2, "c": 3},
+			wantWithNames: []UpgradeHistory{
+				{From: "b", To: "c"},
+			},
+			wantWithoutNames: []UpgradeHistory{
+				{From: "a", To: "c"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This method did not work at all