### PR TITLE
sync: Requeue when rate limited to avoid waiting forever

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -906,8 +906,8 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 		}
 		var delays []string
 		if r.Config.As != releaseConfigModeStable && len(s.Tags) > 0 {
-			if ok, _ := isReleaseDelayedForInterval(r, s.Tags[0]); ok {
-				delays = append(delays, fmt.Sprintf("waiting for %s", time.Duration(r.Config.MinCreationIntervalSeconds)*time.Second))
+			if ok, _, queueAfter := isReleaseDelayedForInterval(r, s.Tags[0]); ok {
+				delays = append(delays, fmt.Sprintf("waiting for %s", queueAfter.Truncate(time.Second)))
 			}
 			if r.Config.MaxUnreadyReleases > 0 && countUnreadyReleases(r, s.Tags) > r.Config.MaxUnreadyReleases {
 				delays = append(delays, fmt.Sprintf("no more than %d pending", r.Config.MaxUnreadyReleases))


### PR DESCRIPTION
Busy image streams would not hit this, but rarely used image streams
wouldn't trigger when the interval was up. For sanity, just queue.

Add log info output to the rate limit code so we know what release
was queued while debugging.