### PR TITLE
Release analysis jobs

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -474,6 +474,11 @@ func (c *Controller) syncReady(release *Release) error {
 	}
 
 	for _, releaseTag := range readyTags {
+		err := c.ensureAnalysisJobs(release, releaseTag)
+		if err != nil {
+			klog.Errorf("Unable to launch analysis job: %v", err)
+		}
+
 		status, err := c.ensureVerificationJobs(release, releaseTag)
 		if err != nil {
 			return err

--- a/cmd/release-controller/sync_analysis.go
+++ b/cmd/release-controller/sync_analysis.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	imagev1 "github.com/openshift/api/image/v1"
+	"k8s.io/klog"
+)
+
+func (c *Controller) ensureAnalysisJobs(release *Release, releaseTag *imagev1.TagReference) error {
+	for name, analysisType := range release.Config.Analysis {
+		if analysisType.Disabled {
+			klog.V(2).Infof("Release %s analysis step %s is disabled, ignoring", releaseTag.Name, name)
+			continue
+		}
+		if analysisType.AnalysisJobCount == 0 {
+			klog.Warningf("Release %s analysis step %s configured without analysisJobCount, ignoring", releaseTag.Name, name)
+			continue
+		}
+
+		// TODO: How do we want to track these jobs...
+		jobLabels := map[string]string{
+			"release.openshift.io/analysis": releaseTag.Name,
+		}
+
+		switch {
+		case analysisType.ProwJob != nil:
+			// if this is an upgrade job, find the appropriate source for the upgrade job
+			var previousTag, previousReleasePullSpec string
+			if analysisType.Upgrade {
+				var err error
+				previousTag, previousReleasePullSpec, err = c.getUpgradeTagAndPullSpec(release, releaseTag, name, analysisType.UpgradeFrom, analysisType.UpgradeFromRelease, false)
+				if err != nil {
+					return err
+				}
+			}
+			for i := 1; i <= analysisType.AnalysisJobCount; i++ {
+				jobName := fmt.Sprintf("%s-analysis-%d", name, i)
+				_, err := c.ensureProwJobForReleaseTag(release, jobName, analysisType, releaseTag, previousTag, previousReleasePullSpec, jobLabels)
+				if err != nil {
+					return err
+				}
+			}
+		default:
+			// manual verification
+		}
+	}
+	return nil
+}

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -41,7 +41,7 @@ func (c *Controller) ensureReleaseJob(release *Release, name string, mirror *ima
 		job.Annotations[releaseAnnotationGeneration] = strconv.FormatInt(release.Target.Generation, 10)
 		job.Annotations[releaseAnnotationReleaseTag] = mirror.Annotations[releaseAnnotationReleaseTag]
 
-		klog.V(2).Infof("Running release creation job %s/%s for %s", job.Namespace, job.Name, name)
+		klog.V(2).Infof("Running release creation job %s/%s for %s", c.jobNamespace, job.Name, name)
 		return job, nil
 	})
 }

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -77,8 +77,10 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 			if jobRetries > 0 {
 				jobName = fmt.Sprintf("%s-%d", jobName, jobRetries)
 			}
-
-			job, err := c.ensureProwJobForReleaseTag(release, jobName, verifyType, releaseTag, previousTag, previousReleasePullSpec)
+			jobLabels := map[string]string{
+				"release.openshift.io/verify": "true",
+			}
+			job, err := c.ensureProwJobForReleaseTag(release, jobName, verifyType, releaseTag, previousTag, previousReleasePullSpec, jobLabels)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -20,7 +20,7 @@ import (
 	prowutil "k8s.io/test-infra/prow/pjutil"
 )
 
-func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName string, verifyType ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string) (*unstructured.Unstructured, error) {
+func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName string, verifyType ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string, extraLabels map[string]string) (*unstructured.Unstructured, error) {
 	jobName := verifyType.ProwJob.Name
 	prowJobName := fmt.Sprintf("%s-%s", releaseTag.Name, verifyName)
 	obj, exists, err := c.prowLister.GetByKey(fmt.Sprintf("%s/%s", c.prowNamespace, prowJobName))
@@ -56,9 +56,7 @@ func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName str
 	if err != nil {
 		return nil, err
 	}
-	pj := prowutil.NewProwJob(spec, map[string]string{
-		"release.openshift.io/verify": "true",
-	}, map[string]string{
+	pj := prowutil.NewProwJob(spec, extraLabels, map[string]string{
 		releaseAnnotationSource: fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
 	})
 	// Override default UUID naming of prowjob

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -119,6 +119,10 @@ type ReleaseConfig struct {
 	// Check is a map of short names to check routines that report additional information
 	// about the health or quality of this stream to the user interface.
 	Check map[string]ReleaseCheck `json:"check"`
+
+	// Analysis is a map of short names to analysis steps to run to check the overall
+	// stability of a particular release.
+	Analysis map[string]ReleaseVerification `json:"analysis"`
 }
 
 type ReleaseCheck struct {
@@ -220,6 +224,8 @@ type ReleaseVerification struct {
 	ProwJob *ProwJobVerification `json:"prowJob"`
 	// Maximum retry attempts for the job. Defaults to 0 - do not retry on fail
 	MaxRetries int `json:"maxRetries,omitempty"`
+	// AnalysisJobCount Number of asynchronous jobs to execute for release analysis.
+	AnalysisJobCount int `json:"analysisJobCount,omitempty"`
 }
 
 // ReleasePeriodic is a job that runs on the speicifed cron or interval period as a

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -31,16 +31,16 @@ type UpgradeRecord struct {
 }
 
 type UpgradeGraph struct {
-	lock sync.Mutex
-	to   map[string]map[string]*UpgradeHistory
-	from map[string]sets.String
+	lock         sync.Mutex
+	to           map[string]map[string]*UpgradeHistory
+	from         map[string]sets.String
 	architecture string
 }
 
 func NewUpgradeGraph(architecture string) *UpgradeGraph {
 	return &UpgradeGraph{
-		to:   make(map[string]map[string]*UpgradeHistory),
-		from: make(map[string]sets.String),
+		to:           make(map[string]map[string]*UpgradeHistory),
+		from:         make(map[string]sets.String),
 		architecture: architecture,
 	}
 }


### PR DESCRIPTION
This PR is to enable the changes that @deads2k is working towards for release analysis.  Currently, these changes will have no impact until a new "analysis" stanza is added to a release's release configuration.

An example entry looks like:
```
  "analysis": {
    "upgrade": {
      "upgrade": true,
      "optional": true,
      "prowJob": {
        "name": "periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade"
      },
      "analysisJobCount": 2
    }
  }
```
The analysis entries are just `ReleaseVerification` blocks that support a new optional parameter: *analysisJobCount*
If not specified, the *analysisJobCount* defaults to executing: *10* instances of the specified job.  There is currently a hardcoded maximum limit, of 20 jobs that can be executed concurrently.  

The prowjobs that are created by this process have the following naming scheme:  
`<release tag>-<analysis name>-analysis-<counter>`

Therefore, the prowjobs for any specific release will look similar to:
```
$ dpcr -n ci-release get prowjobs | grep 201602
4.9.0-0.nightly-2021-07-09-201602-aws                  periodic-ci-openshift-release-master-nightly-4.9-e2e-aws                     periodic                        24m         
4.9.0-0.nightly-2021-07-09-201602-upgrade-analysis-1   periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade             periodic                        24m         
4.9.0-0.nightly-2021-07-09-201602-upgrade-analysis-2   periodic-ci-openshift-release-master-nightly-4.9-e2e-aws-upgrade             periodic                        24m 
```

The "analysis" jobs are not tracked by the release-controller and have no bearing on the Acceptance of the release.  

I have added a new label, to provide a convenient way for processing the results of these jobs, via their release tag:
`"release.openshift.io/analysis": "4.9.0-0.nightly-2021-07-09-201602"`
