### PR TITLE
Make oc adm mirror operation use internal registry name

### DIFF
--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -53,7 +53,7 @@ func (c *Controller) ensureRewriteJob(release *Release, name string, mirror *ima
 		releaseAnnotationGeneration: strconv.FormatInt(generation, 10),
 	}
 	return c.ensureJob(name, preconditions, func() (*batchv1.Job, error) {
-		toImage := fmt.Sprintf("%s:%s", release.Source.Status.PublicDockerImageRepository, name)
+		toImage := fmt.Sprintf("%s:%s", release.Source.Status.DockerImageRepository, name)
 		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)
 		if len(release.Config.OverrideCLIImage) > 0 {
 			cliImage = release.Config.OverrideCLIImage


### PR DESCRIPTION
A change in the behavior of OCP4 makes the external registry name
unavailable by default in the pullsecret. Use internal name.

4.6.10 mirroring jobs presently failing with:
```
$ oc logs -n ci-release 4.6.10-xwwsx
Saved credentials for registry.ci.openshift.org
warning: An image was retrieved that failed verification: unable to locate a valid signature for one or more sources
error: unable to import a release image: release: Internal error occurred: registry.ci.openshift.org/ocp/release:4.6.10: Get "https://registry.ci.openshift.org/v2/ocp/release/manifests/4.6.10": unauthorized: authentication required
```

Potentially fewer unexpected side effects with this approach: https://github.com/openshift/release-controller/pull/247