### PR TITLE
cmd/release-controller: Drop hard-coded ":tests" from latestImageCache.Get error

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -430,7 +430,7 @@ func (c *latestImageCache) Get() (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("could not find a release image stream with :tests")
+	return "", fmt.Errorf("could not find a release image stream with tag %q", c.tag)
 }
 
 func refreshReleaseToolsEvery(interval time.Duration, execReleaseInfo *ExecReleaseInfo, execReleaseFiles *ExecReleaseFiles, stopCh <-chan struct{}) {


### PR DESCRIPTION
The tag name has been configurable since the function landed in 57de0141cf (#33).