### PR TITLE
Allow controllers to pick which image to use for changelog generation

### DIFF
--- a/cmd/release-controller/sync_gc.go
+++ b/cmd/release-controller/sync_gc.go
@@ -50,7 +50,7 @@ func (c *Controller) garbageCollectSync() error {
 		if !ok {
 			continue
 		}
-		config, err := c.parseReleaseConfig(value)
+		config, err := parseReleaseConfig(value, c.parsedReleaseConfigCache)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Currently changelogs are generated by with the image under the "tests"
tag in the first image stream that has a release definition. This
results today in 4.1 being used. Instead, let a flag specify which
tools image to use `--tools-image-stream-tag=4.4:tests` which will
fix a few changelog errors. Use the old behavior if not specified.

Prevent a stable image stream from accidentally being used (it won't
have a tests image).