### PR TITLE
Remove transitionTime field in terminal releases to reduce annotation sizes

### DIFF
--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -135,6 +135,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 			verifyStatus[name] = status
 
 			if jobRetries >= verifyType.MaxRetries {
+				verifyStatus[name].TransitionTime = nil
 				continue
 			}
 


### PR DESCRIPTION
TransitionTime field is used to track completion time of the previous run of a job to decide when a retryable job should be scheduled for run again. This was not being removed on terminal tags, causing release tag annotation sizes to increase, approaching the 2MB annotation size limit. This fix removes the field from the statuses of all terminal tags, and adds a syncTerminal loop to strip any existing terminal release tags of the field.

These changes supersede PR #166 and also contain a fix that enables the logic to work as expected.