### PR TITLE
controller: don't process ImageStreams without a repo

### DIFF
--- a/cmd/release-controller/release.go
+++ b/cmd/release-controller/release.go
@@ -30,6 +30,11 @@ func (c *Controller) releaseDefinition(is *imagev1.ImageStream) (*Release, bool,
 		return nil, false, terminalError{err}
 	}
 
+	if is.Status.PublicDockerImageRepository == "" {
+		klog.V(4).Infof("The release input has no public docker image repository, waiting")
+		return nil, false, nil
+	}
+
 	if len(is.Status.Tags) == 0 {
 		klog.V(4).Infof("The release input has no status tags, waiting")
 		return nil, false, nil


### PR DESCRIPTION
In some cases, we see an ImageStream before the OCP controller manager
has been able to populate it's public image repository URL in the
status. We cannot use this ImageStream yet as we do not know from where
to pull images in this stream. Just wait and re-queue later.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>