### PR TITLE
sync_verify_prow: always set an initial release

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -156,7 +156,12 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *Release, m
 		if !hasReleaseImage {
 			c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 		}
-		if isUpgrade && !hasUpgradeImage {
+		if !isUpgrade {
+			// If an initial release is specified in the ci-operator config, ci-operator will always try to pull it. This can cause jobs to fail
+			// if there are not at least 2 accepted releases for the release being tested. To prevent this issue, always set RELEASE_IMAGE_INITIAL,
+			// even for non-upgrade jobs
+			c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+		} else if !hasUpgradeImage {
 			if len(previousReleasePullSpec) == 0 {
 				return false, nil
 			}


### PR DESCRIPTION
This PR fixes an issue where ci-operator would fail to start a job as it
would try to pull a non-existant release based on the `releases`
configured in the ci-operator config. This situation could occur on
creation of a new release or when many tags fail to be accepted and only
1 accepted tag exists for a release. To fix this, we configure
  release-controller to always set the initial release image to override
what is defined in the ci-operator config.