### PR TITLE
Removing sync terminal loop

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -116,15 +116,6 @@ func (c *Controller) sync(key queueKey) error {
 		return err
 	}
 
-	// ensure cleanup on terminal tags
-	if err := c.syncTerminal(release); err != nil {
-		if errors.IsConflict(err) {
-			return nil
-		}
-		c.eventRecorder.Eventf(release.Source, corev1.EventTypeWarning, "UnableToVerifyRelease", "%v", err)
-		return err
-	}
-
 	// if we're waiting for an interval to elapse, go ahead and queue to be woken
 	if queueAfter > 0 {
 		c.queue.AddAfter(key, queueAfter)
@@ -521,41 +512,6 @@ func (c *Controller) syncReady(release *Release) error {
 	}
 
 	return nil
-}
-
-func (c *Controller) syncTerminal(release *Release) error {
-	terminalTags := sortedRawReleaseTags(release, releasePhaseAccepted, releasePhaseRejected)
-	if klog.V(5) && len(terminalTags) > 0 {
-		klog.Infof("terminal=%v", tagNames(terminalTags))
-	}
-	var tagAnnotations map[string]interface{}
-	for _, releaseTag := range terminalTags {
-		updatedTag := releaseTag.DeepCopy()
-		oldVerifyStatus := updatedTag.Annotations[releaseAnnotationVerify]
-		if len(oldVerifyStatus) == 0 {
-			klog.V(5).Infof("%s: Empty verify annotation, skipping", updatedTag.Name)
-			continue
-		}
-		status := make(VerificationStatusMap)
-		if err := json.Unmarshal([]byte(oldVerifyStatus), &status); err != nil {
-			klog.Errorf("Release %s has invalid verification status, ignoring: %v", updatedTag.Name, err)
-			continue
-		}
-		for i := range status {
-			status[i].TransitionTime = nil
-		}
-		newVerifyStatus := toJSONString(status)
-		if  newVerifyStatus == oldVerifyStatus {
-			continue
-		}
-		updatedTag.Annotations[releaseAnnotationVerify] = newVerifyStatus
-		if tagAnnotations == nil {
-			tagAnnotations = map[string]interface{}{updatedTag.Name: updatedTag.Annotations}
-			continue
-		}
-		tagAnnotations[updatedTag.Name] = updatedTag.Annotations
-	}
-	return c.updateReleaseTagAnnotations(release, tagAnnotations)
 }
 
 func (c *Controller) syncAccepted(release *Release) error {

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -215,48 +215,6 @@ func (c *Controller) ensureReleaseTagPhase(release *Release, preconditionPhases 
 	return nil
 }
 
-// Update annotations for a set of tags in a release
-func (c *Controller) updateReleaseTagAnnotations(release *Release, tagAnnotations map[string]interface{}) error {
-	if len(tagAnnotations) == 0 {
-		return nil
-	}
-	var changed bool
-	target := release.Target.DeepCopy()
-	for name, annotationInterface := range tagAnnotations {
-		annotations, ok := annotationInterface.(map[string]string)
-		if !ok {
-			continue
-		}
-		tag := findTagReference(target, name)
-		if tag == nil {
-			return fmt.Errorf("release %s no longer exists, cannot update annotations", name)
-		}
-		if tag.Annotations == nil {
-			tag.Annotations = make(map[string]string)
-		}
-		for k, v := range annotations {
-			if _, ok := tag.Annotations[k]; ok && len(v) == 0 {
-				delete(tag.Annotations, k)
-				changed = true
-				continue
-			}
-			if tag.Annotations[k] != v {
-				tag.Annotations[k] = v
-				changed = true
-			}
-		}
-	}
-	if !changed {
-		return nil
-	}
-	is, err := c.imageClient.ImageStreams(target.Namespace).Update(target)
-	if err != nil {
-		return err
-	}
-	updateReleaseTarget(release, is)
-	return nil
-}
-
 func (c *Controller) transitionReleasePhaseFailure(release *Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
 	target := release.Target.DeepCopy()
 	changed := 0


### PR DESCRIPTION
These changes remove the syncTerminal loop that was introduced in #213 to
cleanup the transitionTime entry in all of the releases in terminal states.