### PR TITLE
Converting tabs to spaces for python code

### DIFF
--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -534,11 +534,11 @@ class FileServer(SimpleHTTPServer.SimpleHTTPRequestHandler):
         self.wfile.write(content)
         self.wfile.close()
 
-	def _get_extension(self, namespace):
-		index = namespace.find('-')
-		if index == -1:
-			return ''
-		return namespace[index::]
+    def _get_extension(self, namespace):
+        index = namespace.find('-')
+        if index == -1:
+            return ''
+        return namespace[index::]
 
     def do_GET(self):
         path = self.path.strip("/")


### PR DESCRIPTION
Copy and paste error when moving python code into go.  This PR converts the tabs back into spaces.  I have verified that the code runs successfully in our test environment.