### PR TITLE
bugzilla: workaround for permissions issue with certain bugs

### DIFF
--- a/pkg/bugzilla/bugzilla.go
+++ b/pkg/bugzilla/bugzilla.go
@@ -93,7 +93,12 @@ func getPRs(input []int, bzClient bugzilla.Client) ([]pr, []error) {
 	for _, bzID := range input {
 		extBugs, err := bzClient.GetExternalBugPRsOnBug(bzID)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("Failed to get external bugs for bugzilla bug %d: %v", bzID, err))
+			// there are a couple of bugs with weird permissions issues that can cause this to fail; simply log instead of generating error
+			if bugzilla.IsAccessDenied(err) {
+				klog.V(4).Infof("Access denied getting external bugs for bugzilla bug %d: %v", bzID, err)
+			} else {
+				errs = append(errs, fmt.Errorf("Failed to get external bugs for bugzilla bug %d: %v", bzID, err))
+			}
 			continue
 		}
 		foundPR := false


### PR DESCRIPTION
There are some bugs that have an unusual permissions issue that results
in the bugzilla client failing to get external bugs. This commit is a
workaround for that issue that just logs the error instead of returning
it, allowing the release to move into the `bugs-verified` state instead
of looping indefinitely.

/cc @stevekuznetsov 