### PR TITLE
cmd/release-controller/http: Add id anchors to image streams

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -111,7 +111,7 @@ td.upgrade-track {
 <div class="row">
 <div class="col">
 {{ range .Streams }}
-		<h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}">{{ .Release.Config.Name }}</h2>
+		<h2 id="{{ .Release.Config.Name }}" title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}">{{ .Release.Config.Name }}</h2>
 		{{ publishDescription . }}
 		{{ alerts . }}
 		{{ $upgrades := .Upgrades }}


### PR DESCRIPTION
So I can link directly to them with [this][1] and similar.  I considered adding a prefix to avoid possible conflicts with other IDs, but our existing names:

```console
$ curl -s https://openshift-release.svc.ci.openshift.org/ | sed -n 's|.*>\([^<]*\)</h2>.*|\1|p'
4.1.0-0.ci
4.1.0-0.nightly
4.2.0-0.ci
4.2.0-0.nightly
4-stable
```

suggest the names are unique enough on their own, so I haven't used a prefix.

[1]: https://openshift-release.svc.ci.openshift.org/#4-stable