### PR TITLE
Removing analysis block and analysisJobCount

### DIFF
--- a/cmd/release-controller/types.go
+++ b/cmd/release-controller/types.go
@@ -119,10 +119,6 @@ type ReleaseConfig struct {
 	// Check is a map of short names to check routines that report additional information
 	// about the health or quality of this stream to the user interface.
 	Check map[string]ReleaseCheck `json:"check"`
-
-	// Analysis is a map of short names to analysis steps to run to check the overall
-	// stability of a particular release.
-	Analysis map[string]ReleaseVerification `json:"analysis"`
 }
 
 type ReleaseCheck struct {
@@ -224,8 +220,6 @@ type ReleaseVerification struct {
 	ProwJob *ProwJobVerification `json:"prowJob"`
 	// Maximum retry attempts for the job. Defaults to 0 - do not retry on fail
 	MaxRetries int `json:"maxRetries,omitempty"`
-	// AnalysisJobCount Number of asynchronous jobs to execute for release analysis.
-	AnalysisJobCount int `json:"analysisJobCount,omitempty"`
 	// AggregatedProwJob defines the prow job used to run release analysis verification
 	AggregatedProwJob *AggregatedProwJobVerification `json:"aggregatedProwJob,omitempty"`
 }


### PR DESCRIPTION
Now that #310 has merged, we can cleanup these unnecessary fields.