### PR TITLE
Seperate job build cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	go build -ldflags "-X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitCommit=$$(git rev-parse HEAD) -X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitVersion=v1.0.0+$$(git rev-parse --short=7 HEAD)" ./cmd/release-controller
+	GOFLAGS="-mod=vendor" go build -ldflags "-X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitCommit=$$(git rev-parse HEAD) -X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitVersion=v1.0.0+$$(git rev-parse --short=7 HEAD)" ./cmd/release-controller
 .PHONY: build
 
 image:
@@ -7,13 +7,9 @@ image:
 .PHONY: image
 
 test:
-	go test -race ./...
+	GOFLAGS="-mod=vendor" go test -race ./...
 .PHONY: test
 
-test-integration: build
-	./test/integration.sh
-.PHONY: test-integration
-
 vendor:
-	glide update --strip-vendor --skip-test
+	go mod vendor
 .PHONY: vendor

--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -30,8 +30,8 @@ import (
 	imageinformers "github.com/openshift/client-go/image/informers/externalversions/image/v1"
 	imagelisters "github.com/openshift/client-go/image/listers/image/v1"
 
-	prowconfig "k8s.io/test-infra/prow/config"
 	"github.com/openshift/release-controller/pkg/signer"
+	prowconfig "k8s.io/test-infra/prow/config"
 )
 
 // Controller ensures that OpenShift update payload images (also known as
@@ -106,6 +106,8 @@ type Controller struct {
 	jobNamespace string
 	// prowNamespace is the namespace where ProwJobs are created.
 	prowNamespace string
+	// prowJobCluster is the cluster to set on all prowJobs
+	prowJobCluster string
 	// artifactsHost if set is the location to build download links for client tools from
 	artifactsHost string
 
@@ -136,6 +138,7 @@ func NewController(
 	prowClient dynamic.ResourceInterface,
 	releaseNamespace string,
 	jobNamespace string,
+	prowJobCluster string,
 	artifactsHost string,
 	releaseInfo ReleaseInfo,
 	graph *UpgradeGraph,
@@ -182,6 +185,7 @@ func NewController(
 
 		releaseNamespace: releaseNamespace,
 		jobNamespace:     jobNamespace,
+		prowJobCluster:   prowJobCluster,
 
 		artifactsHost: artifactsHost,
 

--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -106,8 +106,6 @@ type Controller struct {
 	jobNamespace string
 	// prowNamespace is the namespace where ProwJobs are created.
 	prowNamespace string
-	// prowJobCluster is the cluster to set on all prowJobs
-	prowJobCluster string
 	// artifactsHost if set is the location to build download links for client tools from
 	artifactsHost string
 
@@ -138,7 +136,6 @@ func NewController(
 	prowClient dynamic.ResourceInterface,
 	releaseNamespace string,
 	jobNamespace string,
-	prowJobCluster string,
 	artifactsHost string,
 	releaseInfo ReleaseInfo,
 	graph *UpgradeGraph,
@@ -185,7 +182,6 @@ func NewController(
 
 		releaseNamespace: releaseNamespace,
 		jobNamespace:     jobNamespace,
-		prowJobCluster:   prowJobCluster,
 
 		artifactsHost: artifactsHost,
 

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -51,7 +51,6 @@ type options struct {
 	JobNamespace      string
 	ProwNamespace     string
 	ProwJobKubeconfig string
-	ProwJobCluster    string
 
 	ProwConfigPath string
 	JobConfigPath  string
@@ -108,7 +107,6 @@ func main() {
 	var ignored string
 	flag.StringVar(&ignored, "to", ignored, "REMOVED: The image stream in the release namespace to push releases to.")
 	flag.StringVar(&opt.JobNamespace, "job-namespace", opt.JobNamespace, "The namespace to execute jobs and hold temporary objects.")
-	flag.StringVar(&opt.ProwJobCluster, "prow-job-cluster", opt.ProwJobCluster, "The cluster to configure on all created ProwJobs.")
 	flag.StringVar(&opt.ProwJobKubeconfig, "prow-job-kubeconfig", opt.ProwJobKubeconfig, "The kubeconfig to use for interacting with ProwJobs. Defaults to the main kubeconfig if unset.")
 	flag.StringSliceVar(&opt.ReleaseNamespaces, "release-namespace", opt.ReleaseNamespaces, "The namespace where the source image streams are located and where releases will be published to.")
 	flag.StringVar(&opt.ProwNamespace, "prow-namespace", opt.ProwNamespace, "The namespace where the Prow jobs will be created (defaults to --job-namespace).")
@@ -216,7 +214,6 @@ func (o *options) Run() error {
 		prowClient.Namespace(o.ProwNamespace),
 		releaseNamespace,
 		o.JobNamespace,
-		o.ProwJobCluster,
 		o.ArtifactsHost,
 		releaseInfo,
 		graph,

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -50,6 +50,8 @@ type options struct {
 	ReleaseNamespaces []string
 	JobNamespace      string
 	ProwNamespace     string
+	ProwJobKubeconfig string
+	ProwJobCluster    string
 
 	ProwConfigPath string
 	JobConfigPath  string
@@ -106,6 +108,8 @@ func main() {
 	var ignored string
 	flag.StringVar(&ignored, "to", ignored, "REMOVED: The image stream in the release namespace to push releases to.")
 	flag.StringVar(&opt.JobNamespace, "job-namespace", opt.JobNamespace, "The namespace to execute jobs and hold temporary objects.")
+	flag.StringVar(&opt.ProwJobCluster, "prow-job-cluster", opt.ProwJobCluster, "The cluster to configure on all created ProwJobs.")
+	flag.StringVar(&opt.ProwJobKubeconfig, "prow-job-kubeconfig", opt.ProwJobKubeconfig, "The kubeconfig to use for interacting with ProwJobs. Defaults to the main kubeconfig if unset.")
 	flag.StringSliceVar(&opt.ReleaseNamespaces, "release-namespace", opt.ReleaseNamespaces, "The namespace where the source image streams are located and where releases will be published to.")
 	flag.StringVar(&opt.ProwNamespace, "prow-namespace", opt.ProwNamespace, "The namespace where the Prow jobs will be created (defaults to --job-namespace).")
 	flag.StringVar(&opt.ProwConfigPath, "prow-config", opt.ProwConfigPath, "A config file containing the prow configuration.")
@@ -137,7 +141,7 @@ func (o *options) Run() error {
 		o.ProwNamespace = o.JobNamespace
 	}
 
-	config, _, _, err := loadClusterConfig()
+	config, err := loadClusterConfig()
 	if err != nil {
 		return err
 	}
@@ -176,12 +180,10 @@ func (o *options) Run() error {
 		return fmt.Errorf("unable to create client: %v", err)
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(config)
+	prowClient, err := o.prowJobClient(config)
 	if err != nil {
-		return fmt.Errorf("unable to create prow client: %v", err)
+		return fmt.Errorf("failed to create prowjob client: %v", err)
 	}
-	prowClient := dynamicClient.Resource(schema.GroupVersionResource{Group: "prow.k8s.io", Version: "v1", Resource: "prowjobs"})
-
 	stopCh := wait.NeverStop
 	var hasSynced []cache.InformerSynced
 
@@ -214,6 +216,7 @@ func (o *options) Run() error {
 		prowClient.Namespace(o.ProwNamespace),
 		releaseNamespace,
 		o.JobNamespace,
+		o.ProwJobCluster,
 		o.ArtifactsHost,
 		releaseInfo,
 		graph,
@@ -369,21 +372,37 @@ func (o *options) Run() error {
 	}
 }
 
+func (o *options) prowJobClient(cfg *rest.Config) (dynamic.NamespaceableResourceInterface, error) {
+	if o.ProwJobKubeconfig != "" {
+		var err error
+		cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: o.ProwJobKubeconfig},
+			&clientcmd.ConfigOverrides{},
+		).ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load prowjob kubeconfig from path %q: %v", o.ProwJobKubeconfig, err)
+		}
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create prow client: %v", err)
+	}
+
+	return dynamicClient.Resource(schema.GroupVersionResource{Group: "prow.k8s.io", Version: "v1", Resource: "prowjobs"}), nil
+}
+
 // loadClusterConfig loads connection configuration
 // for the cluster we're deploying to. We prefer to
 // use in-cluster configuration if possible, but will
 // fall back to using default rules otherwise.
-func loadClusterConfig() (*rest.Config, string, bool, error) {
+func loadClusterConfig() (*rest.Config, error) {
 	cfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
 	clusterConfig, err := cfg.ClientConfig()
 	if err != nil {
-		return nil, "", false, fmt.Errorf("could not load client configuration: %v", err)
+		return nil, fmt.Errorf("could not load client configuration: %v", err)
 	}
-	ns, isSet, err := cfg.Namespace()
-	if err != nil {
-		return nil, "", false, fmt.Errorf("could not load client namespace: %v", err)
-	}
-	return clusterConfig, ns, isSet, nil
+	return clusterConfig, nil
 }
 
 func newDynamicSharedIndexInformer(client dynamic.NamespaceableResourceInterface, namespace string, resyncPeriod time.Duration, selector labels.Selector) cache.SharedIndexInformer {

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -56,6 +56,7 @@ func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName str
 	}, map[string]string{
 		releaseAnnotationSource: fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
 	})
+	pj.Spec.Cluster = c.prowJobCluster
 	// Override default UUID naming of prowjob
 	pj.Name = prowJobName
 	if !ok {

--- a/cmd/release-controller/sync_verify_prow_test.go
+++ b/cmd/release-controller/sync_verify_prow_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	prowconfig "k8s.io/test-infra/prow/config"
+)
+
+func TestValidateProwJob(t *testing.T) {
+	testCases := []struct {
+		name        string
+		pj          *prowconfig.Periodic
+		expectedErr error
+	}{
+		{
+			name:        "No cluster yields error",
+			pj:          &prowconfig.Periodic{},
+			expectedErr: fmt.Errorf(`the jobs cluster must be set to a value that is not default, was ""`),
+		},
+		{
+			name:        "Default cluster yields error",
+			pj:          &prowconfig.Periodic{JobBase: prowconfig.JobBase{Cluster: "default"}},
+			expectedErr: fmt.Errorf(`the jobs cluster must be set to a value that is not default, was "default"`),
+		},
+		{
+			name: "No default cluster, no error",
+			pj:   &prowconfig.Periodic{JobBase: prowconfig.JobBase{Cluster: "api.ci"}},
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualErr := validateProwJob(tc.pj)
+			var actualErrMsg, expectedErrMsg string
+			if actualErr != nil {
+				actualErrMsg = actualErr.Error()
+			}
+			if tc.expectedErr != nil {
+				expectedErrMsg = tc.expectedErr.Error()
+			}
+			if actualErrMsg != expectedErrMsg {
+				t.Errorf("Expected err %q, got err %q", expectedErrMsg, actualErrMsg)
+			}
+		})
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go v2.0.0+incompatible h1:j0GKcs05QVmm7yesiZq2+9cxHkNK9YM6zKx4D2qucQU=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=


### PR DESCRIPTION
With this change it is possible to set up a distinct cluster for ProwJob resources, which we will need once we migrate the prow controlplane to a different cluster.

/assign @smarterclayton @stevekuznetsov 