### PR TITLE
Adding the ability to specify the CI Auth message on the commandline

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -131,6 +131,7 @@ type Controller struct {
 	dashboards []Dashboard
 
 	softDeleteReleaseTags bool
+	disableAuthMessage    bool
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -147,6 +148,7 @@ func NewController(
 	releaseInfo ReleaseInfo,
 	graph *UpgradeGraph,
 	softDeleteReleaseTags bool,
+	disableAuthMessage bool,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -202,6 +204,7 @@ func NewController(
 		parsedReleaseConfigCache: parsedReleaseConfigCache,
 
 		softDeleteReleaseTags: softDeleteReleaseTags,
+		disableAuthMessage: disableAuthMessage,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -131,7 +131,7 @@ type Controller struct {
 	dashboards []Dashboard
 
 	softDeleteReleaseTags bool
-	disableAuthMessage    bool
+	authenticationMessage string
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -148,7 +148,7 @@ func NewController(
 	releaseInfo ReleaseInfo,
 	graph *UpgradeGraph,
 	softDeleteReleaseTags bool,
-	disableAuthMessage bool,
+	authenticationMessage string,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -204,7 +204,7 @@ func NewController(
 		parsedReleaseConfigCache: parsedReleaseConfigCache,
 
 		softDeleteReleaseTags: softDeleteReleaseTags,
-		disableAuthMessage: disableAuthMessage,
+		authenticationMessage: authenticationMessage,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -958,8 +958,8 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 	}
 
 	authMessage := ""
-	if !c.disableAuthMessage {
-		authMessage = "<p>Pulling these images requires <a href=\"https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/\">authenticating to the app.ci cluster</a>.</p>"
+	if len(c.authenticationMessage) > 0 {
+		authMessage = fmt.Sprintf("<p>%s</p>", c.authenticationMessage)
 	}
 
 	now := time.Now()

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -60,7 +60,7 @@ const releasePageHtml = `
 oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}graph"}}' --type=merge
 </pre>
 <div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
-<p>Pulling these images requires <a href="https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/">authenticating to the app.ci cluster</a>.</p>
+{{ displayAuthMessage }}
 <style>
 .upgrade-track-line {
 	position: absolute;
@@ -957,6 +957,11 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 		Dashboards: c.dashboards,
 	}
 
+	authMessage := ""
+	if !c.disableAuthMessage {
+		authMessage = "<p>Pulling these images requires <a href=\"https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/\">authenticating to the app.ci cluster</a>.</p>"
+	}
+
 	now := time.Now()
 	var releasePage = template.Must(template.New("releasePage").Funcs(
 		template.FuncMap{
@@ -1036,6 +1041,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 				}
 				return relTime(t, now, "ago", "from now")
 			},
+			"displayAuthMessage": func() string { return authMessage },
 		},
 	).Parse(releasePageHtml))
 

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -90,7 +90,7 @@ type options struct {
 
 	ReleaseArchitecture string
 
-	disableAuthMessage bool
+	AuthenticationMessage string
 }
 
 func main() {
@@ -160,7 +160,7 @@ func main() {
 
 	flagset.StringVar(&opt.ReleaseArchitecture, "release-architecture", opt.ReleaseArchitecture, "The architecture of the releases to be created (defaults to 'amd64' if not specified).")
 
-	flagset.BoolVar(&opt.disableAuthMessage, "disable-auth-message", false, "If set to true, disables the CI authentication message")
+	flagset.StringVar(&opt.AuthenticationMessage, "authentication-message", opt.AuthenticationMessage, "HTML formatted string to display a registry authentication message")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)
@@ -305,7 +305,7 @@ func (o *options) Run() error {
 		releaseInfo,
 		graph,
 		o.softDeleteReleaseTags,
-		o.disableAuthMessage,
+		o.AuthenticationMessage,
 	)
 
 	if o.VerifyBugzilla {

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -89,6 +89,8 @@ type options struct {
 	softDeleteReleaseTags bool
 
 	ReleaseArchitecture string
+
+	disableAuthMessage bool
 }
 
 func main() {
@@ -157,6 +159,8 @@ func main() {
 	flagset.BoolVar(&opt.softDeleteReleaseTags, "soft-delete-release-tags", false, "If set to true, annotate imagestreamtags instead of deleting them")
 
 	flagset.StringVar(&opt.ReleaseArchitecture, "release-architecture", opt.ReleaseArchitecture, "The architecture of the releases to be created (defaults to 'amd64' if not specified).")
+
+	flagset.BoolVar(&opt.disableAuthMessage, "disable-auth-message", false, "If set to true, disables the CI authentication message")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)
@@ -301,6 +305,7 @@ func (o *options) Run() error {
 		releaseInfo,
 		graph,
 		o.softDeleteReleaseTags,
+		o.disableAuthMessage,
 	)
 
 	if o.VerifyBugzilla {


### PR DESCRIPTION
@vrutkovs  has requested the ability to remove the following message from the
UI for the OKD release-controller:
   `Pulling these images requires authenticating to the app.ci cluster.`
This PR switches the existing logic around to accept a message to display, when necessary, for authenticating to a registry.  The message can be enabled by specifying the following option: `--authentication-message`
The current logic can be achieved by specifying the following:
```
--authentication-message="Pulling these images requires <a href=\"https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/\">authenticating to the app.ci cluster</a>."
```