### PR TITLE
info: ignore empty bugs after string split

### DIFF
--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -235,14 +235,15 @@ func (r *ExecReleaseInfo) Bugs(from, to string) ([]int, error) {
 
 func bugListToArr(s string) ([]int, error) {
 	bugs := []int{}
-	if s != "" {
-		for _, bug := range strings.Split(s, "\n") {
-			bugID, err := strconv.Atoi(bug)
-			if err != nil {
-				return nil, fmt.Errorf("could not convert bug id %s to an int: %v", bug, err)
-			}
-			bugs = append(bugs, bugID)
+	for _, bug := range strings.Split(s, "\n") {
+		if bug == "" {
+			continue
 		}
+		bugID, err := strconv.Atoi(bug)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert bug id %s to an int: %v", bug, err)
+		}
+		bugs = append(bugs, bugID)
 	}
 	return bugs, nil
 }

--- a/cmd/release-controller/info_test.go
+++ b/cmd/release-controller/info_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBugListToArr(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output []int
+	}{{
+		name:   "Empty",
+		input:  "",
+		output: []int{},
+	}, {
+		name:   "Newline",
+		input:  "\n",
+		output: []int{},
+	}, {
+		name:   "Multiple cases",
+		input:  "1\n2\n3",
+		output: []int{1, 2, 3},
+	}, {
+		name:   "Multiple cases ending in newline",
+		input:  "1\n2\n3\n",
+		output: []int{1, 2, 3},
+	}}
+	for _, testCase := range testCases {
+		output, err := bugListToArr(testCase.input)
+		if err != nil {
+			t.Errorf("%s: unexpected err: %v", testCase.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(output, testCase.output) {
+			t.Errorf("%s: Expected %v, got %v", testCase.name, testCase.output, output)
+		}
+	}
+}


### PR DESCRIPTION
This fixes issues where `strconv.Atoi` was throwing errors due to being passed an empty string. I originally thought this was occurring for releases that had no bugs and returned an empty string, and I handled that in an earlier PR, but that wasn't the main issue. 

Before `string` -> `[]int` handling was moved to `info`, the bugzilla pkg would handle `Atoi` errors by adding the error to the `errs` list and then continuing. This error wasn't getting properly get logged before, so we never saw it, and the rest of the bugs would be processed as normal. This masked the strconv errors when presented with an empty string, which would happen at the end of each bug list since the ouptut of `oc adm release info --bugs=... --output=name` always ends in a newline. This handles that and adds a unit test.


/cc @stevekuznetsov 