### PR TITLE
[DPTP-1797] sync_verify: always set RELEASE_IMAGE_INITIAL for upgrades

### DIFF
--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -157,7 +157,7 @@ func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease Pe
 		}
 	}
 	spec := pjutil.PeriodicSpec(*periodicWithRelease.Periodic)
-	ok, err := addReleaseEnvToProwJobSpec(&spec, release, mirror, latestTag, previousReleasePullSpec)
+	ok, err := addReleaseEnvToProwJobSpec(&spec, release, mirror, latestTag, previousReleasePullSpec, periodicWithRelease.Upgrade)
 	if err != nil || !ok {
 		return fmt.Errorf("failed to add release env to periodic %s: %v", periodicWithRelease.Periodic.Name, err)
 	}


### PR DESCRIPTION
This PR changes the behavior of the release-controller to always set the
`RELEASE_IMAGE_INITAL` env var for upgrade release jobs.  Previously, it
would only do this if the job contained the env var in its job spec,
which means that any generated upgrade job would not be able to properly
be run by release-controller. This also means that upgrade jobs
configured to be run by release-controller would not be able to be
rehearsed, as the required empty `RELEASE_IMAGE_INITIAL` in the
rehearsal would cause the ci-operator incorrectly set the pullspec to an
empty string.

/cc @stevekuznetsov 