### PR TITLE
Only add upgradeResults for the specified architecture

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -424,12 +424,20 @@ func (o *options) Run() error {
 					if !ok {
 						continue
 					}
-					from, ok := job.GetAnnotations()[releaseAnnotationFromTag]
+					annotations := job.GetAnnotations()
+					from, ok := annotations[releaseAnnotationFromTag]
 					if !ok {
 						continue
 					}
-					to, ok := job.GetAnnotations()[releaseAnnotationToTag]
+					to, ok := annotations[releaseAnnotationToTag]
 					if !ok {
+						continue
+					}
+					jobArchitecture, ok := annotations[releaseAnnotationArchitecture]
+					if !ok {
+						continue
+					}
+					if jobArchitecture != architecture {
 						continue
 					}
 					status, ok := prowJobVerificationStatus(job)


### PR DESCRIPTION
Now that both the release-controller and the ci-chat-bot are adding
the `release.openshift.io/architecture` annotation to their prowjobs,
we can prevent updating the release-upgrade-graph with jobs that do
not correspond to the architecture specified to the release-controller.