### PR TITLE
Adding a Quick links section to the primary pages

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -129,6 +129,8 @@ type Controller struct {
 	parsedReleaseConfigCache *lru.Cache
 
 	bugzillaVerifier *bugzilla.Verifier
+
+	dashboards []Dashboard
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -208,6 +210,12 @@ func NewController(
 		DeleteFunc: c.processJob,
 		UpdateFunc: func(oldObj, newObj interface{}) { c.processJobIfComplete(newObj) },
 	})
+
+	c.dashboards = []Dashboard {
+		{"Index", "/"},
+		{"Overview", "/dashboards/overview"},
+		{"Compare", "/dashboards/compare"},
+	}
 
 	return c
 }

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -52,6 +52,9 @@ const htmlPageEnd = `
 
 const releasePageHtml = `
 <h1>Release Status</h1>
+<p class="small mb-3">
+	Quick links: {{ dashboardsJoin .Dashboards }}
+</p>
 <p>Visualize upgrades in <a href="/graph">Cincinnati</a> | <a href="/graph?format=dot">dot</a> | <a href="/graph?format=svg">SVG</a> | <a href="/graph?format=png">PNG</a> format. Run the following command to make this your update server:</p>
 <pre class="ml-4">
 oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}graph"}}' --type=merge
@@ -161,6 +164,9 @@ const releaseInfoPageHtml = `
 
 const releaseDashboardPageHtml = `
 <h1>Release Dashboard</h1>
+<p class="small mb-3">
+	Quick links: {{ dashboardsJoin .Dashboards }}
+</p>
 <p><a href=https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&f1=cf_internal_whiteboard&f2=status_whiteboard&j_top=OR&known_name=BuildCop&list_id=10913331&o1=substring&o2=substring&query_format=advanced&v1=buildcop&v2=buildcop>Open Build Cop Bugs</a></p>
 <p class="small mb-3">
 	Jump to: {{ releaseJoin .Streams }}
@@ -919,6 +925,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 	base.Fragment = ""
 	page := &ReleasePage{
 		BaseURL: base.String(),
+		Dashboards: c.dashboards,
 	}
 
 	now := time.Now()
@@ -984,14 +991,15 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 				}
 				return ""
 			},
-			"tableLink":    tableLink,
-			"phaseCell":    phaseCell,
-			"phaseAlert":   phaseAlert,
-			"alerts":       renderAlerts,
-			"links":        links,
-			"releaseJoin":  releaseJoin,
-			"inc":          func(i int) int { return i + 1 },
-			"upgradeCells": upgradeCells,
+			"tableLink":     tableLink,
+			"phaseCell":     phaseCell,
+			"phaseAlert":    phaseAlert,
+			"alerts":        renderAlerts,
+			"links":         links,
+			"releaseJoin":   releaseJoin,
+			"dashboardsJoin": dashboardsJoin,
+			"inc":           func(i int) int { return i + 1 },
+			"upgradeCells":  upgradeCells,
 			"since": func(utcDate string) string {
 				t, err := time.Parse(time.RFC3339, utcDate)
 				if err != nil {
@@ -1065,6 +1073,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 	base.Fragment = ""
 	page := &ReleasePage{
 		BaseURL: base.String(),
+		Dashboards: c.dashboards,
 	}
 
 	now := time.Now()
@@ -1130,12 +1139,13 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 				}
 				return ""
 			},
-			"tableLink":   tableLink,
-			"phaseCell":   phaseCell,
-			"phaseAlert":  phaseAlert,
-			"inc":         func(i int) int { return i + 1 },
-			"upgradeJobs": upgradeJobs,
-			"releaseJoin": releaseJoin,
+			"tableLink":     tableLink,
+			"phaseCell":     phaseCell,
+			"phaseAlert":    phaseAlert,
+			"inc":           func(i int) int { return i + 1 },
+			"upgradeJobs":   upgradeJobs,
+			"releaseJoin":   releaseJoin,
+			"dashboardsJoin": dashboardsJoin,
 			"since": func(utcDate string) string {
 				t, err := time.Parse(time.RFC3339, utcDate)
 				if err != nil {

--- a/cmd/release-controller/http_compare.go
+++ b/cmd/release-controller/http_compare.go
@@ -28,10 +28,14 @@ type ComparisonPage struct {
 	BaseURL string
 	Streams []ReleaseStream
 	Tags []*v1.TagReference
+	Dashboards []Dashboard
 }
 
 const comparisonDashboardPageHtml = `
 <h1>Release Comparison Dashboard</h1>
+<p class="small mb-3">
+	Quick links: {{ dashboardsJoin .Dashboards }}
+</p>
 `
 
 func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Request) {
@@ -51,6 +55,7 @@ func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Reque
 	base.Fragment = ""
 	page := &ComparisonPage{
 		BaseURL: base.String(),
+		Dashboards: c.dashboards,
 	}
 
 	fromRelease := req.URL.Query().Get("from")
@@ -67,7 +72,9 @@ func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Reque
 		PullSpec: "",
 	}
 
-	var releasePage = template.Must(template.New("releaseDashboardPage").Funcs(template.FuncMap{}).Parse(comparisonDashboardPageHtml))
+	var releasePage = template.Must(template.New("releaseDashboardPage").Funcs(template.FuncMap{
+		"dashboardsJoin": dashboardsJoin,
+	}).Parse(comparisonDashboardPageHtml))
 
 	imageStreams, err := c.imageStreamLister.ImageStreams(c.releaseNamespace).List(labels.Everything())
 	if err != nil {

--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -21,6 +21,7 @@ import (
 type ReleasePage struct {
 	BaseURL string
 	Streams []ReleaseStream
+	Dashboards []Dashboard
 }
 
 type ReleaseStream struct {
@@ -35,6 +36,11 @@ type ReleaseStream struct {
 
 	// Failing is set if none of the most recent 5 payloads were accepted
 	Failing bool
+}
+
+type Dashboard struct {
+	Name string
+	Path string
 }
 
 type ReleaseDelay struct {
@@ -516,7 +522,7 @@ func renderAlerts(release ReleaseStream) string {
 func releaseJoin(streams []ReleaseStream) string {
 	releases := []string{}
 	for _, s := range streams {
-		releases = append(releases, fmt.Sprintf("<a href=\"#%s\">%s</a>", s.Release.Config.Name, s.Release.Config.Name))
+		releases = append(releases, fmt.Sprintf("<a href=\"#%s\">%s</a>", template.HTMLEscapeString(s.Release.Config.Name), template.HTMLEscapeString(s.Release.Config.Name)))
 	}
 	return strings.Join(releases, " | ")
 }
@@ -872,4 +878,12 @@ func checkReleasePage(page *ReleasePage) {
 			}
 		}
 	}
+}
+
+func dashboardsJoin(dashboards []Dashboard) string {
+	boards := []string{}
+	for _, d := range dashboards {
+		boards = append(boards, fmt.Sprintf("<a href=\"%s\">%s</a>", template.HTMLEscapeString(d.Path), template.HTMLEscapeString(d.Name)))
+	}
+	return strings.Join(boards, " | ")
 }


### PR DESCRIPTION
The initial impression of the release comparison dashboard was quite positive.  The one piece of feedback we received was to possibly add a link to it from the main page, so it's easier to get to.  This PR adds a "Quick links" section under the main title of each of the primary pages...

Home Page:
![shot1](https://user-images.githubusercontent.com/43015045/84437139-86d15800-ac02-11ea-973e-41e89e17fd63.png)

Overview Dashboard
![shot2](https://user-images.githubusercontent.com/43015045/84437180-92248380-ac02-11ea-8b3b-1f3e951cc2bc.png)

Comparison Dashboard
![shot3](https://user-images.githubusercontent.com/43015045/84437206-9a7cbe80-ac02-11ea-9c3c-bc54e4a83210.png)
