### PR TITLE
Adding support for the builder annotation

### DIFF
--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -39,6 +39,11 @@ func (c *Controller) ensureReleaseMirror(release *Release, releaseTagName, input
 		},
 	}
 
+	builder, ok := release.Source.Annotations[releaseAnnotationBuilder]
+	if ok {
+		is.Annotations[releaseAnnotationBuilder] = builder
+	}
+
 	switch release.Config.As {
 	case releaseConfigModeStable:
 		// stream will be populated later

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -304,6 +304,9 @@ const (
 	// releaseAnnotationFromImageStream specifies the imagestream
 	// a release was promoted from. It has the format <namespace>/<imagestream name>
 	releaseAnnotationFromImageStream = "release.openshift.io/from-image-stream"
+
+	// Art specified builder tag to provide the correct "cli" image to run for multi-arch support
+	releaseAnnotationBuilder = "release.openshift.io/builder"
 )
 
 type Duration time.Duration


### PR DESCRIPTION
The ART team has asked for a way to inject an architecture specific tag for **cli**.  This code looks for the new "release.openshift.io/builder" annotation, if found it passed it along to the mirror and ultimately passes it directly into the "oc adm" jobs that have been failing for multi-arch support.