### PR TITLE
Changes to allow relocation to any cluster without changing code

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -163,7 +163,7 @@ func main() {
 
 	flagset.StringVar(&opt.AuthenticationMessage, "authentication-message", opt.AuthenticationMessage, "HTML formatted string to display a registry authentication message")
 
-	flagset.StringVar(&opt.Registry, "registry", opt.Registry, "Specify an alternate image registry to reference.  This option should be used when running the controller on a different cluster.")
+	flagset.StringVar(&opt.Registry, "registry", opt.Registry, "Specify the registry, that the artifact server will use, to retrieve release images when located on remote clusters")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -91,6 +91,8 @@ type options struct {
 	ReleaseArchitecture string
 
 	AuthenticationMessage string
+
+	Registry string
 }
 
 func main() {
@@ -106,8 +108,8 @@ func main() {
 
 	opt := &options{
 		ListenAddr: ":8080",
-
 		ToolsImageStreamTag: ":tests",
+		Registry: "registry.ci.openshift.org",
 	}
 	cmd := &cobra.Command{
 		Run: func(cmd *cobra.Command, arguments []string) {
@@ -160,6 +162,8 @@ func main() {
 	flagset.StringVar(&opt.ReleaseArchitecture, "release-architecture", opt.ReleaseArchitecture, "The architecture of the releases to be created (defaults to 'amd64' if not specified).")
 
 	flagset.StringVar(&opt.AuthenticationMessage, "authentication-message", opt.AuthenticationMessage, "HTML formatted string to display a registry authentication message")
+
+	flagset.StringVar(&opt.Registry, "registry", opt.Registry, "The image registry to use")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)
@@ -288,7 +292,7 @@ func (o *options) Run() error {
 	execReleaseInfo := NewExecReleaseInfo(toolsClient, toolsConfig, o.JobNamespace, releaseNamespace, imageCache.Get)
 	releaseInfo := NewCachingReleaseInfo(execReleaseInfo, 64*1024*1024)
 
-	execReleaseFiles := NewExecReleaseFiles(toolsClient, toolsConfig, o.JobNamespace, releaseNamespace, releaseNamespace, imageCache.Get)
+	execReleaseFiles := NewExecReleaseFiles(toolsClient, toolsConfig, o.JobNamespace, releaseNamespace, releaseNamespace, o.Registry, imageCache.Get)
 
 	graph := NewUpgradeGraph(architecture)
 

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -163,7 +163,7 @@ func main() {
 
 	flagset.StringVar(&opt.AuthenticationMessage, "authentication-message", opt.AuthenticationMessage, "HTML formatted string to display a registry authentication message")
 
-	flagset.StringVar(&opt.Registry, "registry", opt.Registry, "The image registry to use")
+	flagset.StringVar(&opt.Registry, "registry", opt.Registry, "Specify an alternate image registry to reference.  This option should be used when running the controller on a different cluster.")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)


### PR DESCRIPTION
I have been setting up an environment, on the DPCR cluster, to allow us to test changes, to the release-controller, on.    This PR will allow the release-controller to be run, successfully, on another cluster without having to make any changes to the code.  This can be accomplished by adding the `--registry` option and specifying the name of the registry to use, instead of the default: `registry.ci.openshift.org`. 