### PR TITLE
Only show upgrades to entries once in the details page

### DIFF
--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -273,7 +273,7 @@ func (g *UpgradeGraph) Load(r io.Reader) error {
 	return err
 }
 
-func syncGraphToSecret(graph *UpgradeGraph, dryRun bool, secretClient kv1core.SecretInterface, ns, name string, stopCh <-chan struct{}) {
+func syncGraphToSecret(graph *UpgradeGraph, update bool, secretClient kv1core.SecretInterface, ns, name string, stopCh <-chan struct{}) {
 	// read initial state
 	wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		secret, err := secretClient.Get(name, metav1.GetOptions{})
@@ -297,7 +297,7 @@ func syncGraphToSecret(graph *UpgradeGraph, dryRun bool, secretClient kv1core.Se
 		return true, nil
 	}, stopCh)
 
-	if dryRun {
+	if !update {
 		return
 	}
 

--- a/cmd/release-controller/upgrades_test.go
+++ b/cmd/release-controller/upgrades_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestUpgradeGraph_UpgradesFrom(t *testing.T) {
+	tests := []struct {
+		name      string
+		graph     func() *UpgradeGraph
+		fromNames []string
+		want      []UpgradeHistory
+	}{
+		{
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"})
+				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"})
+				g.Add("1.0.1", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"})
+				g.Add("0.0.1", "1.0.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://4"})
+				g.Add("1.0.0", "1.1.1", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://5"})
+				return g
+			},
+			fromNames: []string{"1.0.0"},
+			want: []UpgradeHistory{
+				{
+					From:    "1.0.0",
+					To:      "1.1.0",
+					Success: 2,
+					Total:   2,
+					History: map[string]UpgradeResult{
+						"http://1": UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"},
+						"http://2": UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"},
+					},
+				},
+				{
+					From:    "1.0.0",
+					To:      "1.1.1",
+					Success: 1,
+					Total:   1,
+					History: map[string]UpgradeResult{
+						"http://5": UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://5"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := tt.graph()
+			got := g.UpgradesFrom(tt.fromNames...)
+			sort.Sort(newNewestSemVerFromSummaries(got))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpgradeGraph.UpgradesFrom() = %s", diff.ObjectReflectDiff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestUpgradeGraph_UpgradesTo(t *testing.T) {
+	tests := []struct {
+		name    string
+		graph   func() *UpgradeGraph
+		toNames []string
+		want    []UpgradeHistory
+	}{
+		{
+			graph: func() *UpgradeGraph {
+				g := NewUpgradeGraph()
+				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"})
+				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"})
+				g.Add("1.0.1", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"})
+				g.Add("0.0.1", "1.0.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://4"})
+				g.Add("1.0.0", "1.1.1", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://5"})
+				return g
+			},
+			toNames: []string{"1.1.0"},
+			want: []UpgradeHistory{
+				{
+					From:    "1.0.1",
+					To:      "1.1.0",
+					Success: 1,
+					Total:   1,
+					History: map[string]UpgradeResult{
+						"http://3": UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"},
+					},
+				},
+				{
+					From:    "1.0.0",
+					To:      "1.1.0",
+					Success: 2,
+					Total:   2,
+					History: map[string]UpgradeResult{
+						"http://1": UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"},
+						"http://2": UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := tt.graph()
+			got := g.UpgradesTo(tt.toNames...)
+			sort.Sort(newNewestSemVerFromSummaries(got))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpgradeGraph.UpgradesFrom() = %s", diff.ObjectReflectDiff(tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The previous version of UpgradesFrom included entries from other versions
incorrectly, which meant the upgrade graph appeared to show more results
than actually appeared.

Fix the display logic to only include upgrades in the 'Upgrades to' list if
they actually come from this version.

Also, sync upgrade graph (read-only) in dry-run so the graph is complete
for debugging problems.