### PR TITLE
periodic: only set interval duration if interval != ""

### DIFF
--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -64,12 +64,14 @@ func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, s
 				// make copy of periodic with updated interval and cron values
 				updatedPeriodicConfig := *periodicConfig
 				updatedPeriodicConfig.Interval = releasePeriodic.Interval
-				intervalDuration, err := time.ParseDuration(releasePeriodic.Interval)
-				if err != nil {
-					klog.Errorf("could not parse interval for periodic job %s/%s: %v", r.Config.Name, name, err)
-					continue
+				if updatedPeriodicConfig.Interval != "" {
+					intervalDuration, err := time.ParseDuration(releasePeriodic.Interval)
+					if err != nil {
+						klog.Errorf("could not parse interval for periodic job %s/%s: %v", r.Config.Name, name, err)
+						continue
+					}
+					updatedPeriodicConfig.SetInterval(intervalDuration)
 				}
-				updatedPeriodicConfig.SetInterval(intervalDuration)
 				updatedPeriodicConfig.Cron = releasePeriodic.Cron
 				releasePeriodics[periodicConfig.Name] = PeriodicWithRelease{
 					Periodic:           &updatedPeriodicConfig,


### PR DESCRIPTION
This was causing release-controller to skip jobs configured via cron instead of interval.