### PR TITLE
Files cache multi arch

### DIFF
--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -78,6 +78,9 @@ type ExecReleaseInfo struct {
 	imageNameFn func() (string, error)
 }
 
+// NewExecReleaseInfo creates a stateful set, in the specified namespace, that provides git changelogs to the
+// Release Status website.  The provided name will prevent other instances of the stateful set
+// from being created when created with an identical name.
 func NewExecReleaseInfo(client kubernetes.Interface, restConfig *rest.Config, namespace string, name string, imageNameFn func() (string, error)) *ExecReleaseInfo {
 	return &ExecReleaseInfo{
 		client:      client,
@@ -207,7 +210,8 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 	spec := appsv1.StatefulSetSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"app": r.name,
+				"app": "git-cache",
+				"release": r.name,
 			},
 		},
 		PodManagementPolicy: appsv1.ParallelPodManagement,
@@ -232,7 +236,8 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"app": r.name,
+					"app": "git-cache",
+					"release": r.name,
 				},
 			},
 			Spec: corev1.PodSpec{
@@ -290,6 +295,10 @@ type ExecReleaseFiles struct {
 	imageNameFn 		func() (string, error)
 }
 
+// NewExecReleaseFiles creates a stateful set, in the specified namespace, that provides cached access to downloaded
+//installer images from the Release Status website.  The provided name will prevent other instances of the stateful set
+// from being created when created with an identical name.  The releaseNamespace is used to ensure that the tools are
+// downloaded from the correct namespace.
 func NewExecReleaseFiles(client kubernetes.Interface, restConfig *rest.Config, namespace string, name string, releaseNamespace string, imageNameFn func() (string, error)) *ExecReleaseFiles {
 	return &ExecReleaseFiles{
 		client:      		client,

--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -435,6 +435,26 @@ sock.listen(5)
 
 
 class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def _present_default_content(self, name):
+        content = ("""<!DOCTYPE html>
+        <html>
+            <head>
+                <meta http-equiv=\"refresh\" content=\"5\">
+            </head>
+            <body>
+                <p>Extracting tools for %s, may take up to a minute ...</p>
+            </body>
+        </html>
+        """ % name).encode('UTF-8')
+
+        self.send_response(200, "OK")
+        self.send_header("Content-Type", "text/html;charset=UTF-8")
+        self.send_header("Content-Length", str(len(content)))
+        self.send_header("Retry-After", "5")
+        self.end_headers()
+        self.wfile.write(content)
+        self.wfile.close()
+
     def do_GET(self):
         path = self.path.strip("/")
         segments = path.split("/")
@@ -447,16 +467,7 @@ class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 return
 
             if os.path.isfile(os.path.join(name, "DOWNLOADING.md")):
-                out = (
-                            "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"5\"></head><body><p>Extracting tools for %s, may take up to a minute ...</p></body></html>" % name).encode(
-                    "UTF-8")
-                self.send_response(200, "OK")
-                self.send_header("Content-Type", "text/html;charset=UTF-8")
-                self.send_header("Content-Length", str(len(out)))
-                self.send_header("Retry-After", "5")
-                self.end_headers()
-                self.wfile.write(out)
-                self.wfile.close()
+                self._present_default_content(name)
                 return
 
             try:
@@ -468,16 +479,7 @@ class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 outfile.write("Downloading %s" % name)
 
             try:
-                out = (
-                            "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"5\"></head><body><p>Extracting tools for %s, may take up to a minute ...</p></body></html>" % name).encode(
-                    "UTF-8")
-                self.send_response(200, "OK")
-                self.send_header("Content-Type", "text/html;charset=UTF-8")
-                self.send_header("Content-Length", str(len(out)))
-                self.send_header("Retry-After", "5")
-                self.end_headers()
-                self.wfile.write(out)
-                self.wfile.close()
+                self._present_default_content(name)
 
                 subprocess.check_output(["oc", "adm", "release", "extract", "--tools", "--to", name, "--command-os", "*", "registry.svc.ci.openshift.org/ocp/release:%s" % name],
                                         stderr=subprocess.STDOUT)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -197,10 +197,10 @@ func (o *options) Run() error {
 	}
 
 	imageCache := newLatestImageCache(tagParts[0], tagParts[1])
-	execReleaseInfo := NewExecReleaseInfo(client, config, o.JobNamespace, fmt.Sprintf("%s", releaseNamespace), imageCache.Get)
+	execReleaseInfo := NewExecReleaseInfo(client, config, o.JobNamespace, releaseNamespace, imageCache.Get)
 	releaseInfo := NewCachingReleaseInfo(execReleaseInfo, 64*1024*1024)
 
-	execReleaseFiles := NewExecReleaseFiles(client, config, o.JobNamespace, fmt.Sprintf("%s", releaseNamespace), fmt.Sprintf("%s", releaseNamespace), imageCache.Get)
+	execReleaseFiles := NewExecReleaseFiles(client, config, o.JobNamespace, releaseNamespace, releaseNamespace, imageCache.Get)
 
 	graph := NewUpgradeGraph()
 

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -200,7 +200,7 @@ func (o *options) Run() error {
 	execReleaseInfo := NewExecReleaseInfo(client, config, o.JobNamespace, fmt.Sprintf("%s", releaseNamespace), imageCache.Get)
 	releaseInfo := NewCachingReleaseInfo(execReleaseInfo, 64*1024*1024)
 
-	execReleaseFiles := NewExecReleaseFiles(client, config, o.JobNamespace, fmt.Sprintf("%s", releaseNamespace), imageCache.Get)
+	execReleaseFiles := NewExecReleaseFiles(client, config, o.JobNamespace, fmt.Sprintf("%s", releaseNamespace), fmt.Sprintf("%s", releaseNamespace), imageCache.Get)
 
 	graph := NewUpgradeGraph()
 


### PR DESCRIPTION
The multi-arch folks reached out about the release-controller not supporting their respective installer downloads when accessing the Release Status webpage. This PR adds support for the files-cache to pull the installers from their architecture specific release-namespace.