### PR TITLE
Update naming of release tag accessors to avoid bugs with sorting

### DIFF
--- a/cmd/release-controller/http_candidate.go
+++ b/cmd/release-controller/http_candidate.go
@@ -230,7 +230,7 @@ func (c *Controller) findReleaseCandidates(upgradeSuccessPercent float64, releas
 		latestPromotedTime = promotedTime.Unix()
 
 		candidates := make([]*ReleaseCandidate, 0)
-		releaseTags := tagsForRelease(releaseStreamTagMap[stream].Release)
+		releaseTags := sortedReleaseTags(releaseStreamTagMap[stream].Release)
 		for _, tag := range releaseTags {
 			if tag.Annotations != nil && tag.Annotations[releaseAnnotationPhase] == releasePhaseAccepted &&
 				tag.Annotations[releaseAnnotationCreationTimestamp] != "" {

--- a/cmd/release-controller/http_upgrade_graph.go
+++ b/cmd/release-controller/http_upgrade_graph.go
@@ -47,7 +47,7 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 		}
 		s := ReleaseStream{
 			Release: r,
-			Tags:    tagsForRelease(r),
+			Tags:    sortedReleaseTags(r),
 		}
 		nodeCount += len(s.Tags)
 		streams = append(streams, s)

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -399,7 +399,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 				if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
 					return err
 				}
-				if tags := findTagReferencesByPhase(release, releasePhaseReady); len(tags) > 0 {
+				if tags := sortedRawReleaseTags(release, releasePhaseReady); len(tags) > 0 {
 					go func() {
 						if _, err := c.releaseInfo.ChangeLog(tags[0].Name, tag.Name); err != nil {
 							glog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
@@ -449,7 +449,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 			if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
 				return err
 			}
-			if tags := findTagReferencesByPhase(release, releasePhaseReady); len(tags) > 0 {
+			if tags := sortedRawReleaseTags(release, releasePhaseReady); len(tags) > 0 {
 				go func() {
 					if _, err := c.releaseInfo.ChangeLog(tags[0].Name, tag.Name); err != nil {
 						glog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
@@ -463,7 +463,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 }
 
 func (c *Controller) syncReady(release *Release) error {
-	readyTags := findTagReferencesByPhase(release, releasePhaseReady)
+	readyTags := sortedRawReleaseTags(release, releasePhaseReady)
 
 	if glog.V(5) && len(readyTags) > 0 {
 		glog.Infof("ready=%v", tagNames(readyTags))
@@ -515,7 +515,7 @@ func (c *Controller) syncReady(release *Release) error {
 }
 
 func (c *Controller) syncAccepted(release *Release) error {
-	acceptedTags := findTagReferencesByPhase(release, releasePhaseAccepted)
+	acceptedTags := sortedRawReleaseTags(release, releasePhaseAccepted)
 
 	if glog.V(5) && len(acceptedTags) > 0 {
 		glog.Infof("release=%s accepted=%v", release.Config.Name, tagNames(acceptedTags))

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -44,7 +44,7 @@ func (c *Controller) createReleaseTag(release *Release, now time.Time, inputImag
 
 func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.TagReference) error {
 	var semanticTags []semver.Version
-	for _, tag := range tagsForRelease(release) {
+	for _, tag := range sortedReleaseTags(release) {
 		version, err := semver.Parse(tag.Name)
 		if err != nil {
 			continue

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -75,7 +75,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 				}
 				switch upgradeType {
 				case releaseUpgradeFromPrevious:
-					if tags := tagsForRelease(release, releasePhaseAccepted); len(tags) > 0 {
+					if tags := sortedReleaseTags(release, releasePhaseAccepted); len(tags) > 0 {
 						previousTag = tags[0].Name
 						previousReleasePullSpec = release.Target.Status.PublicDockerImageRepository + ":" + previousTag
 					}
@@ -84,7 +84,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 						version.Minor--
 						if ref, err := c.stableReleases(); err == nil {
 							for _, stable := range ref.Releases {
-								versions := semanticTagsForRelease(stable.Release, releasePhaseAccepted)
+								versions := unsortedSemanticReleaseTags(stable.Release, releasePhaseAccepted)
 								sort.Sort(versions)
 								if v := firstTagWithMajorMinorSemanticVersion(versions, version); v != nil {
 									previousTag = v.Tag.Name
@@ -98,7 +98,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 					if version, err := semver.Parse(releaseTag.Name); err == nil {
 						if ref, err := c.stableReleases(); err == nil {
 							for _, stable := range ref.Releases {
-								versions := semanticTagsForRelease(stable.Release, releasePhaseAccepted)
+								versions := unsortedSemanticReleaseTags(stable.Release, releasePhaseAccepted)
 								sort.Sort(versions)
 								if v := firstTagWithMajorMinorSemanticVersion(versions, version); v != nil {
 									previousTag = v.Tag.Name


### PR DESCRIPTION
Fix the release stream tags api to return sorted tags.