### PR TITLE
[WIP] Limiting graph updates to releaseNamespace

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -523,7 +523,7 @@ func (o *options) Run() error {
 					if jobArchitecture != architecture {
 						continue
 					}
-					jobSource, ok := annotations[releaseAnnotationSource]
+					jobSource, ok := annotations[releasecontroller.ReleaseAnnotationSource]
 					if !ok {
 						continue
 					}

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -523,6 +523,13 @@ func (o *options) Run() error {
 					if jobArchitecture != architecture {
 						continue
 					}
+					jobSource, ok := annotations[releaseAnnotationSource]
+					if !ok {
+						continue
+					}
+					if strings.Split(jobSource, "/")[0] != releaseNamespace {
+						continue
+					}
 					status, ok := releasecontroller.ProwJobVerificationStatus(job)
 					if !ok {
 						continue


### PR DESCRIPTION
I noticed that the `origin/release-upgrade/graph` is full of upgrades from `ocp`.  This is because the prowjob informer is sending the same updates to both release-controllers.  Usually, the architecture check prevents cross-contamination of the graphs.  Unfortunately, both `origin` and `ocp` are running against `amd64`.  This PR adds another check that ensures that the job's "Source" namespace matches the "releaseNamespace" of the release-controller.