### PR TITLE
Fixing the quoting issue with the authentication message

### DIFF
--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -959,7 +959,11 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 
 	authMessage := ""
 	if len(c.authenticationMessage) > 0 {
-		authMessage = fmt.Sprintf("<p>%s</p>", c.authenticationMessage)
+		if message, err := strconv.Unquote(c.authenticationMessage); err == nil {
+			authMessage = fmt.Sprintf("<p>%s</p>", message)
+		} else {
+			klog.Warningf("Unable to display authenticationMessage: %v", err)
+		}
 	}
 
 	now := time.Now()


### PR DESCRIPTION
The current authentication messages are show with surrounding quotes.  This PR unquotes the message, that is passed into the release-controller, before displaying it on the screen. 