### PR TITLE
Adding simple /healthz and /healthz/ready endpoints

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -392,6 +392,8 @@ func (o *options) Run() error {
 	if len(o.ListenAddr) > 0 {
 		http.DefaultServeMux.Handle("/metrics", promhttp.Handler())
 		http.DefaultServeMux.HandleFunc("/graph", c.graphHandler)
+		http.DefaultServeMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "OK") })
+		http.DefaultServeMux.HandleFunc("/healthz/ready", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, "OK") })
 		http.DefaultServeMux.Handle("/", c.userInterfaceHandler())
 		go func() {
 			klog.Infof("Listening on %s for UI and metrics", o.ListenAddr)


### PR DESCRIPTION
The DPTP folks have opened [DPCR-80](https://issues.redhat.com/browse/DPCR-80) for us to address the fact that the release-controller is frequently unavailable.  Part of the request is that we should add readiness and liveness probes.  This PR adds 2 endpoints to facilitate these probes.