### PR TITLE
Adding support for architectures for RHCOS linking

### DIFF
--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -264,7 +264,7 @@ type ReleaseUpgradeInfo struct {
 }
 
 type ReleaseUpgradeMetadata struct {
-	Version string `json:"version"`
+	Version  string   `json:"version"`
 	Previous []string `json:"previous"`
 }
 


### PR DESCRIPTION
It was pointed out that the architecture specific links to RHCOS content were
all pointing to the x86_64 streams and therefore presenting incorrect information
to the users.  These changes extract the architecture out from the ReleaseInfo 
payload for the specified release. Once the archtecture is known, it is
used to create the correct URL to the architecture specific content and RHCOS
difference tool.