### PR TITLE
Remove transitionTime field in terminal releases to reduce annotation sizes

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -116,6 +116,15 @@ func (c *Controller) sync(key queueKey) error {
 		return err
 	}
 
+	// ensure cleanup on terminal tags
+	if err := c.syncTerminal(release); err != nil {
+		if errors.IsConflict(err) {
+			return nil
+		}
+		c.eventRecorder.Eventf(release.Source, corev1.EventTypeWarning, "UnableToVerifyRelease", "%v", err)
+		return err
+	}
+
 	// if we're waiting for an interval to elapse, go ahead and queue to be woken
 	if queueAfter > 0 {
 		c.queue.AddAfter(key, queueAfter)
@@ -512,6 +521,40 @@ func (c *Controller) syncReady(release *Release) error {
 	}
 
 	return nil
+}
+
+func (c *Controller) syncTerminal(release *Release) error {
+	terminalTags := sortedRawReleaseTags(release, releasePhaseAccepted, releasePhaseRejected)
+	if klog.V(5) && len(terminalTags) > 0 {
+		klog.Infof("terminal=%v", tagNames(terminalTags))
+	}
+	var tagAnnotations map[string]interface{}
+	for _, releaseTag := range terminalTags {
+		oldVerifyStatus := releaseTag.Annotations[releaseAnnotationVerify]
+		if len(oldVerifyStatus) == 0 {
+			klog.V(5).Infof("%s: Empty verify annotation, skipping", releaseTag.Name)
+			continue
+		}
+		status := make(VerificationStatusMap)
+		if err := json.Unmarshal([]byte(oldVerifyStatus), &status); err != nil {
+			klog.Errorf("Release %s has invalid verification status, ignoring: %v", releaseTag.Name, err)
+			continue
+		}
+		for i := range status {
+			status[i].TransitionTime = nil
+		}
+		newVerifyStatus := toJSONString(status)
+		if  newVerifyStatus == oldVerifyStatus {
+			continue
+		}
+		releaseTag.Annotations[releaseAnnotationVerify] = newVerifyStatus
+		if tagAnnotations == nil {
+			tagAnnotations = map[string]interface{}{releaseTag.Name: releaseTag.Annotations}
+			continue
+		}
+		tagAnnotations[releaseTag.Name] = releaseTag.Annotations
+	}
+	return c.updateReleaseTagAnnotations(release, tagAnnotations)
 }
 
 func (c *Controller) syncAccepted(release *Release) error {

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -215,6 +215,50 @@ func (c *Controller) ensureReleaseTagPhase(release *Release, preconditionPhases 
 	return nil
 }
 
+// Update annotations for a set of tags in a release
+func (c *Controller) updateReleaseTagAnnotations(release *Release, tagAnnotations map[string]interface{}) error {
+	if len(tagAnnotations) == 0 {
+		return nil
+	}
+	var changed bool
+	target := release.Target.DeepCopy()
+	for name, annotationInterface := range tagAnnotations {
+		annotations, ok := annotationInterface.(map[string]string)
+		if !ok {
+			continue
+		}
+		tag := findTagReference(target, name)
+		if tag == nil {
+			return fmt.Errorf("release %s no longer exists, cannot update annotations", name)
+		}
+		if tag.Annotations == nil {
+			tag.Annotations = make(map[string]string)
+		}
+		for k, v := range annotations {
+			if _, ok := tag.Annotations[k]; ok && len(v) == 0 {
+				delete(tag.Annotations, k)
+				changed = true
+				continue
+			}
+			if tag.Annotations[k] != v {
+				tag.Annotations[k] = v
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	is, err := c.imageClient.ImageStreams(target.Namespace).Update(target)
+	if err != nil {
+		return err
+	}
+	updateReleaseTarget(release, is)
+	return nil
+}
+
 func (c *Controller) transitionReleasePhaseFailure(release *Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
 	target := release.Target.DeepCopy()
 	changed := 0

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -135,6 +135,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 			verifyStatus[name] = status
 
 			if jobRetries >= verifyType.MaxRetries {
+				verifyStatus[name].TransitionTime = nil
 				continue
 			}
 


### PR DESCRIPTION
As part of the change to allow the retrying of release blocking jobs, https://github.com/openshift/release-controller/pull/112 added a new field transistionTime to track when a retryable job was last failing. This is used to determine when another attempt at running the job should be made, with an exponential backoff between subsequent retries. Once a job has succeeded once or failed more than its allowed maximum number of retries, this value becomes obsolete, but is not removed from the job status. This added an unnecessary timestamp field to every terminal verify job status, increasing release controller annotation size and decreasing the amount of information the release controller could hold in the annotation size limit of 2MB.  

This PR removes the tranisitionTime field from terminal job statuses where they are no longer needed. This fixes any new tags the release controller will process, but does not clean up statuses of already existing terminal tags. 

For this, the PR also introduces a syncTerminal loop, which removes the field from jobs on terminal release tags to quickly reduce annotation size and bring all tags to their desired state. Once this clean up of job statuses is done, the syncTerminal loop can be removed through https://github.com/openshift/release-controller/pull/208

