### PR TITLE
cmd: add config validation mode

### DIFF
--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/robfig/cron.v2"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func validateConfigs(configDir string) error {
+	errors := []error{}
+	releaseConfigs := []ReleaseConfig{}
+	err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
+		if info != nil && filepath.Ext(info.Name()) == ".json" {
+			raw, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			config := ReleaseConfig{}
+			dec := json.NewDecoder(bytes.NewReader(raw))
+			dec.DisallowUnknownFields() // Force errors on unknown fields
+			if err := dec.Decode(&config); err != nil {
+				errors = append(errors, fmt.Errorf("failed to unmarshal release configuration file %s: %v", info.Name(), err))
+				return nil
+			}
+			releaseConfigs = append(releaseConfigs, config)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error encountered while trying to read config files: %w", err)
+	}
+	errors = append(errors, verifyPeriodicFields(releaseConfigs)...)
+	errors = append(errors, findDuplicatePeriodics(releaseConfigs)...)
+	return utilerrors.NewAggregate(errors)
+}
+
+func verifyPeriodicFields(releaseConfigs []ReleaseConfig) []error {
+	errors := []error{}
+	for _, config := range releaseConfigs {
+		for stepName, periodic := range config.Periodic {
+			if periodic.Cron == "" && periodic.Interval == "" {
+				errors = append(errors, fmt.Errorf("%s: periodic %s: must specify a cron or interval", config.Name, stepName))
+			}
+			if periodic.Cron != "" && periodic.Interval != "" {
+				errors = append(errors, fmt.Errorf("%s: periodic %s: cannot have both cron and interval specified", config.Name, stepName))
+			}
+			if periodic.Interval != "" {
+				if _, err := time.ParseDuration(periodic.Interval); err != nil {
+					errors = append(errors, fmt.Errorf("%s: periodic %s: cannot parse interval: %w", config.Name, stepName, err))
+				}
+			}
+			if periodic.Cron != "" {
+				if _, err := cron.Parse(periodic.Cron); err != nil {
+					errors = append(errors, fmt.Errorf("%s: periodic %s: cannot parse cron: %w", config.Name, stepName, err))
+				}
+			}
+		}
+	}
+	return errors
+}
+
+func findDuplicatePeriodics(releaseConfigs []ReleaseConfig) []error {
+	seen := make(map[string][]string)
+	for _, config := range releaseConfigs {
+		for stepName, periodic := range config.Periodic {
+			steps, ok := seen[periodic.ProwJob.Name]
+			if !ok {
+				steps = []string{}
+			}
+			steps = append(steps, fmt.Sprintf("[%s: periodic: %s]", config.Name, stepName))
+			seen[periodic.ProwJob.Name] = steps
+		}
+	}
+	var duplicates []error
+	for job, steps := range seen {
+		if len(steps) == 1 {
+			continue
+		}
+		duplicates = append(duplicates, fmt.Errorf("found job %s in multiple locations: %v", job, steps))
+	}
+	return duplicates
+}

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"testing"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+func TestVerifyPeriodicFields(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       ReleaseConfig
+		expectedErr bool
+	}{{
+		name: "Valid Cron",
+		input: ReleaseConfig{
+			Name: "TestRelease",
+			Periodic: map[string]ReleasePeriodic{
+				"aws": {
+					Cron:    "0 8,20 * * *",
+					ProwJob: &ProwJobVerification{Name: "openshift-e2e-aws"},
+				},
+			},
+		},
+		expectedErr: false,
+	}, {
+		name: "Valid Interval",
+		input: ReleaseConfig{
+			Name: "TestRelease",
+			Periodic: map[string]ReleasePeriodic{
+				"aws": {
+					Interval: "6h",
+					ProwJob:  &ProwJobVerification{Name: "openshift-e2e-aws"},
+				},
+			},
+		},
+		expectedErr: false,
+	}, {
+		name: "Missing Fields",
+		input: ReleaseConfig{
+			Name: "TestRelease",
+			Periodic: map[string]ReleasePeriodic{
+				"aws": {
+					ProwJob: &ProwJobVerification{Name: "openshift-e2e-aws"},
+				},
+			},
+		},
+		expectedErr: true,
+	}, {
+		name: "Interval and Cron",
+		input: ReleaseConfig{
+			Name: "TestRelease",
+			Periodic: map[string]ReleasePeriodic{
+				"aws": {
+					Cron:     "0 8,20 * * *",
+					Interval: "6h",
+					ProwJob:  &ProwJobVerification{Name: "openshift-e2e-aws"},
+				},
+			},
+		},
+		expectedErr: true,
+	}, {
+		name: "Invalid Cron",
+		input: ReleaseConfig{
+			Name: "TestRelease",
+			Periodic: map[string]ReleasePeriodic{
+				"aws": {
+					Cron:    "0 8,25 * * *",
+					ProwJob: &ProwJobVerification{Name: "openshift-e2e-aws"},
+				},
+			},
+		},
+		expectedErr: true,
+	}, {
+		name: "Invalid Interval",
+		input: ReleaseConfig{
+			Name: "TestRelease",
+			Periodic: map[string]ReleasePeriodic{
+				"aws": {
+					Interval: "6g",
+					ProwJob:  &ProwJobVerification{Name: "openshift-e2e-aws"},
+				},
+			},
+		},
+		expectedErr: true,
+	}}
+	for _, testCase := range testCases {
+		errors := verifyPeriodicFields([]ReleaseConfig{testCase.input})
+		if testCase.expectedErr && len(errors) == 0 {
+			t.Errorf("%s: Expected error but none given", testCase.name)
+		}
+		if !testCase.expectedErr && len(errors) > 0 {
+			t.Errorf("%s: Did not expect error, received errors: %v", testCase.name, utilerrors.NewAggregate(errors))
+		}
+	}
+}
+
+func TestFindDuplicatePeriodics(t *testing.T) {
+	goodConfigs := []ReleaseConfig{{
+		Name: "4.5.0-0.nightly",
+		Periodic: map[string]ReleasePeriodic{
+			"upgrade": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
+				},
+			},
+			"upgrade-minor": {
+				Upgrade:     true,
+				UpgradeFrom: "PreviousMinor",
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.4-stable-to-4.5-nightly",
+				},
+			},
+		},
+	}, {
+		Name: "4.6.0-0.nightly",
+		Periodic: map[string]ReleasePeriodic{
+			"upgrade": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.6-nightly",
+				},
+			},
+			"upgrade-minor": {
+				Upgrade:     true,
+				UpgradeFrom: "PreviousMinor",
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
+				},
+			},
+		},
+	}}
+	sameConfigDuplicate := []ReleaseConfig{{
+		Name: "4.5.0-0.nightly",
+		Periodic: map[string]ReleasePeriodic{
+			"upgrade": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
+				},
+			},
+			"upgrade2": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
+				},
+			},
+			"upgrade-minor": {
+				Upgrade:     true,
+				UpgradeFrom: "PreviousMinor",
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.4-stable-to-4.5-nightly",
+				},
+			},
+		},
+	}, {
+		Name: "4.6.0-0.nightly",
+		Periodic: map[string]ReleasePeriodic{
+			"upgrade": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.6-nightly",
+				},
+			},
+			"upgrade-minor": {
+				Upgrade:     true,
+				UpgradeFrom: "PreviousMinor",
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
+				},
+			},
+		},
+	}}
+	differentConfigDuplicate := []ReleaseConfig{{
+		Name: "4.5.0-0.nightly",
+		Periodic: map[string]ReleasePeriodic{
+			"upgrade": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
+				},
+			},
+			"upgrade-minor": {
+				Upgrade:     true,
+				UpgradeFrom: "PreviousMinor",
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.4-stable-to-4.5-nightly",
+				},
+			},
+		},
+	}, {
+		Name: "4.6.0-0.nightly",
+		Periodic: map[string]ReleasePeriodic{
+			"upgrade": {
+				Upgrade: true,
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
+				},
+			},
+			"upgrade-minor": {
+				Upgrade:     true,
+				UpgradeFrom: "PreviousMinor",
+				ProwJob: &ProwJobVerification{
+					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
+				},
+			},
+		},
+	}}
+
+	testCases := []struct {
+		name          string
+		configs       []ReleaseConfig
+		errorExpected bool
+	}{{
+		name:          "Valid configs",
+		configs:       goodConfigs,
+		errorExpected: false,
+	}, {
+		name:          "Duplicate in one config",
+		configs:       sameConfigDuplicate,
+		errorExpected: true,
+	}, {
+		name:          "Duplicate in different configs",
+		configs:       differentConfigDuplicate,
+		errorExpected: true,
+	}}
+
+	for _, testCase := range testCases {
+		errs := findDuplicatePeriodics(testCase.configs)
+		if len(errs) == 0 && testCase.errorExpected {
+			t.Errorf("%s: Expected error but received no errors", testCase.name)
+		} else if len(errs) > 0 && !testCase.errorExpected {
+			t.Errorf("%s: Expected no error, but got errors: %v", testCase.name, errs)
+		}
+	}
+}

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -79,6 +79,8 @@ type options struct {
 	github         flagutil.GitHubOptions
 	bugzilla       flagutil.BugzillaOptions
 	githubThrottle int
+
+	validateConfigs string
 }
 
 func main() {
@@ -136,6 +138,8 @@ func main() {
 	flagset.StringVar(&opt.PluginConfig, "plugin-config", opt.PluginConfig, "Path to Prow plugin config file. Used when verifying bugs, ignored otherwise.")
 	flagset.IntVar(&opt.githubThrottle, "github-throttle", 0, "Maximum number of GitHub requests per hour. Used by bugzilla verifier.")
 
+	flagset.StringVar(&opt.validateConfigs, "validate-configs", "", "Validate configs at specified directory and exit without running operator")
+
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)
 	opt.bugzilla.AddFlags(goFlagSet)
@@ -149,6 +153,10 @@ func main() {
 }
 
 func (o *options) Run() error {
+	if o.validateConfigs != "" {
+		return validateConfigs(o.validateConfigs)
+	}
+
 	tagParts := strings.Split(o.ToolsImageStreamTag, ":")
 	if len(tagParts) != 2 || len(tagParts[1]) == 0 {
 		return fmt.Errorf("--tools-image-stream-tag must be STREAM:TAG or :TAG (default STREAM is the oldest release stream)")

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.15.0
+	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	k8s.io/api v0.18.5
 	k8s.io/apimachinery v0.18.5
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible


### PR DESCRIPTION
This PR adds a config validation mode to the release-controller that can
be run with the `--validate-configs` flag, which takes the directory
containing the configs as its value. It is intended to be run as a
presubmit in `openshift/release`. At the moment, it verifies that all
the release configs can be unmarshalled and does verification on the
periodic job configs. More verification functions can be added to it in
the future to validate that other parts of the release configs are valid
as well.

/cc @stevekuznetsov 