### PR TITLE
Adding random distribution support for build clusters

### DIFF
--- a/cmd/release-controller/cluster_distribution.go
+++ b/cmd/release-controller/cluster_distribution.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type ClusterDistribution interface {
+	Get() string
+	Contains(str string) bool
+}
+
+var ErrEmptyItems = errors.New("cannot create cluster distribution with no items")
+
+type RandomClusterDistribution struct {
+	random  *rand.Rand
+	pool    []string
+}
+
+func NewRandomClusterDistribution(items ...string) (ClusterDistribution, error) {
+	if len(items) == 0 {
+		return nil, ErrEmptyItems
+	}
+	cd := &RandomClusterDistribution{
+		random: rand.New(rand.NewSource(time.Now().UnixNano())),
+		pool: items,
+	}
+	return cd, nil
+}
+
+func (r *RandomClusterDistribution) Get() string {
+	return r.pool[r.random.Intn(len(r.pool))]
+}
+
+func (r *RandomClusterDistribution) Contains(str string) bool {
+	for _, v := range r.pool {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}
+
+type RoundRobinClusterDistribution struct {
+	lock    sync.Mutex
+	current int
+	pool    []string
+}
+
+func NewRoundRobinClusterDistribution(items ...string) (ClusterDistribution, error) {
+	if len(items) == 0 {
+		return nil, ErrEmptyItems
+	}
+	cd := &RoundRobinClusterDistribution{
+		pool: items,
+	}
+	return cd, nil
+}
+
+func (r *RoundRobinClusterDistribution) Get() string {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for ok := r.current >= len(r.pool); ok; ok = r.current >= len(r.pool) {
+		r.current = r.current - len(r.pool)
+	}
+
+	result := r.pool[r.current]
+	r.current++
+	return result
+}
+
+func (r *RoundRobinClusterDistribution) Contains(str string) bool {
+	for _, v := range r.pool {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/release-controller/cluster_distribution_test.go
+++ b/cmd/release-controller/cluster_distribution_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestRoundRobinDistribution(t *testing.T) {
+	testCases := []struct {
+		name        string
+		items       []string
+		expectedErr error
+		wants       []string
+	}{
+		{
+			name:        "NoItemsSpecified",
+			items:       []string{},
+			expectedErr: ErrEmptyItems,
+			wants:       []string{},
+		},
+		{
+			name: "OneItem",
+			items: []string{
+				"build01",
+			},
+			expectedErr: nil,
+			wants: []string{
+				"build01",
+				"build01",
+				"build01",
+			},
+		},
+		{
+			name: "TwoItems",
+			items: []string{
+				"build01",
+				"build02",
+			},
+			expectedErr: nil,
+			wants: []string{
+				"build01",
+				"build02",
+				"build01",
+				"build02",
+			},
+		},
+		{
+			name: "ThreeItems",
+			items: []string{
+				"build01",
+				"build02",
+				"build03",
+			},
+			expectedErr: nil,
+			wants: []string{
+				"build01",
+				"build02",
+				"build03",
+				"build01",
+				"build02",
+				"build03",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		distribution, err := NewRoundRobinClusterDistribution(tc.items...)
+
+		if err != nil && err != tc.expectedErr {
+			t.Errorf("%s - expected error: %v, got: %v", tc.name, tc.expectedErr, err)
+		}
+
+		results := make([]string, 0, len(tc.wants))
+		for j := 0; j < len(tc.wants); j++ {
+			results = append(results, distribution.Get())
+		}
+
+		if !reflect.DeepEqual(results, tc.wants) {
+			t.Errorf("%s - expected: %v, got: %v", tc.name, tc.wants, results)
+		}
+	}
+}
+
+func TestRandomDistribution(t *testing.T) {
+	testCases := []struct {
+		name        string
+		items       []string
+		expectedErr error
+		wants       int
+	}{
+		{
+			name:        "NoItemsSpecified",
+			items:       []string{},
+			expectedErr: ErrEmptyItems,
+			wants:       0,
+		},
+		{
+			name: "OneItemTwentyFiveTimes",
+			items: []string{
+				"build01",
+			},
+			expectedErr: nil,
+			wants: 25,
+		},
+		{
+			name: "TwoItemsFiftyTimes",
+			items: []string{
+				"build01",
+				"build02",
+			},
+			expectedErr: nil,
+			wants: 50,
+		},
+		{
+			name: "ThreeItemsOneHundredTimes",
+			items: []string{
+				"build01",
+				"build02",
+				"build03",
+			},
+			expectedErr: nil,
+			wants: 100,
+		},
+		{
+			name: "FiveItemsOneThousandTimes",
+			items: []string{
+				"build01",
+				"build02",
+				"build03",
+				"build04",
+				"build05",
+			},
+			expectedErr: nil,
+			wants: 1000,
+		},
+	}
+
+	for _, tc := range testCases {
+		distribution, err := NewRandomClusterDistribution(tc.items...)
+
+		if err != nil && err != tc.expectedErr {
+			t.Errorf("%s - expected error: %v, got: %v", tc.name, tc.expectedErr, err)
+		} else if err != nil && err == tc.expectedErr{
+			continue
+		}
+
+		results := make([]string, 0, tc.wants)
+		for j := 0; j < tc.wants; j++ {
+			results = append(results, distribution.Get())
+		}
+
+		if len(results) != tc.wants {
+			t.Errorf("%s - expected: %v items, got: %v items", tc.name, tc.wants, results)
+		}
+
+		var data = make(map[string]int, len(tc.items))
+		for _, item := range tc.items {
+			for _, result := range results{
+				if result == item {
+					data[item]++
+				}
+			}
+		}
+		fmt.Printf("%s - Cluster distribution results:\n", tc.name)
+		for key, value := range data {
+			fmt.Printf("\t%s: %.2f%%\n", key, float32(value)/float32(tc.wants)*100)
+		}
+	}
+}

--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -134,6 +135,8 @@ type Controller struct {
 
 	softDeleteReleaseTags bool
 	authenticationMessage string
+
+	buildClusterDistributions []ClusterDistribution
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -151,6 +154,7 @@ func NewController(
 	graph *UpgradeGraph,
 	softDeleteReleaseTags bool,
 	authenticationMessage string,
+	clusterGroups []string,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -222,6 +226,14 @@ func NewController(
 		{"Index", "/"},
 		{"Overview", "/dashboards/overview"},
 		{"Compare", "/dashboards/compare"},
+	}
+
+	for _, memberList := range clusterGroups {
+		members := strings.Split(memberList, ",")
+		distribution, _ := NewRandomClusterDistribution(members...)
+		if distribution != nil {
+			c.buildClusterDistributions = append(c.buildClusterDistributions, distribution)
+		}
 	}
 
 	return c

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -65,6 +65,14 @@ func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName str
 	if isAggregatedJob {
 		periodicConfig.Name = fmt.Sprintf("%s-%s", jobName, verifyName)
 	}
+	// If the release-controller was given a list of build cluster names to use, this will
+	// distribute the prowjobs onto them.  If not, then the jobs will be run on the
+	// build cluster defined inside the job itself.
+	for _, buildClusterDistribution := range c.buildClusterDistributions {
+		if buildClusterDistribution.Contains(periodicConfig.Cluster){
+			periodicConfig.Cluster = buildClusterDistribution.Get()
+		}
+	}
 	spec := prowutil.PeriodicSpec(*periodicConfig)
 	mirror, _ := c.getMirror(release, releaseTag.Name)
 	ok, err = addReleaseEnvToProwJobSpec(&spec, release, mirror, releaseTag, previousReleasePullSpec, verifyType.Upgrade, c.graph.architecture)


### PR DESCRIPTION
Recently, it has been observed that certain failures are happening on one of the build clusters, but not on another.  It has been requested that instead of the weekly re-balancing of the release-controller jobs (that CI performs), we perform a random rollout of the various release verification jobs to the configured build clusters.  This PR adds the ability to specify "cluster groups", on the commandline, and when defined the release-controller we distribute the release verification jobs out, to the respective group, randomly.

For instance, using the current configuration as reference, we'll need to define 2 cluster groups:
` --cluster-group build01,build02 --cluster-group vsphere`

When the release-controller reads in the prowjob definition, it will check if the defined `cluster:` value exists in one of the cluster groups and then "get" the next cluster from the group and assign the job to that cluster.  If the `cluster:` is not a member of any group, then the release-controller will not make any modifications and the jobs will run on the cluster as it is defined in the job itself.