### PR TITLE
Bug 1841350: Ignore releases in Ready state when calculating maxUnready

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -1330,9 +1330,15 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 }
 
 func isReleaseFailing(tags []*imagev1.TagReference, maxUnready int) bool {
-	for i := 0; i < maxUnready && i < len(tags); i++ {
-		if tags[i].Annotations[releaseAnnotationPhase] == releasePhaseAccepted {
+	unreadyCount := 0
+	for i := 0; unreadyCount < maxUnready && i < len(tags); i++ {
+		switch tags[i].Annotations[releaseAnnotationPhase] {
+		case releasePhaseReady:
+			continue
+		case releasePhaseAccepted:
 			return false
+		default:
+			unreadyCount++
 		}
 	}
 	return true


### PR DESCRIPTION
The overview dashboard displays an alert message:
`This release has no recently accepted payloads, investigation required.`
when the number of non-terminal releases exceed the `maxUnreadyReleases` parameter.  The logic that calculates whether this message is displayed or not, does not take into account releases that are in a **Ready** state.

https://bugzilla.redhat.com/show_bug.cgi?id=1841350