### PR TITLE
validate: add validation for release informing jobs

### DIFF
--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -116,7 +116,7 @@ func validateDefinedReleaseControllerJobs(jobConfig prowconfig.JobConfig, releas
 	releaseConfigJobs := sets.NewString()
 	for _, config := range releaseConfigs {
 		for _, verify := range config.Verify {
-			if verify.ProwJob != nil {
+			if verify.ProwJob != nil && !verify.Disabled {
 				releaseConfigJobs.Insert(verify.ProwJob.Name)
 			}
 		}

--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -134,15 +134,11 @@ func validateDefinedReleaseControllerJobs(jobConfig prowconfig.JobConfig, releas
 		}
 	}
 	var errs []error
-	for rcJob := range releaseConfigJobs {
-		if !releaseJobs.Has(rcJob) {
-			errs = append(errs, fmt.Errorf("job configured in release-controller config not defined as a release-controller job: %s", rcJob))
-		}
+	if rcJobs := releaseConfigJobs.Difference(releaseJobs); len(rcJobs) > 0 {
+		errs = append(errs, fmt.Errorf("job(s) configured in release-controller config not defined as a release-controller job(s): %v", rcJobs.List()))
 	}
-	for job := range releaseJobs {
-		if !releaseConfigJobs.Has(job) {
-			errs = append(errs, fmt.Errorf("job defined as release-controller job not configured in release-controller configs: %s", job))
-		}
+	if jobs := releaseJobs.Difference(releaseConfigJobs); len(jobs) > 0 {
+		errs = append(errs, fmt.Errorf("job(s) defined as release-controller job not configured in release-controller configs: %v", jobs.List()))
 	}
 	return errs
 }

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -444,30 +444,6 @@ func TestValidateDefinedReleaseInformingJobs(t *testing.T) {
 		rcVerify:    map[string]ReleaseVerification{},
 		expectedErr: true,
 	}, {
-		name: "missing job periodic defined in release-controller verification",
-		periodics: []prowconfig.Periodic{{
-			JobBase: prowconfig.JobBase{
-				Name: "periodic3",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/release-controller": "true",
-				},
-			},
-		}},
-		rcPeriodics: map[string]ReleasePeriodic{},
-		rcVerify: map[string]ReleaseVerification{
-			"third": {
-				ProwJob: &ProwJobVerification{
-					Name: "periodic3",
-				},
-			},
-			"fourth": {
-				ProwJob: &ProwJobVerification{
-					Name: "periodic4",
-				},
-			},
-		},
-		expectedErr: true,
-	}, {
 		name: "missing release controller periodic",
 		periodics: []prowconfig.Periodic{{
 			JobBase: prowconfig.JobBase{
@@ -493,6 +469,31 @@ func TestValidateDefinedReleaseInformingJobs(t *testing.T) {
 		},
 		rcVerify:    map[string]ReleaseVerification{},
 		expectedErr: true,
+	}, {
+		name: "disabled verification does not require match",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic3",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{},
+		rcVerify: map[string]ReleaseVerification{
+			"third": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic3",
+				},
+			},
+			"fourth": {
+				Disabled: true,
+				ProwJob: &ProwJobVerification{
+					Name: "periodic4",
+				},
+			},
+		},
+		expectedErr: false,
 	}, {
 		name: "missing release controller verification",
 		periodics: []prowconfig.Periodic{{

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	prowconfig "k8s.io/test-infra/prow/config"
 )
 
 func TestVerifyPeriodicFields(t *testing.T) {
@@ -352,5 +353,212 @@ func TestValidateUpgradeJobs(t *testing.T) {
 		if len(errs) == 0 && testCase.expectedErr {
 			t.Errorf("%s: did not get error when error was expected", testCase.name)
 		}
+	}
+}
+
+func TestValidateDefinedReleaseInformingJobs(t *testing.T) {
+	testCases := []struct {
+		name        string
+		periodics   []prowconfig.Periodic
+		rcPeriodics map[string]ReleasePeriodic
+		rcVerify    map[string]ReleaseVerification
+		expectedErr bool
+	}{{
+		name: "exact match",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic1",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}, {
+			JobBase: prowconfig.JobBase{
+				Name: "periodic2",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}, {
+			JobBase: prowconfig.JobBase{
+				Name: "periodic3",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}, {
+			JobBase: prowconfig.JobBase{
+				Name: "periodic4",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{
+			"first": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic1",
+				},
+			},
+			"second": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic2",
+				},
+			},
+		},
+		rcVerify: map[string]ReleaseVerification{
+			"third": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic3",
+				},
+			},
+			"fourth": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic4",
+				},
+			},
+		},
+		expectedErr: false,
+	}, {
+		name: "missing job periodic defined in release-controller periodic",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic1",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{
+			"first": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic1",
+				},
+			},
+			"second": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic2",
+				},
+			},
+		},
+		rcVerify:    map[string]ReleaseVerification{},
+		expectedErr: true,
+	}, {
+		name: "missing job periodic defined in release-controller verification",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic3",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{},
+		rcVerify: map[string]ReleaseVerification{
+			"third": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic3",
+				},
+			},
+			"fourth": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic4",
+				},
+			},
+		},
+		expectedErr: true,
+	}, {
+		name: "missing release controller periodic",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic1",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}, {
+			JobBase: prowconfig.JobBase{
+				Name: "periodic2",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{
+			"first": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic1",
+				},
+			},
+		},
+		rcVerify:    map[string]ReleaseVerification{},
+		expectedErr: true,
+	}, {
+		name: "missing release controller verification",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic3",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}, {
+			JobBase: prowconfig.JobBase{
+				Name: "periodic4",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{},
+		rcVerify: map[string]ReleaseVerification{
+			"third": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic3",
+				},
+			},
+		},
+		expectedErr: true,
+	}, {
+		name: "job config not labeled as release informing",
+		periodics: []prowconfig.Periodic{{
+			JobBase: prowconfig.JobBase{
+				Name: "periodic1",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/release-controller": "true",
+				},
+			},
+		}, {
+			JobBase: prowconfig.JobBase{
+				Name: "periodic2",
+			},
+		}},
+		rcPeriodics: map[string]ReleasePeriodic{
+			"first": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic1",
+				},
+			},
+			"second": {
+				ProwJob: &ProwJobVerification{
+					Name: "periodic2",
+				},
+			},
+		},
+		rcVerify:    map[string]ReleaseVerification{},
+		expectedErr: true,
+	}}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			jobConfig := prowconfig.JobConfig{Periodics: testCase.periodics}
+			releaseConfig := []ReleaseConfig{{Periodic: testCase.rcPeriodics, Verify: testCase.rcVerify}}
+			errs := validateDefinedReleaseControllerJobs(jobConfig, releaseConfig)
+			if errs != nil && !testCase.expectedErr {
+				t.Errorf("Got errors when non were expected: %v", errs)
+			}
+			if errs == nil && testCase.expectedErr {
+				t.Errorf("Got no errors when errors were expected")
+			}
+		})
 	}
 }

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -179,7 +179,7 @@ func main() {
 
 func (o *options) Run() error {
 	if o.validateConfigs != "" {
-		return validateConfigs(o.validateConfigs)
+		return validateConfigs(o.validateConfigs, o.prowconfig.ConfigPath, o.prowconfig.JobConfigPath)
 	}
 
 	tagParts := strings.Split(o.ToolsImageStreamTag, ":")


### PR DESCRIPTION
A new field has been added to ci-operator that adds a label to jobs to
define them as release-controller jobs. This reduces confusion when
defining jobs in ci-operator configs that are supposed to be executed
periodically or as verification by release-controller.

This PR adds validation to make sure that all jobs defined as periodics
or verification in release-controller have the correct label on the job
config, and all job configs with the label are exist in the
release-controller configs.