### PR TITLE
Propagate labels from release source to target

### DIFF
--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -29,6 +29,7 @@ func (c *Controller) ensureReleaseMirror(release *Release, releaseTagName, input
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mirrorName,
 			Namespace: release.Source.Namespace,
+			Labels: release.Source.Labels,
 			Annotations: map[string]string{
 				releaseAnnotationSource:     fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
 				releaseAnnotationTarget:     fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name),


### PR DESCRIPTION
This will allow ART to easily correlate an update to the source imagestream with the nightly it ultimately creates.
Within `4.x-art-latest`, ART will put a uniquely identifying label in the source. We can then watch for a new imagestream with that label to determine the name of the resulting nightly.