### PR TITLE
Files-cache messaging format fix

### DIFF
--- a/cmd/release-controller/info.go
+++ b/cmd/release-controller/info.go
@@ -642,7 +642,7 @@ class FileServer(handler):
                 os.remove(os.path.join(name, "DOWNLOADING.md"))
 
             except CalledProcessError as e:
-                print("Unable to get release tools for %s: %s" % name, e.output)
+                print("Unable to get release tools for %s: %s" % (name, e.output))
 
                 if e.output and ("no such image" in e.output or
                                   "image does not exist" in e.output or
@@ -658,7 +658,7 @@ class FileServer(handler):
                     outfile.write("Unable to get release tools: %s" % e.output)
 
             except Exception as e:
-                print("Unable to get release tools for %s: %s" % name, e.message)
+                print("Unable to get release tools for %s: %s" % (name, e.message))
                 self.log_error('An unexpected error has occurred: {}'.format(e.message))
 
             return


### PR DESCRIPTION
Someone reached out in slack stating that they were unable to download the
installer for a specific release.  Upon further investigation, it turns out
that there was a bug in the FileServer logic when handling the exceptions that
allow for the retrying of the downloads.  The specific error was:

```
File "/tmp/serve.py", line 67, in do_GET
  print("Unable to get release tools for %s: %s" % name, e.output)
TypeError: not enough arguments for format string
```

The fix is to enclose the values in parenthesis.