### PR TITLE
main: add new flags

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,2 +1,3 @@
 approvers:
 - smarterclayton
+- stevekuznetsov


### PR DESCRIPTION
This is an intermediate PR that changes the variable name of `flag` to `flagset` in the main function and adds new flags for the bugzilla and github clients that will be added via #151. It is necessary to add them in a separate PR because the changes from #151 will result in the release-controller crashing if it is not provided the flags. This PR allows us to make the required changes to the running deployments ahead of time.

/cc @stevekuznetsov 