### PR TITLE
bugzilla: use full email for bz comment checks

### DIFF
--- a/pkg/bugzilla/bugzilla.go
+++ b/pkg/bugzilla/bugzilla.go
@@ -138,7 +138,7 @@ func (c *Verifier) VerifyBugs(bugs []int) []error {
 			}
 			var alreadyCommented bool
 			for _, comment := range comments {
-				if comment.Text == message && comment.Creator == "openshift-bugzilla-robot" {
+				if comment.Text == message && (comment.Creator == "openshift-bugzilla-robot" || comment.Creator == "openshift-bugzilla-robot@redhat.com") {
 					alreadyCommented = true
 					break
 				}


### PR DESCRIPTION
When this code was first made, I checked the `creator` value by curling
a public bug that the bugzilla bot had made a public comment on. The
creator was set as `openshift-bugzilla-robot`. However, a couple of bugs
with multiple PRs have had multiple identical comments posted on them
recently. Apparently, when the REST call is performed with
authentication, the creator is `openshift-bugzilla-robot@redhat.com`.

/cc @bradmwilliams 