### PR TITLE
Adding the 'release.openshift.io/architecture' annotation to prow jobs

### DIFF
--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -22,7 +22,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 		{
 			tags: []*imagev1.TagReference{},
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				return g
 			},
 			want: &ReleaseUpgrades{
@@ -36,7 +36,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				{Name: "4.0.0"},
 			},
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				return g
 			},
 			want: &ReleaseUpgrades{
@@ -54,7 +54,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				{Name: "4.0.0-9"},
 			},
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				g.Add("4.0.0", "4.0.1", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
 				return g
 			},
@@ -89,7 +89,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				{Name: "4.0.1"},
 			},
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				g.Add("4.0.4", "4.0.5", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
 				g.Add("4.0.3", "4.0.5", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
 				g.Add("4.0.0", "4.0.2", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
@@ -141,7 +141,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				{Name: "4.1.0-0.test-06"},
 			},
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				g.Add("4.1.0-0.test-08", "4.1.0-0.test-09", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
 				g.Add("4.1.0-0.test-07", "4.1.0-0.test-08", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
 				g.Add("4.1.0-rc.0", "4.1.0-0.test-08", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -278,7 +278,7 @@ func (o *options) Run() error {
 
 	execReleaseFiles := NewExecReleaseFiles(toolsClient, toolsConfig, o.JobNamespace, releaseNamespace, releaseNamespace, imageCache.Get)
 
-	graph := NewUpgradeGraph()
+	graph := NewUpgradeGraph(architecture)
 
 	c := NewController(
 		client.CoreV1(),

--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -170,6 +170,7 @@ func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease Pe
 	if periodicWithRelease.Upgrade && len(previousTag) > 0 {
 		prowJob.Annotations[releaseAnnotationFromTag] = previousTag
 	}
+	prowJob.Annotations[releaseAnnotationArchitecture] = c.graph.architecture
 
 	_, err = c.prowClient.Create(context.TODO(), objectToUnstructured(&prowJob), metav1.CreateOptions{})
 	if err != nil {

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -80,6 +80,7 @@ func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName str
 	if verifyType.Upgrade && len(previousTag) > 0 {
 		pj.Annotations[releaseAnnotationFromTag] = previousTag
 	}
+	pj.Annotations[releaseAnnotationArchitecture] = c.graph.architecture
 	out, err := c.prowClient.Create(context.TODO(), objectToUnstructured(&pj), metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
 		// find a cached version or do a live call

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -469,6 +469,9 @@ const (
 
 	// releaseAnnotationSoftDelete indicates automation external to the release controller can use this annotation to decide when, formatted with RFC3339, to clean up the tag
 	releaseAnnotationSoftDelete = "release.openshift.io/soft-delete"
+
+	// releaseAnnotationArchitecture indicates the architecture of the release
+	releaseAnnotationArchitecture = "release.openshift.io/architecture"
 )
 
 type Duration time.Duration

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -34,12 +34,14 @@ type UpgradeGraph struct {
 	lock sync.Mutex
 	to   map[string]map[string]*UpgradeHistory
 	from map[string]sets.String
+	architecture string
 }
 
-func NewUpgradeGraph() *UpgradeGraph {
+func NewUpgradeGraph(architecture string) *UpgradeGraph {
 	return &UpgradeGraph{
 		to:   make(map[string]map[string]*UpgradeHistory),
 		from: make(map[string]sets.String),
+		architecture: architecture,
 	}
 }
 

--- a/cmd/release-controller/upgrades_test.go
+++ b/cmd/release-controller/upgrades_test.go
@@ -17,7 +17,7 @@ func TestUpgradeGraph_UpgradesFrom(t *testing.T) {
 	}{
 		{
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"})
 				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"})
 				g.Add("1.0.1", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"})
@@ -70,7 +70,7 @@ func TestUpgradeGraph_UpgradesTo(t *testing.T) {
 	}{
 		{
 			graph: func() *UpgradeGraph {
-				g := NewUpgradeGraph()
+				g := NewUpgradeGraph("amd64")
 				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"})
 				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"})
 				g.Add("1.0.1", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"})


### PR DESCRIPTION
Introducing the `release.openshift.io/architecture` annotation to be applied to all the prowjobs created by the release-controller. 
 This annotation will eventually be used to filter prowjobs, by their respective architecture, prior to inserting data into the upgrade graph.