### PR TITLE
Add additional sync loop for running candidate tests against releases marked with the "keep" annotation

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -706,6 +706,8 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	renderVerifyLinks(w, *info.Tag, info.Release)
 
+	renderCandidateLinks(w, *info.Tag, info.Release)
+
 	upgradesTo := c.graph.UpgradesTo(tag)
 
 	var missingUpgrades []string
@@ -744,7 +746,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			if len(supportedUpgrades) > 0 && !upgradeFound[upgrade.From] {
 				continue
 			}
-			fmt.Fprintf(w, `<li><a class="text-monospace %s" href="/releasetag/%s">%s</a>`, style, upgrade.From, upgrade.From)
+			fmt.Fprintf(w, `<li><a id="%s" class="text-monospace %s" href="/releasetag/%s">%s</a>`, upgrade.From, style, upgrade.From, upgrade.From)
 			if info.Previous == nil || upgrade.From != info.Previous.Name {
 				fmt.Fprintf(w, ` (<a href="?from=%s">changes</a>)`, upgrade.From)
 			}

--- a/cmd/release-controller/prow.go
+++ b/cmd/release-controller/prow.go
@@ -22,16 +22,16 @@ func prowJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationSta
 	switch prowjobsv1.ProwJobState(s) {
 	case prowjobsv1.SuccessState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &VerificationStatus{State: releaseVerificationStateSucceeded, URL: url}
+		status = &VerificationStatus{VerifyJobStatus: VerifyJobStatus{State: releaseVerificationStateSucceeded, URL: url}}
 	case prowjobsv1.FailureState, prowjobsv1.ErrorState, prowjobsv1.AbortedState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &VerificationStatus{State: releaseVerificationStateFailed, URL: url}
+		status = &VerificationStatus{VerifyJobStatus: VerifyJobStatus{State: releaseVerificationStateFailed, URL: url}}
 	case prowjobsv1.TriggeredState, prowjobsv1.PendingState, prowjobsv1.ProwJobState(""):
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "pendingTime")
 		if transitionTime == "" {
 			transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "startTime")
 		}
-		status = &VerificationStatus{State: releaseVerificationStatePending, URL: url}
+		status = &VerificationStatus{VerifyJobStatus: VerifyJobStatus{State: releaseVerificationStatePending, URL: url}}
 	default:
 		klog.Errorf("Unrecognized prow job state %q on job %s", s, obj.GetName())
 		return nil, false

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -590,13 +590,13 @@ func (c *Controller) syncCandidateTesting(release *Release) error {
 		testTagLen--
 	}
 	testTags = testTags[:testTagLen]
-	if glog.V(4) && len(testTags) > 0 {
-		glog.Infof("release=%s keep=%v", release.Config.Name, tagNames(testTags))
+	if klog.V(4) && len(testTags) > 0 {
+		klog.Infof("release=%s keep=%v", release.Config.Name, tagNames(testTags))
 	}
 	for _, tag := range testTags {
 		candidateTests, status, err := c.ensureCandidateTests(release, tag)
 		if err != nil {
-			glog.V(4).Infof("Unable to run CandidateTests for %s: %v", tag.Name, err)
+			klog.V(4).Infof("Unable to run CandidateTests for %s: %v", tag.Name, err)
 			return err
 		}
 		newStatusJSON := toJSONString(status)
@@ -604,7 +604,7 @@ func (c *Controller) syncCandidateTesting(release *Release) error {
 			continue
 		}
 		if names := status.Incomplete(candidateTests); len(names) > 0 {
-			glog.V(4).Infof("CandidateTests for %s are still running: %s", tag.Name, strings.Join(names, ", "))
+			klog.V(4).Infof("CandidateTests for %s are still running: %s", tag.Name, strings.Join(names, ", "))
 			if err := c.setReleaseAnnotation(release, tag.Annotations[releaseAnnotationPhase], map[string]string{releaseAnnotationCandidateTests: toJSONString(status)}, tag.Name); err != nil {
 				return err
 			}

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -217,3 +217,197 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *UpgradeRelease, relea
 	}
 	return "", "", fmt.Errorf("upgradeRelease fields must be set if upgradeRelease is set")
 }
+
+func (c *Controller) ensureCandidateTests(release *Release, releaseTag *imagev1.TagReference) (map[string]*ReleaseCandidateTest, VerificationStatusList, error) {
+	var testStatus VerificationStatusList
+	retryQueueDelay := 0 * time.Second
+
+	if len(releaseTag.Annotations) > 0 {
+		if data := releaseTag.Annotations[releaseAnnotationCandidateTests]; len(data) > 0 {
+			testStatus = make(VerificationStatusList)
+			if err := json.Unmarshal([]byte(data), &testStatus); err != nil {
+				glog.Errorf("Release %s has invalid verification status, ignoring: %v", releaseTag.Name, err)
+			}
+		}
+	}
+
+	for name, candidateTest := range release.Config.CandidateTests {
+		if candidateTest.Disabled {
+			glog.V(2).Infof("Release verification step %s is disabled, ignoring", name)
+			continue
+		}
+		switch {
+		case candidateTest.ProwJob != nil:
+			if testStatus == nil {
+				if data := releaseTag.Annotations[releaseAnnotationVerify]; len(data) > 0 {
+					testStatus = make(VerificationStatusList)
+					if err := json.Unmarshal([]byte(data), &testStatus); err != nil {
+						glog.Errorf("Release %s has invalid verification status, ignoring: %v", releaseTag.Name, err)
+					}
+				}
+			}
+
+			var jobRetries int
+			if status, ok := testStatus[name]; ok {
+				var lastJobFailed bool
+				for _, state := range status.Status {
+					switch state.State {
+					case releaseVerificationStateSucceeded:
+						if candidateTest.RetryStrategy == RetryStrategyFirstSuccess {
+							jobRetries = candidateTest.MaxRetries + 1
+							break
+						}
+						jobRetries++
+						lastJobFailed = false
+						continue
+					case releaseVerificationStateFailed:
+						jobRetries++
+						lastJobFailed = true
+						if jobRetries > candidateTest.MaxRetries {
+							continue
+						}
+					case releaseVerificationStatePending:
+						lastJobFailed = false
+						// we need to process this
+					default:
+						glog.V(2).Infof("Unrecognized verification status %q for type %s on release %s", state.State, name, releaseTag.Name)
+					}
+					break
+				}
+				// find the next time, if ok run.
+				if lastJobFailed && status.TransitionTime != nil {
+					backoffDuration := calculateBackoff(jobRetries-1, status.TransitionTime, &metav1.Time{time.Now()})
+					if backoffDuration > 0 {
+						glog.V(6).Infof("%s: Release verification step %s failed %d times, last failure: %s, backoff till: %s",
+							releaseTag.Name, name, jobRetries, status.TransitionTime.Format(time.RFC3339), time.Now().Add(backoffDuration).Format(time.RFC3339))
+						if retryQueueDelay == 0 || backoffDuration < retryQueueDelay {
+							retryQueueDelay = backoffDuration
+						}
+						continue
+					}
+				}
+			}
+			if jobRetries > candidateTest.MaxRetries {
+				continue
+			}
+			// if this is an upgrade job, find the appropriate source for the upgrade job
+			var previousTag, previousReleasePullSpec string
+			if candidateTest.Upgrade {
+				upgradeType := releaseUpgradeFromPrevious
+				if release.Config.As == releaseConfigModeStable {
+					upgradeType = releaseUpgradeFromPreviousPatch
+				}
+				if len(candidateTest.UpgradeFrom) > 0 {
+					upgradeType = candidateTest.UpgradeFrom
+				}
+				switch upgradeType {
+				case releaseUpgradeFromPrevious:
+					if tags := sortedReleaseTags(release, releasePhaseAccepted); len(tags) > 0 {
+						previousTag = tags[0].Name
+						previousReleasePullSpec = release.Target.Status.PublicDockerImageRepository + ":" + previousTag
+					}
+				case releaseUpgradeFromPreviousMinor:
+					if version, err := semver.Parse(releaseTag.Name); err == nil && version.Minor > 0 {
+						version.Minor--
+						if ref, err := c.stableReleases(); err == nil {
+							for _, stable := range ref.Releases {
+								versions := unsortedSemanticReleaseTags(stable.Release, releasePhaseAccepted)
+								sort.Sort(versions)
+								if v := firstTagWithMajorMinorSemanticVersion(versions, version); v != nil {
+									previousTag = v.Tag.Name
+									previousReleasePullSpec = stable.Release.Target.Status.PublicDockerImageRepository + ":" + previousTag
+									break
+								}
+							}
+						}
+					}
+				case releaseUpgradeFromPreviousPatch:
+					if version, err := semver.Parse(releaseTag.Name); err == nil {
+						if ref, err := c.stableReleases(); err == nil {
+							for _, stable := range ref.Releases {
+								versions := unsortedSemanticReleaseTags(stable.Release, releasePhaseAccepted)
+								sort.Sort(versions)
+								if v := firstTagWithMajorMinorSemanticVersion(versions, version); v != nil {
+									previousTag = v.Tag.Name
+									previousReleasePullSpec = stable.Release.Target.Status.PublicDockerImageRepository + ":" + previousTag
+									break
+								}
+							}
+						}
+					}
+				default:
+					return nil, nil, fmt.Errorf("release %s has verify type %s which defines invalid upgradeFrom: %s", release.Config.Name, name, upgradeType)
+				}
+			}
+			jobName := name
+			if jobRetries > 0 {
+				jobName = fmt.Sprintf("%s-%d", jobName, jobRetries)
+			}
+
+			job, err := c.ensureProwJobForReleaseTag(release, jobName, candidateTest.ReleaseVerification, releaseTag, previousTag, previousReleasePullSpec)
+			if err != nil {
+				return nil, nil, err
+			}
+			status, ok := prowJobVerificationStatus(job)
+			if !ok {
+				return nil, nil, fmt.Errorf("unexpected error accessing prow job definition")
+			}
+			if status.State == releaseVerificationStateSucceeded {
+				glog.V(2).Infof("Prow job %s for release %s succeeded, logs at %s", name, releaseTag.Name, status.URL)
+				status.TransitionTime = nil
+			}
+
+			if testStatus == nil {
+				testStatus = VerificationStatusList{name: &CandidateTestStatus{Status: make([]*VerifyJobStatus, 0)}}
+			} else if testStatus[name] == nil {
+				testStatus[name] = &CandidateTestStatus{Status: make([]*VerifyJobStatus, 0)}
+			} else if testStatus[name].Status == nil {
+				testStatus[name].Status = make([]*VerifyJobStatus, 0)
+			}
+
+			if jobRetries < len(testStatus[name].Status) {
+				testStatus[name].Status[jobRetries] = &VerifyJobStatus{State: status.State, URL: status.URL}
+			} else {
+				testStatus[name].Status = append(testStatus[name].Status, &VerifyJobStatus{State: status.State, URL: status.URL})
+			}
+			testStatus[name].TransitionTime = status.TransitionTime
+			if jobRetries >= candidateTest.MaxRetries {
+				testStatus[name].TransitionTime = nil
+				continue
+			}
+
+			status.Retries = jobRetries
+			if jobRetries < len(testStatus[name].Status) {
+				testStatus[name].Status[jobRetries] = &VerifyJobStatus{State: status.State, URL: status.URL}
+			} else {
+				testStatus[name].Status = append(testStatus[name].Status, &VerifyJobStatus{State: status.State, URL: status.URL})
+			}
+			testStatus[name].TransitionTime = status.TransitionTime
+
+			if jobRetries >= candidateTest.MaxRetries {
+				testStatus[name].TransitionTime = nil
+				continue
+			}
+
+			if status.State == releaseVerificationStateFailed {
+				// Queue for retry if at least one retryable job at earliest interval
+				backoffDuration := calculateBackoff(jobRetries, status.TransitionTime, &metav1.Time{time.Now()})
+				if retryQueueDelay == 0 || backoffDuration < retryQueueDelay {
+					retryQueueDelay = backoffDuration
+				}
+			}
+
+		default:
+			// manual verification
+		}
+	}
+	if retryQueueDelay > 0 {
+		key := queueKey{
+			name:      release.Source.Name,
+			namespace: release.Source.Namespace,
+		}
+		c.queue.AddAfter(key, retryQueueDelay)
+	}
+	return release.Config.CandidateTests, testStatus, nil
+}
+

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -457,6 +457,30 @@ func (m VerificationStatusList) Incomplete(required map[string]*ReleaseCandidate
 	return names
 }
 
+func (t *ReleaseCandidateTest) state(status ...*VerifyJobStatus) string {
+	retryStrategy := t.RetryStrategy
+	if len(retryStrategy) == 0 {
+		retryStrategy = DefaultRetryStrategy
+	}
+	success := 0
+	for _, s := range status {
+		switch s.State {
+		case releaseVerificationStatePending:
+			return s.State
+		case releaseVerificationStateSucceeded:
+			if t.RetryStrategy == RetryStrategyFirstSuccess {
+				return s.State
+			}
+			success++
+		}
+	}
+	if success >= len(status)/2 {
+		// TODO: add success threshold for tests
+		return releaseVerificationStateSucceeded
+	}
+	return releaseVerificationStateFailed
+}
+
 const (
 	// releasePhasePending is assigned to release tags that are waiting for an update
 	// payload image to be created and pushed.


### PR DESCRIPTION
This PR supersedes Ankita's PR #167.  The work she has done here introduces another sync loop to check for, execute, and verify any candidate tests that are defined in the respective release's release config whenever the particular release is updated with the "keep" annotation.