### PR TITLE
Add a stream api endpoint /api/v1/releasestream/{name}/tags

### DIFF
--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -47,13 +47,6 @@ type ReleaseCheckResult struct {
 	Warnings []string
 }
 
-// LatestAccepted contains information about the latest accepted release in a stream.
-type LatestAccepted struct {
-	Name        string `json:"name"`
-	PullSpec    string `json:"pullSpec"`
-	DownloadURL string `json:"downloadURL"`
-}
-
 type ReleaseStreamTag struct {
 	Release *Release
 	Tag     *imagev1.TagReference

--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -289,10 +289,8 @@ func semanticTagsForRelease(release *Release, phases ...string) SemanticVersions
 		if tag.Annotations[releaseAnnotationName] != release.Config.Name {
 			continue
 		}
-		if len(phases) > 0 {
-			if !stringSliceContains(phases, tag.Annotations[releaseAnnotationPhase]) {
-				continue
-			}
+		if len(phases) > 0 && !stringSliceContains(phases, tag.Annotations[releaseAnnotationPhase]) {
+			continue
 		}
 
 		if version, err := semver.Parse(tag.Name); err == nil {

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -11,6 +11,26 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// APITag contains information about a release tag in a stream.
+type APITag struct {
+	// Name is the name of the tag. This is usually a semantic version.
+	Name string `json:"name"`
+	// Phase is the phase of the tag.
+	Phase string `json:"phase"`
+	// PullSpec can be used to retrieve the release image.
+	PullSpec string `json:"pullSpec"`
+	// DownloadURL is a link to the web page for downloading the tools.
+	DownloadURL string `json:"downloadURL"`
+}
+
+// APIRelease contains information about a release stream.
+type APIRelease struct {
+	// Name is the name of the release stream.
+	Name string `json:"name"`
+	// Tags is a list of all tags in the release sorted by semantic version, oldest to newest.
+	Tags []APITag `json:"tags"`
+}
+
 // Release holds information about the release used during processing.
 type Release struct {
 	// Source is the image stream that the Config was loaded from and holds all


### PR DESCRIPTION
Returns tags within that stream, supports `phase=` filter and
shows all tags by default.