### PR TITLE
audit: Fix audit with latest GCS client and correct an argument bug

### DIFF
--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -84,7 +84,7 @@ func (c *Controller) syncAuditTag(releaseName string) error {
 		out, err := exec.Command("oc", "adm", "release", "info", "--verify", record.Location).CombinedOutput()
 		if err != nil {
 			failureMsg := fmt.Sprintf("Unable to verify release:\n%s", strings.TrimSpace(string(out)))
-			glog.V(4).Infof("Release verification command failed: %s", failureMsg)
+			glog.V(4).Infof("Release verification command failed: %s: %s", record.Location, failureMsg)
 			c.auditTracker.SetFailure(record.Name, failureMsg)
 			return nil
 		}

--- a/cmd/release-controller/audit_backend_gcs.go
+++ b/cmd/release-controller/audit_backend_gcs.go
@@ -38,6 +38,7 @@ func NewGCSAuditStore(bucket string, prefix, userAgent, serviceAccountPath strin
 	}
 	client, err := storage.NewClient(
 		context.Background(),
+		options...,
 	)
 	if err != nil {
 		return nil, err
@@ -128,7 +129,7 @@ func (b *GCSAuditStore) PutSignature(ctx context.Context, dgst string, signature
 		objectPath = path.Join("signatures", "openshift", "release", fmt.Sprintf("%s=%s", parts[0], parts[1]), fmt.Sprintf("signature-%d", index))
 	}
 	glog.V(4).Infof("Writing signature to gs://%s/%s", b.bucketName, objectPath)
-	obj := b.bucket.Object(objectPath).If(storage.Conditions{GenerationMatch:0})
+	obj := b.bucket.Object(objectPath).If(storage.Conditions{DoesNotExist: true, GenerationMatch: 0})
 
 	w := obj.NewWriter(ctx)
 	if _, err := w.Write(signature); err != nil {

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -300,10 +300,10 @@ func (o *options) Run() error {
 			}
 			store, err := NewGCSAuditStore(u.Host, path, config.UserAgent, o.AuditGCSServiceAccount)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to initialize audit store: %v", err)
 			}
 			if err := store.Refresh(context.Background()); err != nil {
-				return err
+				return fmt.Errorf("unable to refresh audit store: %v", err)
 			}
 			c.auditStore = store
 		default:


### PR DESCRIPTION
Fix a bug where newer GCS clients reject an empty precondition object
(because 0 and default serialization are the same) by explicitly stating
DoesNotExist. Also ensure options is passed to the client to pick up the
command line credentials (which was always broken).

After these changes signatures are uploaded to GCS using the service
account path correctly.