### PR TITLE
Fix unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ image:
 	imagebuilder -t openshift/release-controller:latest .
 .PHONY: image
 
-check:
+test:
 	go test -race ./...
-.PHONY: check
+.PHONY: test
 
 test-integration: build
 	./test/integration.sh

--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -195,7 +195,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 					Config: &ReleaseConfig{},
 				}
 			}
-			if got := calculateReleaseUpgrades(tt.release, tt.tags, tt.graph()); !reflect.DeepEqual(got, tt.want) {
+			if got := calculateReleaseUpgrades(tt.release, tt.tags, tt.graph(), false); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s", diff.ObjectReflectDiff(tt.want, got))
 			}
 		})


### PR DESCRIPTION
Unittests are currently broken, which we never noticed because the `unit` ci operator ends up executing [`make test`](https://github.com/openshift/release/blob/e75d84a8ff9c9393beb6b80e1e508b6906fea59a/ci-operator/config/openshift/release-controller/openshift-release-controller-master.yaml#L35) which is undefined, which `make` consider a reason to happily return:

```
$ make test
make: Nothing to be done for 'test'.
alvaro@t470s-[2020-03-19-15:22]:[master][2]~/.../openshift/release-controller
$ echo $?
0
```

/assign @smarterclayton 