### PR TITLE
http_upgrade_graph: filter channels using releaseAnnotationName

### DIFF
--- a/cmd/release-controller/http_upgrade_graph.go
+++ b/cmd/release-controller/http_upgrade_graph.go
@@ -92,26 +92,21 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 		for _, history := range histories {
 			var toChannel = findChannelForNode(history.To, &nodes)
 			switch {
-			case channel == "", channel == "stable":
+			case channel == "", channel == "stable", strings.HasPrefix(channel, "stable-"):
 				if history.Success == 0 {
+					continue
+				}
+				if toChannel != "4-stable" {
 					continue
 				}
 			case channel == "prerelease", channel == "nightly":
-			case strings.HasPrefix(channel, "stable-"):
-				if history.Success == 0 {
-					continue
-				}
-				branch := channel[len("stable-"):] + "."
-				if !strings.HasPrefix(toChannel, branch) {
-					continue
-				}
 			case strings.HasPrefix(channel, "prerelease-"):
 				branch := channel[len("prerelease-"):] + "."
 				if !strings.HasPrefix(toChannel, branch) {
 					continue
 				}
 			case strings.HasPrefix(channel, "nightly-"):
-				branch := channel[len("nightly-"):] + ".0-0.nightly-"
+				branch := channel[len("nightly-"):] + ".0-0.nightly"
 				if !strings.HasPrefix(toChannel, branch) {
 					continue
 				}

--- a/cmd/release-controller/http_upgrade_graph.go
+++ b/cmd/release-controller/http_upgrade_graph.go
@@ -19,6 +19,7 @@ import (
 type ReleaseNode struct {
 	Version string `json:"version"`
 	Payload string `json:"payload"`
+	Channel string `json:"-"`
 }
 
 type ReleaseEdge []int
@@ -66,11 +67,13 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 					nodes = append(nodes, ReleaseNode{
 						Version: tag.Name,
 						Payload: s.Release.Target.Status.PublicDockerImageRepository + "@" + id,
+						Channel: tag.Annotations[releaseAnnotationName],
 					})
 				} else {
 					nodes = append(nodes, ReleaseNode{
 						Version: tag.Name,
 						Payload: s.Release.Target.Status.PublicDockerImageRepository + ":" + tag.Name,
+						Channel: tag.Annotations[releaseAnnotationName],
 					})
 				}
 			}


### PR DESCRIPTION
Use `releaseAnnotationName` when filtering upgrade graph by channel. `stable.*` would match releases with 4-stable name annotation, nightly.* would filter nightlies. This would ensure upgrade graph would show the same releases as on UI

Fixes openshift/okd#217

Resubmit of #206  