### PR TITLE
Updating ImageStream comparison logic

### DIFF
--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -108,7 +108,7 @@ func calculateMirrorImageStream(release *Release, is *imagev1.ImageStream) error
 			ref = &imagev1.TagReference{Name: tag.Tag}
 		} else {
 			// prevent unimported images from being skipped
-			if ref.Generation != nil && *ref.Generation != tag.Items[0].Generation {
+			if ref.Generation != nil && *ref.Generation > tag.Items[0].Generation {
 				return fmt.Errorf("the tag %q in the source input stream has not been imported yet", tag.Tag)
 			}
 			// use the tag ref as the source


### PR DESCRIPTION
Recently the release-controller has been struggling with images where
the `.status.tag` was ahead of the `.spec.tag`.  The logic in this PR
expected that these 2 values should be equal.  The fix is to error when
the `.spec.tag` is greater than the `.status.tag`.