### PR TITLE
Adding multi-arch support to the files-cache web server

### DIFF
--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -698,11 +698,15 @@ func renderInstallInstructions(w io.Writer, mirror *imagev1.ImageStream, tag *im
 		fmt.Fprintf(w, `<p class="alert alert-warning">No public location to pull this image from</p>`)
 		return
 	}
-	if len(artifactsHost) == 0 {
+	if len(artifactsHost) == 0 || strings.Contains(tagPull, "@sha256:") {
 		fmt.Fprintf(w, `<p>Download installer and client with:<pre class="ml-4">oc adm release extract --tools %s</pre>`, template.HTMLEscapeString(tagPull))
 		return
 	}
-	fmt.Fprintf(w, `<p><a href="%s">Download the installer</a> for your operating system or run <pre class="ml-4">oc adm release extract --tools %s</pre>`, template.HTMLEscapeString(fmt.Sprintf("https://%s/%s", artifactsHost, tag.Name)), template.HTMLEscapeString(tagPull))
+	pieces := strings.Split(tagPull, ":")
+	pullSpec, name := pieces[0], pieces[1]
+	pieces = strings.Split(pullSpec, "/")
+	namespace, imagestream := pieces[1], pieces[2]
+	fmt.Fprintf(w, `<p><a href="%s">Download the installer</a> for your operating system or run <pre class="ml-4">oc adm release extract --tools %s</pre>`, template.HTMLEscapeString(fmt.Sprintf("https://%s/%s?ns=%s&is=%s", artifactsHost, name, namespace, imagestream)), template.HTMLEscapeString(tagPull))
 }
 
 func checkReleasePage(page *ReleasePage) {

--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -435,6 +435,26 @@ sock.listen(5)
 
 
 class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def _present_default_content(self, name):
+        content = ("""<!DOCTYPE html>
+        <html>
+            <head>
+                <meta http-equiv=\"refresh\" content=\"5\">
+            </head>
+            <body>
+                <p>Extracting tools for %s, may take up to a minute ...</p>
+            </body>
+        </html>
+        """ % name).encode('UTF-8')
+
+        self.send_response(200, "OK")
+        self.send_header("Content-Type", "text/html;charset=UTF-8")
+        self.send_header("Content-Length", str(len(content)))
+        self.send_header("Retry-After", "5")
+        self.end_headers()
+        self.wfile.write(content)
+        self.wfile.close()
+
     def do_GET(self):
         path = self.path.strip("/")
         segments = path.split("/")
@@ -447,16 +467,7 @@ class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 return
 
             if os.path.isfile(os.path.join(name, "DOWNLOADING.md")):
-                out = (
-                            "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"5\"></head><body><p>Extracting tools for %s, may take up to a minute ...</p></body></html>" % name).encode(
-                    "UTF-8")
-                self.send_response(200, "OK")
-                self.send_header("Content-Type", "text/html;charset=UTF-8")
-                self.send_header("Content-Length", str(len(out)))
-                self.send_header("Retry-After", "5")
-                self.end_headers()
-                self.wfile.write(out)
-                self.wfile.close()
+                self._present_default_content(name)
                 return
 
             try:
@@ -468,16 +479,7 @@ class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 outfile.write("Downloading %s" % name)
 
             try:
-                out = (
-                            "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"5\"></head><body><p>Extracting tools for %s, may take up to a minute ...</p></body></html>" % name).encode(
-                    "UTF-8")
-                self.send_response(200, "OK")
-                self.send_header("Content-Type", "text/html;charset=UTF-8")
-                self.send_header("Content-Length", str(len(out)))
-                self.send_header("Retry-After", "5")
-                self.end_headers()
-                self.wfile.write(out)
-                self.wfile.close()
+                self._present_default_content(name)
 
                 subprocess.check_output(["oc", "adm", "release", "extract", "--tools", "--to", name, "--command-os", "*", "registry.svc.ci.openshift.org/ocp/release:%s" % name],
                                         stderr=subprocess.STDOUT)


### PR DESCRIPTION
The multi-arch folks reached out about the release-controller not supporting their respective installer downloads when accessing the Release Status webpage.  This PR adds support for the files-cache to pull the installers from their architecture specific pull specs.