### PR TITLE
pruning edges from release controller graph

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -336,7 +336,7 @@ func (o *options) Run() error {
 		klog.Infof("Dry run mode (no changes will be made)")
 
 		// read the graph
-		go syncGraphToSecret(graph, false, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh)
+		go syncGraphToSecret(graph, false, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh, c)
 
 		<-stopCh
 		return nil
@@ -344,7 +344,7 @@ func (o *options) Run() error {
 		klog.Infof("Auditing releases to %s", o.AuditStorage)
 
 		// read the graph
-		go syncGraphToSecret(graph, false, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh)
+		go syncGraphToSecret(graph, false, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh, c)
 
 		c.RunAudit(2, stopCh)
 		return nil
@@ -352,7 +352,7 @@ func (o *options) Run() error {
 		klog.Infof("Managing only %s, no garbage collection", o.LimitSources)
 
 		// read the graph
-		go syncGraphToSecret(graph, false, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh)
+		go syncGraphToSecret(graph, false, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh, c)
 
 		c.RunSync(3, stopCh)
 		return nil
@@ -360,7 +360,7 @@ func (o *options) Run() error {
 		klog.Infof("Managing releases")
 
 		// keep the graph in a more persistent form
-		go syncGraphToSecret(graph, true, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh)
+		go syncGraphToSecret(graph, true, client.CoreV1().Secrets(releaseNamespace), releaseNamespace, "release-upgrade-graph", stopCh, c)
 		// maintain the release pods
 		go refreshReleaseToolsEvery(2*time.Hour, execReleaseInfo, execReleaseFiles, stopCh)
 

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"sort"
 	"sync"
@@ -291,7 +292,7 @@ func (g *UpgradeGraph) Load(r io.Reader) error {
 	return err
 }
 
-func syncGraphToSecret(graph *UpgradeGraph, update bool, secretClient kv1core.SecretInterface, ns, name string, stopCh <-chan struct{}) {
+func syncGraphToSecret(graph *UpgradeGraph, update bool, secretClient kv1core.SecretInterface, ns, name string, stopCh <-chan struct{}, c *Controller) {
 	// read initial state
 	wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
 		secret, err := secretClient.Get(name, metav1.GetOptions{})
@@ -311,6 +312,9 @@ func syncGraphToSecret(graph *UpgradeGraph, update bool, secretClient kv1core.Se
 			if err := graph.Load(bytes.NewReader(data)); err != nil {
 				glog.Errorf("Can't load initial state from secret %s/%s: %v", ns, name, err)
 			}
+		}
+		if c != nil {
+			c.PruneGraph()
 		}
 		return true, nil
 	}, stopCh)
@@ -344,4 +348,102 @@ func syncGraphToSecret(graph *UpgradeGraph, update bool, secretClient kv1core.Se
 		}
 		glog.V(2).Infof("Saved upgrade graph state to %s/%s", ns, name)
 	}, 5*time.Minute, stopCh)
+}
+
+const releaseTagTimestampFormat = "2006-01-02-150405"
+
+func releaseTagTimestamp(v string) (time.Time, error) {
+	var t time.Time
+	version, err := semverParseTolerant(v)
+	if err != nil {
+		return t, err
+	}
+	if len(version.Pre) == 0 {
+		return t, fmt.Errorf("tag %s has no timestamp", v)
+	}
+	// release of format x.y.z-prefix-timestamp gets preifx-timetamp parsed into PreRelease array
+	// last entry of this has timestamp string, possibly with a prefix
+	prereleaseLast := version.Pre[len(version.Pre) - 1].VersionStr
+	// format string expects a timestamp of equal length
+	if len(prereleaseLast) < len(releaseTagTimestampFormat) {
+		return t, fmt.Errorf("tag %s has no timestamp", v)
+	}
+	// Remove any prefixes from the timestamp and parse
+	return time.Parse(releaseTagTimestampFormat, prereleaseLast[len(prereleaseLast) - len(releaseTagTimestampFormat):])
+}
+
+func (g *UpgradeGraph) Remove(fromTag, toTag string) {
+	if len(fromTag) == 0 || len(toTag) == 0 {
+		return
+	}
+
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	g.removeWithLock(fromTag, toTag)
+}
+
+func (g *UpgradeGraph) removeWithLock(fromTag, toTag string) {
+	delete(g.to[toTag], fromTag)
+	if len(g.to[toTag]) == 0 {
+		delete(g.to, toTag)
+	}
+	g.from[fromTag].Delete(toTag)
+	if g.from[fromTag].Len() == 0 {
+		delete(g.from, fromTag)
+	}
+}
+
+func (c *Controller) PruneGraph() {
+	if len(c.graph.to) == 0 {
+		return
+	}
+	now := time.Now()
+	pruneThreshold := time.Hour * 730 // roughly a month
+	tagList := make([]string, 0, len(c.graph.to))
+	for tag := range c.graph.to {
+		releaseTimestamp, err := releaseTagTimestamp(tag)
+		if err != nil {
+			// Release tag does not have an embedded date, skip
+			continue
+		}
+		if now.Sub(releaseTimestamp) <= pruneThreshold {
+			// Check only edges pointing to releases older than a month
+			continue
+		}
+		tagList = append(tagList, tag)
+	}
+	if len(tagList) == 0 {
+		return
+	}
+	tags, _ := c.findReleaseStreamTags(false, tagList...)
+	var prune []string
+	if len(tags) == 0 {
+		prune = tagList
+	} else {
+		prune = make([]string, 0, len(tagList))
+		for _, tag := range tagList {
+			// Remove edges that point to releases that don't exist
+			if tags[tag] == nil {
+				prune = append(prune, tag)
+				continue
+			}
+
+			// Remove tags with invalid pullspec
+			tagPullSpec := findPublicImagePullSpec(tags[tag].Release.Target, tag)
+			if len(tagPullSpec) == 0 {
+				prune = append(prune, tag)
+				continue
+			}
+			if _, err := c.releaseInfo.ReleaseInfo(tagPullSpec); err != nil {
+				prune = append(prune, tag)
+				continue
+			}
+		}
+	}
+	glog.V(1).Infof("Pruning %d/%d tags from release controller graph: %v", len(prune), len(c.graph.to), prune)
+	for _, toTag := range prune {
+		for fromTag := range c.graph.to[toTag] {
+			c.graph.Remove(fromTag, toTag)
+		}
+	}
 }


### PR DESCRIPTION
Pruning edges with missing/invalid release targets that are older than a month