### PR TITLE
Annotation: release.openshift.io/soft-delete

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -129,6 +129,8 @@ type Controller struct {
 	bugzillaVerifier *bugzilla.Verifier
 
 	dashboards []Dashboard
+
+	softDeleteReleaseTags bool
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -144,6 +146,7 @@ func NewController(
 	artifactsHost string,
 	releaseInfo ReleaseInfo,
 	graph *UpgradeGraph,
+	softDeleteReleaseTags bool,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -197,6 +200,8 @@ func NewController(
 		graph: graph,
 
 		parsedReleaseConfigCache: parsedReleaseConfigCache,
+
+		softDeleteReleaseTags: softDeleteReleaseTags,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -84,6 +84,8 @@ type options struct {
 	githubThrottle int
 
 	validateConfigs string
+
+	softDeleteReleaseTags bool
 }
 
 func main() {
@@ -147,6 +149,7 @@ func main() {
 	flagset.IntVar(&opt.githubThrottle, "github-throttle", 0, "Maximum number of GitHub requests per hour. Used by bugzilla verifier.")
 
 	flagset.StringVar(&opt.validateConfigs, "validate-configs", "", "Validate configs at specified directory and exit without running operator")
+	flagset.BoolVar(&opt.softDeleteReleaseTags, "soft-delete-release-tags", false, "If set to true, annotate imagestreamtags instead of deleting them")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)
@@ -281,6 +284,7 @@ func (o *options) Run() error {
 		o.ArtifactsHost,
 		releaseInfo,
 		graph,
+		o.softDeleteReleaseTags,
 	)
 
 	if o.VerifyBugzilla {

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -466,6 +466,9 @@ const (
 	// releaseAnnotationBugsVerified indicates whether or not the release has been
 	// processed by the BugzillaVerifier
 	releaseAnnotationBugsVerified = "release.openshift.io/bugs-verified"
+
+	// releaseAnnotationSoftDelete indicates automation external to the release controller can use this annotation to decide when, formatted with RFC3339, to clean up the tag
+	releaseAnnotationSoftDelete = "release.openshift.io/soft-delete"
 )
 
 type Duration time.Duration


### PR DESCRIPTION
The actual delete will be done by DPTP-CM: https://github.com/openshift/ci-tools/tree/master/cmd/dptp-controller-manager
We can revert this after migration of CI-Registry is done.

/hold

Wait for the deleting implementation with DPTP-CM.
https://github.com/openshift/ci-tools/pull/1483

/cc @stevekuznetsov @alvaroaleman 