### PR TITLE
types: add PreviousMinus1 upgrade type

### DIFF
--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -148,7 +148,7 @@ func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease Pe
 	}
 	var previousTag, previousReleasePullSpec string
 	if periodicWithRelease.Upgrade {
-		previousTag, previousReleasePullSpec, err = c.getUpgradeTagAndPullSpec(release, latestTag, periodicWithRelease.Periodic.Name, periodicWithRelease.UpgradeFrom)
+		previousTag, previousReleasePullSpec, err = c.getUpgradeTagAndPullSpec(release, latestTag, periodicWithRelease.Periodic.Name, periodicWithRelease.UpgradeFrom, true)
 		if err != nil {
 			return fmt.Errorf("failed to get previous release spec and tag for release %s tag %s: %v", release.Config.Name, latestTag.Name, err)
 		}

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -377,9 +377,10 @@ const (
 
 	releaseConfigModeStable = "Stable"
 
-	releaseUpgradeFromPreviousMinor = "PreviousMinor"
-	releaseUpgradeFromPreviousPatch = "PreviousPatch"
-	releaseUpgradeFromPrevious      = "Previous"
+	releaseUpgradeFromPreviousMinor  = "PreviousMinor"
+	releaseUpgradeFromPreviousPatch  = "PreviousPatch"
+	releaseUpgradeFromPrevious       = "Previous"
+	releaseUpgradeFromPreviousMinus1 = "PreviousMinus1"
 
 	// releaseAnnotationConfig is the JSON serialized representation of the ReleaseConfig
 	// struct. It is only accepted on image streams. An image stream with this annotation


### PR DESCRIPTION
This adds the `PreviousMinus1` upgrade type, which is the second latest
accepted tag for an image stream. This will be the default upgradeType
for upgrade periodics, which use the latest accepted tag as
`RELEASE_IMAGE_LATEST`.

/cc @stevekuznetsov 