### PR TITLE
bugzilla: reimplement bugzilla commenting

### DIFF
--- a/pkg/bugzilla/bugzilla.go
+++ b/pkg/bugzilla/bugzilla.go
@@ -110,10 +110,11 @@ func (c *Verifier) VerifyBugs(bugs []int) []error {
 			comments, err := c.bzClient.GetComments(bugID)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("Failed to get comments on bug %d: %v", bug.ID, err))
+				continue
 			}
 			var alreadyCommented bool
 			for _, comment := range comments {
-				if comment.Text == message {
+				if comment.Text == message && comment.Creator == "openshift-bugzilla-robot" {
 					alreadyCommented = true
 					break
 				}


### PR DESCRIPTION
This PR reimplements the commenting feature originally added in #312 and
later reverted due to unintended spamming. This adds a check to prevent
spamming where it loads all comments for the bug and verifies that an
identical comment has not already been made.

/cc @bradmwilliams @stevekuznetsov 