### PR TITLE
Sync Dockerfile and ci-operator config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.16

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openshift/origin-release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.16
 WORKDIR /go/src/github.com/openshift/release-controller
 COPY . .
 RUN make build
 
-FROM centos:8
+FROM registry.ci.openshift.org/origin/centos:8
 COPY --from=0 /go/src/github.com/openshift/release-controller/release-controller /usr/bin/
 RUN yum install -y graphviz


### PR DESCRIPTION
The ci-operator config allows for a `from-repository` build-root image definition.  A follow up PR in `openshift/release` will enable these changes and then we'll only have to update a single location if/when switching Golang versions in the future.