### PR TITLE
bugzilla: use public docker image repo for releaseInfo.Bugs

### DIFF
--- a/cmd/release-controller/bugzilla.go
+++ b/cmd/release-controller/bugzilla.go
@@ -77,7 +77,12 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 		return nil
 	}
 
-	bugs, err := c.releaseInfo.Bugs(prevTag.Name, tag.Name)
+	dockerRepo := release.Target.Status.PublicDockerImageRepository
+	if len(dockerRepo) == 0 {
+		return fmt.Errorf("bugzilla: release target %s does not have a configured registry", release.Target.Name)
+	}
+
+	bugs, err := c.releaseInfo.Bugs(dockerRepo+":"+prevTag.Name, dockerRepo+":"+tag.Name)
 	if err != nil {
 		return fmt.Errorf("Unable to generate changelog from %s to %s: %v", prevTag.Name, tag.Name, err)
 	}


### PR DESCRIPTION
Using just `tag.Name` (as used in `sync.go`) results in the following error:
```
I0527 20:16:11.174903       1 glog.go:58] Failed to generate bug list: command terminated with exit code 1
$ oc adm release info --bugs=/tmp/git/ --output=name 4.1.0-0.nightly-2020-05-23-080652 4.1.0-0.nightly-2020-05-24-040147
error: the semantic version "4.1.0-0.nightly-2020-05-23-080652" is not present in the cluster version status or in the official versions list, cannot be resolved
```

This PR changes the bugzilla sync function to use the public docker repo version of the image instead, similar to the way the web interface works.

/cc @stevekuznetsov 