### PR TITLE
bugzilla: add previousReleaseTag field to verifyBugs in config

### DIFF
--- a/cmd/release-controller/bugzilla_test.go
+++ b/cmd/release-controller/bugzilla_test.go
@@ -26,20 +26,25 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test1",
 		}},
-		expectedCurrent:  &v1.TagReference{Name: "test2"},
-		expectedPrevious: &v1.TagReference{Name: "test1"},
+		expectedCurrent:  &v1.TagReference{Name: "test1"},
+		expectedPrevious: nil,
 	}, {
 		name: "2 tags, 1 verified",
 		acceptedTags: []*v1.TagReference{{
 			Name: "test2",
+		}, {
+			Name: "test1",
 			Annotations: map[string]string{
 				releaseAnnotationBugsVerified: "true",
 			},
-		}, {
-			Name: "test1",
 		}},
-		expectedCurrent:  nil,
-		expectedPrevious: nil,
+		expectedCurrent: &v1.TagReference{Name: "test2"},
+		expectedPrevious: &v1.TagReference{
+			Name: "test1",
+			Annotations: map[string]string{
+				releaseAnnotationBugsVerified: "true",
+			},
+		},
 	}, {
 		name: "Multiple tags",
 		acceptedTags: []*v1.TagReference{{
@@ -57,6 +62,9 @@ func TestGetNonVerifiedTags(t *testing.T) {
 			},
 		}, {
 			Name: "test1",
+			Annotations: map[string]string{
+				releaseAnnotationBugsVerified: "true",
+			},
 		}},
 		expectedCurrent: &v1.TagReference{
 			Name:        "test4",
@@ -64,6 +72,35 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		},
 		expectedPrevious: &v1.TagReference{
 			Name: "test3",
+			Annotations: map[string]string{
+				releaseAnnotationBugsVerified: "true",
+			},
+		},
+	}, {
+		name: "Multiple tags with unverified in between",
+		acceptedTags: []*v1.TagReference{{
+			Name:        "test4",
+			Annotations: map[string]string{},
+		}, {
+			Name: "test3",
+			Annotations: map[string]string{
+				releaseAnnotationBugsVerified: "true",
+			},
+		}, {
+			Name:        "test2",
+			Annotations: map[string]string{},
+		}, {
+			Name: "test1",
+			Annotations: map[string]string{
+				releaseAnnotationBugsVerified: "true",
+			},
+		}},
+		expectedCurrent: &v1.TagReference{
+			Name:        "test2",
+			Annotations: map[string]string{},
+		},
+		expectedPrevious: &v1.TagReference{
+			Name: "test1",
 			Annotations: map[string]string{
 				releaseAnnotationBugsVerified: "true",
 			},

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -165,7 +165,20 @@ type PublishStreamReference struct {
 
 // PublishVerifyBugs marks bugs fixed by this tag as VERIFIED in bugzilla if the QA contact reviewed and approved the bugfix PR
 type PublishVerifyBugs struct {
-	// No specific information currently required for bug verification
+	// PreviousRelease points to the last release created before the imagestream
+	// being published was created. It is used to verify bugs on the oldest tag
+	// in the release being published.
+	PreviousReleaseTag *VerifyBugsTagInfo `json:"previousReleaseTag"`
+}
+
+// VerifyBugsTagInfo contains the necessary data to get a tag reference as needed in the bugzilla verification support.
+type VerifyBugsTagInfo struct {
+	// Namespace is the namespace where the imagestream resides.
+	Namespace string `json:"namespace"`
+	// Name is the name of the imagestream
+	Name string `json:"name"`
+	// Tag is the tag that is being referenced in the image stream
+	Tag string `json:"tag"`
 }
 
 // ReleaseVerification is a task that must be completed before a release is marked


### PR DESCRIPTION
This commit allows us to configure a release tag to compare against
when we are trying to verify bugs for the oldest release in an image
stream.

/cc @stevekuznetsov 