### PR TITLE
cmd/release-controller/http: Add id anchors to "Upgrades from" and "Upgrades to"

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -519,7 +519,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	if upgradesTo := c.graph.UpgradesTo(tag); len(upgradesTo) > 0 {
 		sort.Sort(newNewestSemVerFromSummaries(upgradesTo))
-		fmt.Fprintf(w, `<p>Upgrades from:</p><ul>`)
+		fmt.Fprintf(w, `<p id="upgrades-from">Upgrades from:</p><ul>`)
 		for _, upgrade := range upgradesTo {
 			var style string
 			switch {
@@ -570,7 +570,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	if upgradesFrom := c.graph.UpgradesFrom(tag); len(upgradesFrom) > 0 {
 		sort.Sort(newNewestSemVerToSummaries(upgradesFrom))
-		fmt.Fprintf(w, `<p>Upgrades to:</p><ul>`)
+		fmt.Fprintf(w, `<p id="upgrades-to">Upgrades to:</p><ul>`)
 		for _, upgrade := range upgradesFrom {
 			var style string
 			switch {


### PR DESCRIPTION
So I can link directly to them with [this][1] and similar.

[1]: https://openshift-release.svc.ci.openshift.org/releasestream/4-stable/release/4.1.0-rc.6#upgrades-from