### PR TITLE
Adding nil check to prevent Untested upgrades block from always showing up

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -725,8 +725,11 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 	if len(upgradesTo) > 0 {
 		sort.Sort(newNewestSemVerFromSummaries(upgradesTo))
-		fmt.Fprintf(w, `<p id="upgrades-from">Upgrades from:</p>`)
-		fmt.Fprintf(w, "<div class=\"alert alert-warning\">Untested upgrades: %s</div><ul>", strings.Join(missingUpgrades, ", "))
+		if len(missingUpgrades) > 0 {
+			fmt.Fprintf(w, `<p id="upgrades-from">Upgrades from:</p>`)
+			fmt.Fprintf(w, "<div class=\"alert alert-warning\">Untested upgrades: %s</div>", strings.Join(missingUpgrades, ", "))
+		}
+		fmt.Fprintf(w, "<ul>")
 		for _, upgrade := range upgradesTo {
 			var style string
 			switch {


### PR DESCRIPTION
This PR is to add a nil check around the "Untested upgrades" warning block to prevent it from showing up when there are no untested upgrades.  Found while navigating here:

https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.5.0-rc.3