### PR TITLE
Adding support for launching analysis aggregator job

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -474,11 +474,6 @@ func (c *Controller) syncReady(release *Release) error {
 	}
 
 	for _, releaseTag := range readyTags {
-		err := c.ensureAnalysisJobs(release, releaseTag)
-		if err != nil {
-			klog.Errorf("Unable to launch analysis job: %v", err)
-		}
-
 		status, err := c.ensureVerificationJobs(release, releaseTag)
 		if err != nil {
 			return err

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -80,6 +80,12 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 			jobLabels := map[string]string{
 				"release.openshift.io/verify": "true",
 			}
+			if verifyType.AggregatedProwJob != nil {
+				err := c.launchAnalysisJobs(release, jobName, verifyType, releaseTag, previousTag, previousReleasePullSpec)
+				if err != nil {
+					return nil, err
+				}
+			}
 			job, err := c.ensureProwJobForReleaseTag(release, jobName, verifyType, releaseTag, previousTag, previousReleasePullSpec, jobLabels)
 			if err != nil {
 				return nil, err

--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -226,6 +226,20 @@ type ReleaseVerification struct {
 	MaxRetries int `json:"maxRetries,omitempty"`
 	// AnalysisJobCount Number of asynchronous jobs to execute for release analysis.
 	AnalysisJobCount int `json:"analysisJobCount,omitempty"`
+	// AggregatedProwJob defines the prow job used to run release analysis verification
+	AggregatedProwJob *AggregatedProwJobVerification `json:"aggregatedProwJob,omitempty"`
+}
+
+// AggregatedProwJobVerification identifies the name of a prow job that will be used to
+// aggregate the release analysis jobs.
+type AggregatedProwJobVerification struct{
+	// ProwJob requires that the named ProwJob from the prow config pass before the
+	// release is accepted. The job is run only one time and if it fails the release
+	// is rejected.
+	// Defaults to "release-openshift-release-analysis-aggregator" if not specified.
+	ProwJob *ProwJobVerification `json:"prowJob,omitempty"`
+	// AnalysisJobCount Number of asynchronous jobs to execute for release analysis.
+	AnalysisJobCount int `json:"analysisJobCount,omitempty"`
 }
 
 // ReleasePeriodic is a job that runs on the speicifed cron or interval period as a
@@ -536,4 +550,43 @@ func calculateBackoff(retryCount int, initialTime, currentTime *metav1.Time) tim
 		backoffDuration = 0
 	}
 	return backoffDuration
+}
+
+func (in *ReleaseVerification) DeepCopy() *ReleaseVerification {
+	if in == nil {
+		return nil
+	}
+	out := new(ReleaseVerification)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ReleaseVerification) DeepCopyInto(out *ReleaseVerification) {
+	*out = *in
+	if in.ProwJob != nil {
+		in, out := &in.ProwJob, &out.ProwJob
+		*out = new(ProwJobVerification)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.AggregatedProwJob != nil {
+		in, out := &in.AggregatedProwJob, &out.AggregatedProwJob
+		*out = new(AggregatedProwJobVerification)
+		(*in).DeepCopyInto(*out)
+	}
+	return
+}
+
+func (in *ProwJobVerification) DeepCopyInto(out *ProwJobVerification) {
+	*out = *in
+	return
+}
+
+func (in *AggregatedProwJobVerification) DeepCopyInto(out *AggregatedProwJobVerification) {
+	*out = *in
+	if in.ProwJob != nil {
+		in, out := &in.ProwJob, &out.ProwJob
+		*out = new(ProwJobVerification)
+		(*in).DeepCopyInto(*out)
+	}
+	return
 }


### PR DESCRIPTION
This PR refactors the Analysis Verification Job definitions to be part of the `verify` stanza.  This eliminates the need for the `analysis` stanza all together.  The reason that this was done was to enable the release-controller to:

1. Launch the specified number of Analysis jobs
2. Launch the aggregator job with the necessary information for the analysis jobs

I have also added a new field `AggregateProwJob` to the `ReleaseVerification` struct to allow for an override to the default aggregator job name (`release-openshift-release-analysis-aggregator`) defined as a [step](https://steps.ci.openshift.org/reference/openshift-release-analysis-aggregator) in the ci-operator config.