### PR TITLE
sync: Allow concurrency to be limited for release tags

### DIFF
--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -24,8 +24,15 @@ type ReleaseStream struct {
 	Release *Release
 	Tags    []*imagev1.TagReference
 
+	// Delayed is set if there is a pending release
+	Delayed *ReleaseDelay
+
 	Upgrades *ReleaseUpgrades
 	Checks   []ReleaseCheckResult
+}
+
+type ReleaseDelay struct {
+	Message string
 }
 
 type ReleaseCheckResult struct {

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -44,6 +44,14 @@ type ReleaseConfig struct {
 	// Integration. This field is ignored when As is Stable.
 	To string `json:"to"`
 
+	// MaxUnreadyReleases blocks creating new releases if there are more than this many
+	// releases in non-terminal (Failed, Accepted, Rejected) states.
+	MaxUnreadyReleases int `json:"maxUnreadyReleases"`
+
+	// MinCreationIntervalSeconds controls how quickly multiple releases can be created.
+	// Releases will be created no more rapidly than this interval.
+	MinCreationIntervalSeconds int `json:"minCreationIntervalSeconds"`
+
 	// ReferenceMode describes how the release image will refer to the origin. If empty
 	// or 'public' images will be copied and no source location will be preserved. If
 	// `source` then the controller will attempt to keep the originating reference in place.


### PR DESCRIPTION
We are peaking at 10-15 concurrent releases and generating more
releases than anyone would look at. The only downside to limiting
concurrency is that it takes longer to bisect a break, but only
in a minor sense.