### PR TITLE
add a buildcop dashboard for upgrade jobs

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -298,6 +298,7 @@ func (o *options) Run() error {
 		go prowInformers.Run(stopCh)
 
 		go func() {
+
 			index := prowInformers.GetIndexer()
 			cache.WaitForCacheSync(stopCh, prowInformers.HasSynced)
 			wait.Until(func() {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4974046/75072108-cabe1700-54c4-11ea-999d-8e3e59732231.png)


Each link under the "upgrades from" column goes to the job that ran the upgrade test.

Note that if we ran a particular upgrade multiple times, it is represented multiple times (the from version is repeated once for each attempt).


example of "release failing" warning:
![image](https://user-images.githubusercontent.com/4974046/75072145-dc9fba00-54c4-11ea-8083-7c622367dbe5.png)

