### PR TITLE
bugzilla: initialize and set bugzilla error metrics on start

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -371,6 +371,7 @@ func (o *options) Run() error {
 			return fmt.Errorf("Failed to create plugin agent: %v", err)
 		}
 		c.bugzillaVerifier = bugzilla.NewVerifier(bzClient, ghClient, pluginAgent.Config())
+		initializeMetrics(bugzillaErrorMetrics)
 		c.bugzillaErrorMetrics = bugzillaErrorMetrics
 	}
 	klog.V(4).Infof("8: %v", time.Now().Sub(start))


### PR DESCRIPTION
In order for alerts based on errors to function, values must be set for
the countervec labels. This PR sets all labels used for bugzilla errors
to 0 when bugzilla verification is enabled.