### PR TITLE
cmd: add support for running periodics in release-controller

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -391,6 +391,8 @@ func (o *options) Run() error {
 				}
 			}, 2*time.Minute, stopCh)
 		}()
+
+		go c.syncPeriodicJobs(prowInformers, stopCh)
 	}
 
 	klog.Infof("Waiting for caches to sync")

--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -59,19 +59,13 @@ func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, s
 					klog.Errorf("the prowjob %s is not valid: %v", periodic.ProwJob.Name, err)
 					continue
 				}
-				// create unique job name based on release; this prevents issues where the same base job is specified
-				// by 2 different releases (for example nightly vs ci) or when a job gets runs by horologium
-				jobName := fmt.Sprintf("%s-%s-periodic", periodic.ProwJob.Name, r.Config.Name)
-				// make new copy of periodicConfig so we can update the name
-				newPeriodicConfig := *periodicConfig
-				newPeriodicConfig.Name = jobName
-				releasePeriodics[jobName] = PeriodicWithRelease{
-					Periodic:    &newPeriodicConfig,
+				releasePeriodics[periodicConfig.Name] = PeriodicWithRelease{
+					Periodic:    periodicConfig,
 					Release:     r,
 					Upgrade:     periodic.Upgrade,
 					UpgradeFrom: periodic.UpgradeFrom,
 				}
-				cronConfig.Periodics = append(cronConfig.Periodics, newPeriodicConfig)
+				cronConfig.Periodics = append(cronConfig.Periodics, *periodicConfig)
 			}
 		}
 		// update cron

--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	config "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/cron"
+	"k8s.io/test-infra/prow/pjutil"
+)
+
+type PeriodicWithRelease struct {
+	Periodic    *config.Periodic
+	Release     *Release
+	Upgrade     bool
+	UpgradeFrom string
+}
+
+func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, stopCh <-chan struct{}) {
+	prowIndex := prowInformers.GetIndexer()
+	cache.WaitForCacheSync(stopCh, prowInformers.HasSynced)
+	cr := cron.New()
+	cr.Start()
+	wait.Until(func() {
+		imagestreams, err := c.releaseLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("failed to get list of imagestreams: %v", err)
+			return
+		}
+		cfg := c.prowConfigLoader.Config()
+		if cfg == nil {
+			klog.Errorf("the prow config is not valid: no prow jobs have been defined")
+			return
+		}
+		releasePeriodics := make(map[string]PeriodicWithRelease)
+		// to reuse cron code from k8s test-infra, we can create a fake prow Config that just has just the periodics specified in the release configs
+		cronConfig := &config.Config{}
+		for _, is := range imagestreams {
+			r, ok, err := c.releaseDefinition(is)
+			if err != nil || !ok {
+				continue
+			}
+			for _, periodic := range r.Config.Periodic {
+				periodicConfig, ok := hasProwJob(cfg, periodic.ProwJob.Name)
+				if !ok {
+					klog.Errorf("the prow job %s is not valid: no job with that name", periodic.ProwJob.Name)
+					continue
+				}
+				if err := validateProwJob(periodicConfig); err != nil {
+					klog.Errorf("the prowjob %s is not valid: %v", periodic.ProwJob.Name, err)
+					continue
+				}
+				// create unique job name based on release; this prevents issues where the same base job is specified
+				// by 2 different releases (for example nightly vs ci) or when a job gets runs by horologium
+				jobName := fmt.Sprintf("%s-%s-periodic", periodic.ProwJob.Name, r.Config.Name)
+				// make new copy of periodicConfig so we can update the name
+				newPeriodicConfig := *periodicConfig
+				newPeriodicConfig.Name = jobName
+				releasePeriodics[jobName] = PeriodicWithRelease{
+					Periodic:    &newPeriodicConfig,
+					Release:     r,
+					Upgrade:     periodic.Upgrade,
+					UpgradeFrom: periodic.UpgradeFrom,
+				}
+				cronConfig.Periodics = append(cronConfig.Periodics, newPeriodicConfig)
+			}
+		}
+		// update cron
+		if err := cr.SyncConfig(cronConfig); err != nil {
+			klog.Errorf("Error syncing cron jobs: %v", err)
+		}
+
+		cronTriggers := sets.NewString()
+		for _, job := range cr.QueuedJobs() {
+			cronTriggers.Insert(job)
+		}
+
+		// get current prowjobs; returned as []interface, and thus must be converted to unstructured and then periodics
+		jobInterfaces := prowIndex.List()
+		jobs := []prowapi.ProwJob{}
+		for _, item := range jobInterfaces {
+			unstructuredJob, ok := item.(*unstructured.Unstructured)
+			if !ok {
+				klog.Warning("job interface from prow informer index list could not be cast to unstructured")
+				continue
+			}
+			prowjob := prowapi.ProwJob{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredJob.UnstructuredContent(), &prowjob); err != nil {
+				klog.Errorf("failed to convert unstructured prowjob to prowjob type object: %v", err)
+				continue
+			}
+			jobs = append(jobs, prowjob)
+		}
+		latestJobs := pjutil.GetLatestProwJobs(jobs, prowapi.PeriodicJob)
+
+		var errs []error
+		for _, p := range cronConfig.Periodics {
+			j, previousFound := latestJobs[p.Name]
+			if p.Cron == "" {
+				shouldTrigger := j.Complete() && time.Now().Sub(j.Status.StartTime.Time) > p.GetInterval()
+				if !previousFound || shouldTrigger {
+					err := c.createProwJobFromPeriodicWithRelease(releasePeriodics[p.Name])
+					if err != nil {
+						errs = append(errs, err)
+					}
+				}
+			} else if cronTriggers.Has(p.Name) {
+				shouldTrigger := j.Complete()
+				if !previousFound || shouldTrigger {
+					err := c.createProwJobFromPeriodicWithRelease(releasePeriodics[p.Name])
+					if err != nil {
+						errs = append(errs, err)
+					}
+				}
+			}
+		}
+
+		if len(errs) > 0 {
+			klog.Errorf("failed to create %d periodic prowjobs: %v", len(errs), errs)
+		}
+	}, 2*time.Minute, stopCh)
+}
+
+func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease PeriodicWithRelease) error {
+	// get release info
+	release := periodicWithRelease.Release
+	acceptedTags := sortedRawReleaseTags(release, releasePhaseAccepted)
+	if len(acceptedTags) == 0 {
+		return fmt.Errorf("no accepted tags found for release %s", release.Config.Name)
+	}
+	latestTag := acceptedTags[0]
+	mirror, err := c.getMirror(release, latestTag.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get mirror for release %s tag %s: %v", release.Config.Name, latestTag.Name, err)
+	}
+	var previousTag, previousReleasePullSpec string
+	if periodicWithRelease.Upgrade {
+		previousTag, previousReleasePullSpec, err = c.getUpgradeTagAndPullSpec(release, latestTag, periodicWithRelease.Periodic.Name, periodicWithRelease.UpgradeFrom)
+		if err != nil {
+			return fmt.Errorf("failed to get previous release spec and tag for release %s tag %s: %v", release.Config.Name, latestTag.Name, err)
+		}
+	}
+	spec := pjutil.PeriodicSpec(*periodicWithRelease.Periodic)
+	ok, err := addReleaseEnvToProwJobSpec(&spec, release, mirror, latestTag, previousReleasePullSpec)
+	if err != nil || !ok {
+		return fmt.Errorf("failed to add release env to periodic %s: %v", periodicWithRelease.Periodic.Name, err)
+	}
+	prowJob := pjutil.NewProwJob(spec, periodicWithRelease.Periodic.Labels, periodicWithRelease.Periodic.Annotations)
+	prowJob.Labels[releaseAnnotationVerify] = "true"
+	prowJob.Annotations[releaseAnnotationSource] = fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name)
+	prowJob.Annotations[releaseAnnotationToTag] = latestTag.Name
+	if periodicWithRelease.Upgrade && len(previousTag) > 0 {
+		prowJob.Annotations[releaseAnnotationFromTag] = previousTag
+	}
+
+	_, err = c.prowClient.Create(objectToUnstructured(&prowJob), metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create periodic prowjob %s: %v", periodicWithRelease.Periodic.Name, err)
+	}
+	klog.V(2).Infof("Created new prow job %s", prowJob.Name)
+	return nil
+}

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -106,6 +106,10 @@ type ReleaseConfig struct {
 	// rejected.
 	Verify map[string]ReleaseVerification `json:"verify"`
 
+	// Periodic is a map of short names to verification steps that run based on a cron
+	// or interval timer.
+	Periodic map[string]ReleasePeriodic `json:"periodic"`
+
 	// Publish is a map of short names to publish steps that will be performed after
 	// the release is Accepted. Some publish steps are continuously maintained, others
 	// may only be performed once.
@@ -211,6 +215,36 @@ type ReleaseVerification struct {
 	ProwJob *ProwJobVerification `json:"prowJob"`
 	// Maximum retry attempts for the job. Defaults to 0 - do not retry on fail
 	MaxRetries int `json:"maxRetries,omitempty"`
+}
+
+// ReleasePeriodic is a job that runs on the speicifed cron or interval period as a
+// release informer.
+type ReleasePeriodic struct {
+	// Interval to wait between two runs of the job.
+	Interval string `json:"interval,omitempty"`
+	// Cron representation of job trigger time
+	Cron string `json:"cron,omitempty"`
+
+	// Upgrade is true if this verification should be used to verify upgrades.
+	// The default UpgradeFrom for stable streams is PreviousMicro and the default
+	// for other types of streams is Previous.
+	Upgrade bool `json:"upgrade"`
+	// UpgradeFrom, if set, describes a different default upgrade source. The supported
+	// values are:
+	//
+	// Previous - selects the latest accepted tag from the current stream
+	// PreviousMicro - selects the latest accepted patch version from the current minor
+	//   version (4.2.1 will select the latest accepted 4.2.z tag).
+	// PreviousMinor - selects the latest accepted patch version from the previous minor
+	//   version (4.2.1 will select the latest accepted 4.1.z tag).
+	//
+	// If no matching target exists the job will be a no-op.
+	UpgradeFrom string `json:"upgradeFrom"`
+
+	// ProwJob requires that the named ProwJob from the prow config pass before the
+	// release is accepted. The job is run only one time and if it fails the release
+	// is rejected.
+	ProwJob *ProwJobVerification `json:"prowJob"`
 }
 
 // ProwJobVerification identifies the name of a prow job that will be used to

--- a/vendor/k8s.io/test-infra/prow/cron/BUILD.bazel
+++ b/vendor/k8s.io/test-infra/prow/cron/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cron.go"],
+    importpath = "k8s.io/test-infra/prow/cron",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/config:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@in_gopkg_robfig_cron_v2//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cron_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "@in_gopkg_robfig_cron_v2//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/test-infra/prow/cron/cron.go
+++ b/vendor/k8s.io/test-infra/prow/cron/cron.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cron provides a wrapper of robfig/cron, which manages schedule cron jobs for horologium
+package cron
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	cron "gopkg.in/robfig/cron.v2" // using v2 api, doc at https://godoc.org/gopkg.in/robfig/cron.v2
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+// jobStatus is a cache layer for tracking existing cron jobs
+type jobStatus struct {
+	// entryID is a unique-identifier for each cron entry generated from cronAgent
+	entryID cron.EntryID
+	// triggered marks if a job has been triggered for the next cron.QueuedJobs() call
+	triggered bool
+	// cronStr is a cache for job's cron status
+	// cron entry will be regenerated if cron string changes from the periodic job
+	cronStr string
+}
+
+// Cron is a wrapper for cron.Cron
+type Cron struct {
+	cronAgent *cron.Cron
+	jobs      map[string]*jobStatus
+	logger    *logrus.Entry
+	lock      sync.Mutex
+}
+
+// New makes a new Cron object
+func New() *Cron {
+	return &Cron{
+		cronAgent: cron.New(),
+		jobs:      map[string]*jobStatus{},
+		logger:    logrus.WithField("client", "cron"),
+	}
+}
+
+// Start kicks off current cronAgent scheduler
+func (c *Cron) Start() {
+	c.cronAgent.Start()
+}
+
+// Stop pauses current cronAgent scheduler
+func (c *Cron) Stop() {
+	c.cronAgent.Stop()
+}
+
+// QueuedJobs returns a list of jobs that need to be triggered
+// and reset trigger in jobStatus
+func (c *Cron) QueuedJobs() []string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	res := []string{}
+	for k, v := range c.jobs {
+		if v.triggered {
+			res = append(res, k)
+		}
+		c.jobs[k].triggered = false
+	}
+	return res
+}
+
+// SyncConfig syncs current cronAgent with current prow config
+// which add/delete jobs accordingly.
+func (c *Cron) SyncConfig(cfg *config.Config) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for _, p := range cfg.Periodics {
+		if err := c.addPeriodic(p); err != nil {
+			return err
+		}
+	}
+
+	periodicNames := sets.NewString()
+	for _, p := range cfg.AllPeriodics() {
+		periodicNames.Insert(p.Name)
+	}
+
+	existing := sets.NewString()
+	for k := range c.jobs {
+		existing.Insert(k)
+	}
+
+	var removalErrors []error
+	for _, job := range existing.Difference(periodicNames).List() {
+		if err := c.removeJob(job); err != nil {
+			removalErrors = append(removalErrors, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(removalErrors)
+}
+
+// HasJob returns if a job has been scheduled in cronAgent or not
+func (c *Cron) HasJob(name string) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	_, ok := c.jobs[name]
+	return ok
+}
+
+func (c *Cron) addPeriodic(p config.Periodic) error {
+	if p.Cron == "" {
+		return nil
+	}
+
+	if job, ok := c.jobs[p.Name]; ok {
+		if job.cronStr == p.Cron {
+			return nil
+		}
+		// job updated, remove old entry
+		if err := c.removeJob(p.Name); err != nil {
+			return err
+		}
+	}
+
+	if err := c.addJob(p.Name, p.Cron); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// addJob adds a cron entry for a job to cronAgent
+func (c *Cron) addJob(name, cron string) error {
+	id, err := c.cronAgent.AddFunc("TZ=UTC "+cron, func() {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+
+		c.jobs[name].triggered = true
+		c.logger.Infof("Triggering cron job %s.", name)
+	})
+
+	if err != nil {
+		return fmt.Errorf("cronAgent fails to add job %s with cron %s: %v", name, cron, err)
+	}
+
+	c.jobs[name] = &jobStatus{
+		entryID: id,
+		cronStr: cron,
+		// try to kick of a periodic trigger right away
+		triggered: strings.HasPrefix(cron, "@every"),
+	}
+
+	c.logger.Infof("Added new cron job %s with trigger %s.", name, cron)
+	return nil
+}
+
+// removeJob removes the job from cronAgent
+func (c *Cron) removeJob(name string) error {
+	job, ok := c.jobs[name]
+	if !ok {
+		return fmt.Errorf("job %s has not been added to cronAgent yet", name)
+	}
+	c.cronAgent.Remove(job.entryID)
+	delete(c.jobs, name)
+	c.logger.Infof("Removed previous cron job %s.", name)
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -755,6 +755,7 @@ k8s.io/test-infra/prow/commentpruner
 k8s.io/test-infra/prow/config
 k8s.io/test-infra/prow/config/secret
 k8s.io/test-infra/prow/crier/reporters/github
+k8s.io/test-infra/prow/cron
 k8s.io/test-infra/prow/entrypoint
 k8s.io/test-infra/prow/flagutil
 k8s.io/test-infra/prow/gcsupload


### PR DESCRIPTION
This PR adds support for the release-controller to run periodics defined
in release configs, similar to verify jobs. It uses the test-infra cron
pkg and has a similar structure to prow's horologium sync function, but
modified to use the data structures, interfaces, and configuration that
the release-controller has.

To add a periodic job, a user would add the job to the `periodic`
section of the release config with the name of the job, the interval or
cron timing the user wants, and an `upgrade` bool and `upgradeFrom`
string if it is an upgrade job.

Previously, release informers (specifically upgrades) were run by
horologium and used curl to get release tags and annotated themselves to
be picked up by release-controller. This PR allows us to fix that
problem by creating the prowjobs directly from release-controller with
the proper annotations and env vars from the start.

/cc @stevekuznetsov @smarterclayton 