### PR TITLE
Adding an unsupported banner to the release-controller pages

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -52,7 +52,6 @@ const htmlPageEnd = `
 
 const releasePageHtml = `
 <h1>Release Status</h1>
-<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
@@ -60,6 +59,7 @@ const releasePageHtml = `
 <pre class="ml-4">
 oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}graph"}}' --type=merge
 </pre>
+<div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <style>
 .upgrade-track-line {
 	position: absolute;
@@ -165,10 +165,10 @@ const releaseInfoPageHtml = `
 
 const releaseDashboardPageHtml = `
 <h1>Release Dashboard</h1>
-<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
+<div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p><a href=https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&f1=cf_internal_whiteboard&f2=status_whiteboard&j_top=OR&known_name=BuildCop&list_id=10913331&o1=substring&o2=substring&query_format=advanced&v1=buildcop&v2=buildcop>Open Build Cop Bugs</a></p>
 <p class="small mb-3">
 	Jump to: {{ releaseJoin .Streams }}
@@ -700,8 +700,6 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, `</div>`)
 		return
 	}
-
-	fmt.Fprintf(w, "<div class=\"alert alert-warning\">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>")
 
 	renderInstallInstructions(w, mirror, info.Tag, tagPull, c.artifactsHost)
 

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -52,6 +52,7 @@ const htmlPageEnd = `
 
 const releasePageHtml = `
 <h1>Release Status</h1>
+<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href="https://access.redhat.com/downloads/content/290/">the Red Hat Customer Portal</a> for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
@@ -164,6 +165,7 @@ const releaseInfoPageHtml = `
 
 const releaseDashboardPageHtml = `
 <h1>Release Dashboard</h1>
+<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href="https://access.redhat.com/downloads/content/290/">the Red Hat Customer Portal</a> for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
@@ -698,6 +700,8 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, `</div>`)
 		return
 	}
+
+	fmt.Fprintf(w, "<div class=\"alert alert-warning\">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href=\"https://access.redhat.com/downloads/content/290/\">the Red Hat Customer Portal</a> for the latest supported product details.</div>")
 
 	renderInstallInstructions(w, mirror, info.Tag, tagPull, c.artifactsHost)
 

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -52,7 +52,7 @@ const htmlPageEnd = `
 
 const releasePageHtml = `
 <h1>Release Status</h1>
-<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href="https://access.redhat.com/downloads/content/290/">the Red Hat Customer Portal</a> for the latest supported product details.</div>
+<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
@@ -165,7 +165,7 @@ const releaseInfoPageHtml = `
 
 const releaseDashboardPageHtml = `
 <h1>Release Dashboard</h1>
-<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href="https://access.redhat.com/downloads/content/290/">the Red Hat Customer Portal</a> for the latest supported product details.</div>
+<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
@@ -701,7 +701,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	fmt.Fprintf(w, "<div class=\"alert alert-warning\">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href=\"https://access.redhat.com/downloads/content/290/\">the Red Hat Customer Portal</a> for the latest supported product details.</div>")
+	fmt.Fprintf(w, "<div class=\"alert alert-warning\">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>")
 
 	renderInstallInstructions(w, mirror, info.Tag, tagPull, c.artifactsHost)
 

--- a/cmd/release-controller/http_compare.go
+++ b/cmd/release-controller/http_compare.go
@@ -34,6 +34,7 @@ type ComparisonPage struct {
 
 const comparisonDashboardPageHtml = `
 <h1>Release Comparison Dashboard</h1>
+<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href="https://access.redhat.com/downloads/content/290/">the Red Hat Customer Portal</a> for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>

--- a/cmd/release-controller/http_compare.go
+++ b/cmd/release-controller/http_compare.go
@@ -34,7 +34,7 @@ type ComparisonPage struct {
 
 const comparisonDashboardPageHtml = `
 <h1>Release Comparison Dashboard</h1>
-<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit <a href="https://access.redhat.com/downloads/content/290/">the Red Hat Customer Portal</a> for the latest supported product details.</div>
+<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>

--- a/cmd/release-controller/http_compare.go
+++ b/cmd/release-controller/http_compare.go
@@ -34,10 +34,10 @@ type ComparisonPage struct {
 
 const comparisonDashboardPageHtml = `
 <h1>Release Comparison Dashboard</h1>
-<div class="alert alert-warning">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 <p class="small mb-3">
 	Quick links: {{ dashboardsJoin .Dashboards }}
 </p>
+<div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
 `
 
 func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Per JIRA ticket: https://issues.redhat.com/browse/DPCR-38
We have been requested to update our pages with a banner that indicates:

a) This site is part of OpenShift's continuous delivery pipeline and
only builds obtained directly from access.redhat.com or try.openshift.com
are considered GA OCP builds

b) Tested upgrade paths recorded in this site do not represent OCP
supported upgrade paths. Only those upgrade paths available via either
the fast or stable OpenShift Update Service (Cincinnati) channels are
supported by Red Hat.

These changes update the various pages as follows:

1. Release Status
![RC1](https://user-images.githubusercontent.com/43015045/95260961-9569fd80-07f7-11eb-8d43-aac90989576b.png)

2. Release Dashboard
![RC2](https://user-images.githubusercontent.com/43015045/95260980-9c910b80-07f7-11eb-9f4a-22ea304688f8.png)

3. Release Comparison Dashboard
![RC3](https://user-images.githubusercontent.com/43015045/95260994-a0249280-07f7-11eb-88b6-12d9914ad2aa.png)

4. Release Stream
![RC4](https://user-images.githubusercontent.com/43015045/95261008-a3b81980-07f7-11eb-9e48-5c58b15cbf83.png)
