### PR TITLE
main: do not reload on in cluster token change

### DIFF
--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -752,7 +752,7 @@ func setupKubeconfigWatches(o *options) error {
 	if err != nil {
 		return fmt.Errorf("failed to set up watcher: %w", err)
 	}
-	for _, candidate := range []string{o.ProwJobKubeconfig, o.NonProwJobKubeconfig, "/var/run/secrets/kubernetes.io/serviceaccount/token"} {
+	for _, candidate := range []string{o.ProwJobKubeconfig, o.NonProwJobKubeconfig} {
 		if _, err := os.Stat(candidate); err != nil {
 			continue
 		}


### PR DESCRIPTION
The client used by the release-controller for in-cluster configs is set
up to automatically reload in-cluster configs periodically without
needing to change how it is currently configured in the
release-controller. This means that the watch on the token file's path
that triggered periodic restarts when the bound token was updated can be
removed.

/cc @stevekuznetsov @bradmwilliams 