### PR TITLE
Refactoring types.go out into common place

### DIFF
--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"os/exec"
 	"sort"
 	"strings"
@@ -146,7 +147,7 @@ func (c *Controller) syncAuditTag(releaseName string) error {
 	return nil
 }
 
-var auditVerifyJobSelector = labels.SelectorFromSet(labels.Set{releaseAnnotationJobPurpose: "audit"})
+var auditVerifyJobSelector = labels.SelectorFromSet(labels.Set{release_controller.ReleaseAnnotationJobPurpose: "audit"})
 
 func (c *Controller) ensureMaximumAuditVerifyJobs(maximum int, expireJobs time.Duration) (bool, error) {
 	result, err := c.jobLister.Jobs(c.jobNamespace).List(auditVerifyJobSelector)
@@ -171,7 +172,7 @@ func (c *Controller) ensureMaximumAuditVerifyJobs(maximum int, expireJobs time.D
 	return count < maximum, lastErr
 }
 
-func (c *Controller) ensureAuditVerifyJob(release *Release, record *AuditRecord) (*batchv1.Job, error) {
+func (c *Controller) ensureAuditVerifyJob(release *release_controller.Release, record *AuditRecord) (*batchv1.Job, error) {
 	// create a safe job name
 	name := record.ID
 	parts := strings.SplitN(record.ID, ":", 2)
@@ -202,10 +203,10 @@ func (c *Controller) ensureAuditVerifyJob(release *Release, record *AuditRecord)
 		if job.Labels == nil {
 			job.Labels = make(map[string]string)
 		}
-		job.Labels[releaseAnnotationJobPurpose] = "audit"
-		job.Annotations[releaseAnnotationTarget] = fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name)
-		job.Annotations[releaseAnnotationReleaseTag] = record.Name
-		job.Annotations[releaseAnnotationJobPurpose] = "audit"
+		job.Labels[release_controller.ReleaseAnnotationJobPurpose] = "audit"
+		job.Annotations[release_controller.ReleaseAnnotationTarget] = fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name)
+		job.Annotations[release_controller.ReleaseAnnotationReleaseTag] = record.Name
+		job.Annotations[release_controller.ReleaseAnnotationJobPurpose] = "audit"
 
 		klog.V(2).Infof("Running release verify job for %s (%s)", record.ID, record.Name)
 		return job, nil
@@ -312,8 +313,8 @@ func (a *AuditTracker) Get(name string) (*AuditRecord, bool) {
 	return &copied, true
 }
 
-func (a *AuditTracker) Sync(release *Release) {
-	if release.Config.As != releaseConfigModeStable {
+func (a *AuditTracker) Sync(release *release_controller.Release) {
+	if release.Config.As != release_controller.ReleaseConfigModeStable {
 		return
 	}
 
@@ -325,13 +326,13 @@ func (a *AuditTracker) Sync(release *Release) {
 	found := sets.NewString()
 	from := release.Target
 	for _, tag := range from.Spec.Tags {
-		if _, ok := tag.Annotations[releaseAnnotationSource]; !ok {
+		if _, ok := tag.Annotations[release_controller.ReleaseAnnotationSource]; !ok {
 			continue
 		}
 		if len(tag.Name) == 0 {
 			continue
 		}
-		phase := tag.Annotations[releaseAnnotationPhase]
+		phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
 		if phase != "Accepted" && phase != "Ready" && phase != "Rejected" {
 			continue
 		}

--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -147,7 +147,7 @@ func (c *Controller) syncAuditTag(releaseName string) error {
 	return nil
 }
 
-var auditVerifyJobSelector = labels.SelectorFromSet(labels.Set{release_controller.ReleaseAnnotationJobPurpose: "audit"})
+var auditVerifyJobSelector = labels.SelectorFromSet(labels.Set{releasecontroller.ReleaseAnnotationJobPurpose: "audit"})
 
 func (c *Controller) ensureMaximumAuditVerifyJobs(maximum int, expireJobs time.Duration) (bool, error) {
 	result, err := c.jobLister.Jobs(c.jobNamespace).List(auditVerifyJobSelector)
@@ -172,7 +172,7 @@ func (c *Controller) ensureMaximumAuditVerifyJobs(maximum int, expireJobs time.D
 	return count < maximum, lastErr
 }
 
-func (c *Controller) ensureAuditVerifyJob(release *release_controller.Release, record *AuditRecord) (*batchv1.Job, error) {
+func (c *Controller) ensureAuditVerifyJob(release *releasecontroller.Release, record *AuditRecord) (*batchv1.Job, error) {
 	// create a safe job name
 	name := record.ID
 	parts := strings.SplitN(record.ID, ":", 2)
@@ -203,10 +203,10 @@ func (c *Controller) ensureAuditVerifyJob(release *release_controller.Release, r
 		if job.Labels == nil {
 			job.Labels = make(map[string]string)
 		}
-		job.Labels[release_controller.ReleaseAnnotationJobPurpose] = "audit"
-		job.Annotations[release_controller.ReleaseAnnotationTarget] = fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name)
-		job.Annotations[release_controller.ReleaseAnnotationReleaseTag] = record.Name
-		job.Annotations[release_controller.ReleaseAnnotationJobPurpose] = "audit"
+		job.Labels[releasecontroller.ReleaseAnnotationJobPurpose] = "audit"
+		job.Annotations[releasecontroller.ReleaseAnnotationTarget] = fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name)
+		job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag] = record.Name
+		job.Annotations[releasecontroller.ReleaseAnnotationJobPurpose] = "audit"
 
 		klog.V(2).Infof("Running release verify job for %s (%s)", record.ID, record.Name)
 		return job, nil
@@ -313,8 +313,8 @@ func (a *AuditTracker) Get(name string) (*AuditRecord, bool) {
 	return &copied, true
 }
 
-func (a *AuditTracker) Sync(release *release_controller.Release) {
-	if release.Config.As != release_controller.ReleaseConfigModeStable {
+func (a *AuditTracker) Sync(release *releasecontroller.Release) {
+	if release.Config.As != releasecontroller.ReleaseConfigModeStable {
 		return
 	}
 
@@ -326,13 +326,13 @@ func (a *AuditTracker) Sync(release *release_controller.Release) {
 	found := sets.NewString()
 	from := release.Target
 	for _, tag := range from.Spec.Tags {
-		if _, ok := tag.Annotations[release_controller.ReleaseAnnotationSource]; !ok {
+		if _, ok := tag.Annotations[releasecontroller.ReleaseAnnotationSource]; !ok {
 			continue
 		}
 		if len(tag.Name) == 0 {
 			continue
 		}
-		phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
+		phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
 		if phase != "Accepted" && phase != "Ready" && phase != "Rejected" {
 			continue
 		}

--- a/cmd/release-controller/bugzilla.go
+++ b/cmd/release-controller/bugzilla.go
@@ -45,7 +45,7 @@ func getNonVerifiedTags(acceptedTags []*v1.TagReference) (current, previous *v1.
 		acceptedTags[i], acceptedTags[j] = acceptedTags[j], acceptedTags[i]
 	}
 	for index, tag := range acceptedTags {
-		if anno, ok := tag.Annotations[release_controller.ReleaseAnnotationBugsVerified]; !ok || anno != "true" {
+		if anno, ok := tag.Annotations[releasecontroller.ReleaseAnnotationBugsVerified]; !ok || anno != "true" {
 			if index == 0 {
 				return tag, nil
 			}
@@ -72,7 +72,7 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	klog.V(6).Infof("checking if %v (%s) has verifyBugs set", key, release.Config.Name)
 
 	// check if verifyBugs publish step is enabled for release
-	var verifyBugs *release_controller.PublishVerifyBugs
+	var verifyBugs *releasecontroller.PublishVerifyBugs
 	for _, publishType := range release.Config.Publish {
 		if publishType.Disabled {
 			continue
@@ -93,7 +93,7 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	klog.V(4).Infof("Verifying fixed bugs in %s", release.Config.Name)
 
 	// get accepted tags
-	acceptedTags := sortedRawReleaseTags(release, release_controller.ReleasePhaseAccepted)
+	acceptedTags := sortedRawReleaseTags(release, releasecontroller.ReleasePhaseAccepted)
 	tag, prevTag := getNonVerifiedTags(acceptedTags)
 	if tag == nil {
 		klog.V(6).Infof("bugzilla: All accepted tags for %s have already been verified", release.Config.Name)
@@ -152,14 +152,14 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	}
 	tagToBeUpdated := findTagReference(target, tag.Name)
 	if tagToBeUpdated == nil {
-		klog.V(6).Infof("release %s no longer exists, cannot set annotation %s=true", tag.Name, release_controller.ReleaseAnnotationBugsVerified)
-		return fmt.Errorf("release %s no longer exists, cannot set annotation %s=true", tag.Name, release_controller.ReleaseAnnotationBugsVerified)
+		klog.V(6).Infof("release %s no longer exists, cannot set annotation %s=true", tag.Name, releasecontroller.ReleaseAnnotationBugsVerified)
+		return fmt.Errorf("release %s no longer exists, cannot set annotation %s=true", tag.Name, releasecontroller.ReleaseAnnotationBugsVerified)
 	}
 	if tagToBeUpdated.Annotations == nil {
 		tagToBeUpdated.Annotations = make(map[string]string)
 	}
-	tagToBeUpdated.Annotations[release_controller.ReleaseAnnotationBugsVerified] = "true"
-	klog.V(6).Infof("Setting %s annotation to \"true\" for %s in imagestream %s/%s", release_controller.ReleaseAnnotationBugsVerified, tag.Name, target.GetNamespace(), target.GetName())
+	tagToBeUpdated.Annotations[releasecontroller.ReleaseAnnotationBugsVerified] = "true"
+	klog.V(6).Infof("Setting %s annotation to \"true\" for %s in imagestream %s/%s", releasecontroller.ReleaseAnnotationBugsVerified, tag.Name, target.GetNamespace(), target.GetName())
 	if _, err := c.imageClient.ImageStreams(target.Namespace).Update(context.TODO(), target, meta.UpdateOptions{}); err != nil {
 		klog.V(4).Infof("Failed to update bugzilla annotation for tag %s in imagestream %s/%s: %v", tag.Name, target.GetNamespace(), target.GetName(), err)
 		c.bugzillaErrorMetrics.WithLabelValues(bzFailedAnnotation).Inc()

--- a/cmd/release-controller/bugzilla.go
+++ b/cmd/release-controller/bugzilla.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"time"
 
 	v1 "github.com/openshift/api/image/v1"
@@ -44,7 +45,7 @@ func getNonVerifiedTags(acceptedTags []*v1.TagReference) (current, previous *v1.
 		acceptedTags[i], acceptedTags[j] = acceptedTags[j], acceptedTags[i]
 	}
 	for index, tag := range acceptedTags {
-		if anno, ok := tag.Annotations[releaseAnnotationBugsVerified]; !ok || anno != "true" {
+		if anno, ok := tag.Annotations[release_controller.ReleaseAnnotationBugsVerified]; !ok || anno != "true" {
 			if index == 0 {
 				return tag, nil
 			}
@@ -71,7 +72,7 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	klog.V(6).Infof("checking if %v (%s) has verifyBugs set", key, release.Config.Name)
 
 	// check if verifyBugs publish step is enabled for release
-	var verifyBugs *PublishVerifyBugs
+	var verifyBugs *release_controller.PublishVerifyBugs
 	for _, publishType := range release.Config.Publish {
 		if publishType.Disabled {
 			continue
@@ -92,7 +93,7 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	klog.V(4).Infof("Verifying fixed bugs in %s", release.Config.Name)
 
 	// get accepted tags
-	acceptedTags := sortedRawReleaseTags(release, releasePhaseAccepted)
+	acceptedTags := sortedRawReleaseTags(release, release_controller.ReleasePhaseAccepted)
 	tag, prevTag := getNonVerifiedTags(acceptedTags)
 	if tag == nil {
 		klog.V(6).Infof("bugzilla: All accepted tags for %s have already been verified", release.Config.Name)
@@ -151,14 +152,14 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	}
 	tagToBeUpdated := findTagReference(target, tag.Name)
 	if tagToBeUpdated == nil {
-		klog.V(6).Infof("release %s no longer exists, cannot set annotation %s=true", tag.Name, releaseAnnotationBugsVerified)
-		return fmt.Errorf("release %s no longer exists, cannot set annotation %s=true", tag.Name, releaseAnnotationBugsVerified)
+		klog.V(6).Infof("release %s no longer exists, cannot set annotation %s=true", tag.Name, release_controller.ReleaseAnnotationBugsVerified)
+		return fmt.Errorf("release %s no longer exists, cannot set annotation %s=true", tag.Name, release_controller.ReleaseAnnotationBugsVerified)
 	}
 	if tagToBeUpdated.Annotations == nil {
 		tagToBeUpdated.Annotations = make(map[string]string)
 	}
-	tagToBeUpdated.Annotations[releaseAnnotationBugsVerified] = "true"
-	klog.V(6).Infof("Setting %s annotation to \"true\" for %s in imagestream %s/%s", releaseAnnotationBugsVerified, tag.Name, target.GetNamespace(), target.GetName())
+	tagToBeUpdated.Annotations[release_controller.ReleaseAnnotationBugsVerified] = "true"
+	klog.V(6).Infof("Setting %s annotation to \"true\" for %s in imagestream %s/%s", release_controller.ReleaseAnnotationBugsVerified, tag.Name, target.GetNamespace(), target.GetName())
 	if _, err := c.imageClient.ImageStreams(target.Namespace).Update(context.TODO(), target, meta.UpdateOptions{}); err != nil {
 		klog.V(4).Infof("Failed to update bugzilla annotation for tag %s in imagestream %s/%s: %v", tag.Name, target.GetNamespace(), target.GetName(), err)
 		c.bugzillaErrorMetrics.WithLabelValues(bzFailedAnnotation).Inc()

--- a/cmd/release-controller/bugzilla_test.go
+++ b/cmd/release-controller/bugzilla_test.go
@@ -36,14 +36,14 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test1",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}},
 		expectedCurrent: &v1.TagReference{Name: "test2"},
 		expectedPrevious: &v1.TagReference{
 			Name: "test1",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		},
 	}, {
@@ -54,17 +54,17 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test3",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}, {
 			Name: "test2",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}, {
 			Name: "test1",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}},
 		expectedCurrent: &v1.TagReference{
@@ -74,7 +74,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		expectedPrevious: &v1.TagReference{
 			Name: "test3",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		},
 	}, {
@@ -85,7 +85,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test3",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}, {
 			Name:        "test2",
@@ -93,7 +93,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test1",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}},
 		expectedCurrent: &v1.TagReference{
@@ -103,7 +103,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		expectedPrevious: &v1.TagReference{
 			Name: "test1",
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationBugsVerified: "true",
+				releasecontroller.ReleaseAnnotationBugsVerified: "true",
 			},
 		},
 	}}

--- a/cmd/release-controller/bugzilla_test.go
+++ b/cmd/release-controller/bugzilla_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"reflect"
 	"testing"
 
@@ -35,14 +36,14 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test1",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}},
 		expectedCurrent: &v1.TagReference{Name: "test2"},
 		expectedPrevious: &v1.TagReference{
 			Name: "test1",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		},
 	}, {
@@ -53,17 +54,17 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test3",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}, {
 			Name: "test2",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}, {
 			Name: "test1",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}},
 		expectedCurrent: &v1.TagReference{
@@ -73,7 +74,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		expectedPrevious: &v1.TagReference{
 			Name: "test3",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		},
 	}, {
@@ -84,7 +85,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test3",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}, {
 			Name:        "test2",
@@ -92,7 +93,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		}, {
 			Name: "test1",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		}},
 		expectedCurrent: &v1.TagReference{
@@ -102,7 +103,7 @@ func TestGetNonVerifiedTags(t *testing.T) {
 		expectedPrevious: &v1.TagReference{
 			Name: "test1",
 			Annotations: map[string]string{
-				releaseAnnotationBugsVerified: "true",
+				release_controller.ReleaseAnnotationBugsVerified: "true",
 			},
 		},
 	}}

--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -15,14 +16,14 @@ import (
 
 func validateConfigs(configDir string) error {
 	errors := []error{}
-	releaseConfigs := []ReleaseConfig{}
+	releaseConfigs := []release_controller.ReleaseConfig{}
 	err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
 		if info != nil && filepath.Ext(info.Name()) == ".json" {
 			raw, err := ioutil.ReadFile(path)
 			if err != nil {
 				return err
 			}
-			config := ReleaseConfig{}
+			config := release_controller.ReleaseConfig{}
 			dec := json.NewDecoder(bytes.NewReader(raw))
 			dec.DisallowUnknownFields() // Force errors on unknown fields
 			if err := dec.Decode(&config); err != nil {
@@ -41,7 +42,7 @@ func validateConfigs(configDir string) error {
 	return utilerrors.NewAggregate(errors)
 }
 
-func validateUpgradeJobs(releaseConfigs []ReleaseConfig) []error {
+func validateUpgradeJobs(releaseConfigs []release_controller.ReleaseConfig) []error {
 	errors := []error{}
 	for _, config := range releaseConfigs {
 		for name, verify := range config.Verify {
@@ -58,7 +59,7 @@ func validateUpgradeJobs(releaseConfigs []ReleaseConfig) []error {
 	return errors
 }
 
-func verifyPeriodicFields(releaseConfigs []ReleaseConfig) []error {
+func verifyPeriodicFields(releaseConfigs []release_controller.ReleaseConfig) []error {
 	errors := []error{}
 	for _, config := range releaseConfigs {
 		for stepName, periodic := range config.Periodic {
@@ -83,7 +84,7 @@ func verifyPeriodicFields(releaseConfigs []ReleaseConfig) []error {
 	return errors
 }
 
-func findDuplicatePeriodics(releaseConfigs []ReleaseConfig) []error {
+func findDuplicatePeriodics(releaseConfigs []release_controller.ReleaseConfig) []error {
 	seen := make(map[string][]string)
 	for _, config := range releaseConfigs {
 		for stepName, periodic := range config.Periodic {

--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -16,14 +16,14 @@ import (
 
 func validateConfigs(configDir string) error {
 	errors := []error{}
-	releaseConfigs := []release_controller.ReleaseConfig{}
+	releaseConfigs := []releasecontroller.ReleaseConfig{}
 	err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
 		if info != nil && filepath.Ext(info.Name()) == ".json" {
 			raw, err := ioutil.ReadFile(path)
 			if err != nil {
 				return err
 			}
-			config := release_controller.ReleaseConfig{}
+			config := releasecontroller.ReleaseConfig{}
 			dec := json.NewDecoder(bytes.NewReader(raw))
 			dec.DisallowUnknownFields() // Force errors on unknown fields
 			if err := dec.Decode(&config); err != nil {
@@ -42,7 +42,7 @@ func validateConfigs(configDir string) error {
 	return utilerrors.NewAggregate(errors)
 }
 
-func validateUpgradeJobs(releaseConfigs []release_controller.ReleaseConfig) []error {
+func validateUpgradeJobs(releaseConfigs []releasecontroller.ReleaseConfig) []error {
 	errors := []error{}
 	for _, config := range releaseConfigs {
 		for name, verify := range config.Verify {
@@ -59,7 +59,7 @@ func validateUpgradeJobs(releaseConfigs []release_controller.ReleaseConfig) []er
 	return errors
 }
 
-func verifyPeriodicFields(releaseConfigs []release_controller.ReleaseConfig) []error {
+func verifyPeriodicFields(releaseConfigs []releasecontroller.ReleaseConfig) []error {
 	errors := []error{}
 	for _, config := range releaseConfigs {
 		for stepName, periodic := range config.Periodic {
@@ -84,7 +84,7 @@ func verifyPeriodicFields(releaseConfigs []release_controller.ReleaseConfig) []e
 	return errors
 }
 
-func findDuplicatePeriodics(releaseConfigs []release_controller.ReleaseConfig) []error {
+func findDuplicatePeriodics(releaseConfigs []releasecontroller.ReleaseConfig) []error {
 	seen := make(map[string][]string)
 	for _, config := range releaseConfigs {
 		for stepName, periodic := range config.Periodic {

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -10,83 +10,83 @@ import (
 func TestVerifyPeriodicFields(t *testing.T) {
 	testCases := []struct {
 		name        string
-		input       release_controller.ReleaseConfig
+		input       releasecontroller.ReleaseConfig
 		expectedErr bool
 	}{{
 		name: "Valid Cron",
-		input: release_controller.ReleaseConfig{
+		input: releasecontroller.ReleaseConfig{
 			Name: "TestRelease",
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"aws": {
 					Cron:    "0 8,20 * * *",
-					ProwJob: &release_controller.ProwJobVerification{Name: "openshift-e2e-aws"},
+					ProwJob: &releasecontroller.ProwJobVerification{Name: "openshift-e2e-aws"},
 				},
 			},
 		},
 		expectedErr: false,
 	}, {
 		name: "Valid Interval",
-		input: release_controller.ReleaseConfig{
+		input: releasecontroller.ReleaseConfig{
 			Name: "TestRelease",
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"aws": {
 					Interval: "6h",
-					ProwJob:  &release_controller.ProwJobVerification{Name: "openshift-e2e-aws"},
+					ProwJob:  &releasecontroller.ProwJobVerification{Name: "openshift-e2e-aws"},
 				},
 			},
 		},
 		expectedErr: false,
 	}, {
 		name: "Missing Fields",
-		input: release_controller.ReleaseConfig{
+		input: releasecontroller.ReleaseConfig{
 			Name: "TestRelease",
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"aws": {
-					ProwJob: &release_controller.ProwJobVerification{Name: "openshift-e2e-aws"},
+					ProwJob: &releasecontroller.ProwJobVerification{Name: "openshift-e2e-aws"},
 				},
 			},
 		},
 		expectedErr: true,
 	}, {
 		name: "Interval and Cron",
-		input: release_controller.ReleaseConfig{
+		input: releasecontroller.ReleaseConfig{
 			Name: "TestRelease",
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"aws": {
 					Cron:     "0 8,20 * * *",
 					Interval: "6h",
-					ProwJob:  &release_controller.ProwJobVerification{Name: "openshift-e2e-aws"},
+					ProwJob:  &releasecontroller.ProwJobVerification{Name: "openshift-e2e-aws"},
 				},
 			},
 		},
 		expectedErr: true,
 	}, {
 		name: "Invalid Cron",
-		input: release_controller.ReleaseConfig{
+		input: releasecontroller.ReleaseConfig{
 			Name: "TestRelease",
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"aws": {
 					Cron:    "0 8,25 * * *",
-					ProwJob: &release_controller.ProwJobVerification{Name: "openshift-e2e-aws"},
+					ProwJob: &releasecontroller.ProwJobVerification{Name: "openshift-e2e-aws"},
 				},
 			},
 		},
 		expectedErr: true,
 	}, {
 		name: "Invalid Interval",
-		input: release_controller.ReleaseConfig{
+		input: releasecontroller.ReleaseConfig{
 			Name: "TestRelease",
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"aws": {
 					Interval: "6g",
-					ProwJob:  &release_controller.ProwJobVerification{Name: "openshift-e2e-aws"},
+					ProwJob:  &releasecontroller.ProwJobVerification{Name: "openshift-e2e-aws"},
 				},
 			},
 		},
 		expectedErr: true,
 	}}
 	for _, testCase := range testCases {
-		errors := verifyPeriodicFields([]release_controller.ReleaseConfig{testCase.input})
+		errors := verifyPeriodicFields([]releasecontroller.ReleaseConfig{testCase.input})
 		if testCase.expectedErr && len(errors) == 0 {
 			t.Errorf("%s: Expected error but none given", testCase.name)
 		}
@@ -97,112 +97,112 @@ func TestVerifyPeriodicFields(t *testing.T) {
 }
 
 func TestFindDuplicatePeriodics(t *testing.T) {
-	goodConfigs := []release_controller.ReleaseConfig{{
+	goodConfigs := []releasecontroller.ReleaseConfig{{
 		Name: "4.5.0-0.nightly",
-		Periodic: map[string]release_controller.ReleasePeriodic{
+		Periodic: map[string]releasecontroller.ReleasePeriodic{
 			"upgrade": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
 				},
 			},
 			"upgrade-minor": {
 				Upgrade:     true,
 				UpgradeFrom: "PreviousMinor",
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.4-stable-to-4.5-nightly",
 				},
 			},
 		},
 	}, {
 		Name: "4.6.0-0.nightly",
-		Periodic: map[string]release_controller.ReleasePeriodic{
+		Periodic: map[string]releasecontroller.ReleasePeriodic{
 			"upgrade": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.6-nightly",
 				},
 			},
 			"upgrade-minor": {
 				Upgrade:     true,
 				UpgradeFrom: "PreviousMinor",
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 				},
 			},
 		},
 	}}
-	sameConfigDuplicate := []release_controller.ReleaseConfig{{
+	sameConfigDuplicate := []releasecontroller.ReleaseConfig{{
 		Name: "4.5.0-0.nightly",
-		Periodic: map[string]release_controller.ReleasePeriodic{
+		Periodic: map[string]releasecontroller.ReleasePeriodic{
 			"upgrade": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
 				},
 			},
 			"upgrade2": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
 				},
 			},
 			"upgrade-minor": {
 				Upgrade:     true,
 				UpgradeFrom: "PreviousMinor",
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.4-stable-to-4.5-nightly",
 				},
 			},
 		},
 	}, {
 		Name: "4.6.0-0.nightly",
-		Periodic: map[string]release_controller.ReleasePeriodic{
+		Periodic: map[string]releasecontroller.ReleasePeriodic{
 			"upgrade": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.6-nightly",
 				},
 			},
 			"upgrade-minor": {
 				Upgrade:     true,
 				UpgradeFrom: "PreviousMinor",
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 				},
 			},
 		},
 	}}
-	differentConfigDuplicate := []release_controller.ReleaseConfig{{
+	differentConfigDuplicate := []releasecontroller.ReleaseConfig{{
 		Name: "4.5.0-0.nightly",
-		Periodic: map[string]release_controller.ReleasePeriodic{
+		Periodic: map[string]releasecontroller.ReleasePeriodic{
 			"upgrade": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
 				},
 			},
 			"upgrade-minor": {
 				Upgrade:     true,
 				UpgradeFrom: "PreviousMinor",
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.4-stable-to-4.5-nightly",
 				},
 			},
 		},
 	}, {
 		Name: "4.6.0-0.nightly",
-		Periodic: map[string]release_controller.ReleasePeriodic{
+		Periodic: map[string]releasecontroller.ReleasePeriodic{
 			"upgrade": {
 				Upgrade: true,
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-nightly",
 				},
 			},
 			"upgrade-minor": {
 				Upgrade:     true,
 				UpgradeFrom: "PreviousMinor",
-				ProwJob: &release_controller.ProwJobVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
 					Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 				},
 			},
@@ -211,7 +211,7 @@ func TestFindDuplicatePeriodics(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		configs       []release_controller.ReleaseConfig
+		configs       []releasecontroller.ReleaseConfig
 		errorExpected bool
 	}{{
 		name:          "Valid configs",
@@ -240,33 +240,33 @@ func TestFindDuplicatePeriodics(t *testing.T) {
 func TestValidateUpgradeJobs(t *testing.T) {
 	testCases := []struct {
 		name        string
-		configs     []release_controller.ReleaseConfig
+		configs     []releasecontroller.ReleaseConfig
 		expectedErr bool
 	}{{
 		name: "Good config",
-		configs: []release_controller.ReleaseConfig{{
+		configs: []releasecontroller.ReleaseConfig{{
 			Name: "4.6.0-0.nightly",
-			Verify: map[string]release_controller.ReleaseVerification{
+			Verify: map[string]releasecontroller.ReleaseVerification{
 				"upgrade-minor": {
 					Upgrade:     true,
 					UpgradeFrom: "PreviousMinor",
-					ProwJob: &release_controller.ProwJobVerification{
+					ProwJob: &releasecontroller.ProwJobVerification{
 						Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 					},
 				},
 			},
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"upgrade-minor": {
 					Upgrade: true,
-					UpgradeFromRelease: &release_controller.UpgradeRelease{
-						Prerelease: &release_controller.UpgradePrerelease{
-							VersionBounds: release_controller.UpgradeVersionBounds{
+					UpgradeFromRelease: &releasecontroller.UpgradeRelease{
+						Prerelease: &releasecontroller.UpgradePrerelease{
+							VersionBounds: releasecontroller.UpgradeVersionBounds{
 								Lower: "4.5.0",
 								Upper: "4.6.0-0",
 							},
 						},
 					},
-					ProwJob: &release_controller.ProwJobVerification{
+					ProwJob: &releasecontroller.ProwJobVerification{
 						Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 					},
 				},
@@ -275,37 +275,37 @@ func TestValidateUpgradeJobs(t *testing.T) {
 		expectedErr: false,
 	}, {
 		name: "Bad Verification",
-		configs: []release_controller.ReleaseConfig{{
+		configs: []releasecontroller.ReleaseConfig{{
 			Name: "4.6.0-0.nightly",
-			Verify: map[string]release_controller.ReleaseVerification{
+			Verify: map[string]releasecontroller.ReleaseVerification{
 				"upgrade-minor": {
 					Upgrade:     true,
 					UpgradeFrom: "PreviousMinor",
-					UpgradeFromRelease: &release_controller.UpgradeRelease{
-						Prerelease: &release_controller.UpgradePrerelease{
-							VersionBounds: release_controller.UpgradeVersionBounds{
+					UpgradeFromRelease: &releasecontroller.UpgradeRelease{
+						Prerelease: &releasecontroller.UpgradePrerelease{
+							VersionBounds: releasecontroller.UpgradeVersionBounds{
 								Lower: "4.5.0",
 								Upper: "4.6.0-0",
 							},
 						},
 					},
-					ProwJob: &release_controller.ProwJobVerification{
+					ProwJob: &releasecontroller.ProwJobVerification{
 						Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 					},
 				},
 			},
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"upgrade-minor": {
 					Upgrade: true,
-					UpgradeFromRelease: &release_controller.UpgradeRelease{
-						Prerelease: &release_controller.UpgradePrerelease{
-							VersionBounds: release_controller.UpgradeVersionBounds{
+					UpgradeFromRelease: &releasecontroller.UpgradeRelease{
+						Prerelease: &releasecontroller.UpgradePrerelease{
+							VersionBounds: releasecontroller.UpgradeVersionBounds{
 								Lower: "4.5.0",
 								Upper: "4.6.0-0",
 							},
 						},
 					},
-					ProwJob: &release_controller.ProwJobVerification{
+					ProwJob: &releasecontroller.ProwJobVerification{
 						Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 					},
 				},
@@ -314,30 +314,30 @@ func TestValidateUpgradeJobs(t *testing.T) {
 		expectedErr: true,
 	}, {
 		name: "Bad Periodic",
-		configs: []release_controller.ReleaseConfig{{
+		configs: []releasecontroller.ReleaseConfig{{
 			Name: "4.6.0-0.nightly",
-			Verify: map[string]release_controller.ReleaseVerification{
+			Verify: map[string]releasecontroller.ReleaseVerification{
 				"upgrade-minor": {
 					Upgrade:     true,
 					UpgradeFrom: "PreviousMinor",
-					ProwJob: &release_controller.ProwJobVerification{
+					ProwJob: &releasecontroller.ProwJobVerification{
 						Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 					},
 				},
 			},
-			Periodic: map[string]release_controller.ReleasePeriodic{
+			Periodic: map[string]releasecontroller.ReleasePeriodic{
 				"upgrade-minor": {
 					Upgrade:     true,
 					UpgradeFrom: "PreviousMinor",
-					UpgradeFromRelease: &release_controller.UpgradeRelease{
-						Prerelease: &release_controller.UpgradePrerelease{
-							VersionBounds: release_controller.UpgradeVersionBounds{
+					UpgradeFromRelease: &releasecontroller.UpgradeRelease{
+						Prerelease: &releasecontroller.UpgradePrerelease{
+							VersionBounds: releasecontroller.UpgradeVersionBounds{
 								Lower: "4.5.0",
 								Upper: "4.6.0-0",
 							},
 						},
 					},
-					ProwJob: &release_controller.ProwJobVerification{
+					ProwJob: &releasecontroller.ProwJobVerification{
 						Name: "release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-nightly",
 					},
 				},

--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -323,14 +323,14 @@ func (c *Controller) processJob(obj interface{}) {
 	switch t := obj.(type) {
 	case *batchv1.Job:
 		// this job should wake the audit queue
-		if t.Annotations[release_controller.ReleaseAnnotationJobPurpose] == "audit" {
-			if name, ok := t.Annotations[release_controller.ReleaseAnnotationReleaseTag]; ok {
+		if t.Annotations[releasecontroller.ReleaseAnnotationJobPurpose] == "audit" {
+			if name, ok := t.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]; ok {
 				c.auditQueue.Add(name)
 			}
 			return
 		}
 
-		key, ok := queueKeyFor(t.Annotations[release_controller.ReleaseAnnotationSource])
+		key, ok := queueKeyFor(t.Annotations[releasecontroller.ReleaseAnnotationSource])
 		if !ok {
 			return
 		}
@@ -359,7 +359,7 @@ func (c *Controller) processJobIfComplete(obj interface{}) {
 func (c *Controller) processProwJob(obj interface{}) {
 	switch t := obj.(type) {
 	case *unstructured.Unstructured:
-		key, ok := queueKeyFor(t.GetAnnotations()[release_controller.ReleaseAnnotationSource])
+		key, ok := queueKeyFor(t.GetAnnotations()[releasecontroller.ReleaseAnnotationSource])
 		if !ok {
 			return
 		}
@@ -378,18 +378,18 @@ func (c *Controller) processImageStream(obj interface{}) {
 		c.expectations.Clear(t.Namespace, t.Name)
 
 		// if this image stream is a mirror for releases, requeue any that it touches
-		if _, ok := t.Annotations[release_controller.ReleaseAnnotationConfig]; ok {
+		if _, ok := t.Annotations[releasecontroller.ReleaseAnnotationConfig]; ok {
 			klog.V(6).Infof("Image stream %s is a release input and will be queued", t.Name)
 			c.addQueueKey(queueKey{namespace: t.Namespace, name: t.Name})
 			return
 		}
-		if key, ok := queueKeyFor(t.Annotations[release_controller.ReleaseAnnotationSource]); ok {
+		if key, ok := queueKeyFor(t.Annotations[releasecontroller.ReleaseAnnotationSource]); ok {
 			klog.V(6).Infof("Image stream %s was created by %v, queuing source", t.Name, key)
 			c.addQueueKey(key)
 			c.addBugzillaQueueKey(key)
 			return
 		}
-		if _, ok := t.Annotations[release_controller.ReleaseAnnotationHasReleases]; ok {
+		if _, ok := t.Annotations[releasecontroller.ReleaseAnnotationHasReleases]; ok {
 			// if the release image stream is modified, tags might have been deleted so retrigger
 			// everything
 			klog.V(6).Infof("Image stream %s is a release target, requeue release namespace", t.Name)
@@ -483,7 +483,7 @@ func (c *Controller) processNextNamespace(ns string) error {
 		return err
 	}
 	for _, imageStream := range imageStreams {
-		if _, ok := imageStream.Annotations[release_controller.ReleaseAnnotationConfig]; ok {
+		if _, ok := imageStream.Annotations[releasecontroller.ReleaseAnnotationConfig]; ok {
 			c.addQueueKey(queueKey{namespace: imageStream.Namespace, name: imageStream.Name})
 		}
 	}

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -252,7 +252,7 @@ func (c *Controller) findReleaseStreamTags(includeStableTags bool, tags ...strin
 		// TODO: should be refactored to be unsortedSemanticReleaseTags
 		releaseTags := sortedReleaseTags(r)
 		if includeStableTags {
-			if version, err := semverParseTolerant(r.Config.Name); err == nil || r.Config.As == release_controller.ReleaseConfigModeStable {
+			if version, err := semverParseTolerant(r.Config.Name); err == nil || r.Config.As == releasecontroller.ReleaseConfigModeStable {
 				stable.Releases = append(stable.Releases, StableRelease{
 					Release:  r,
 					Version:  version,
@@ -335,7 +335,7 @@ func (c *Controller) urlForArtifacts(tagName string) (string, bool) {
 	return fmt.Sprintf("https://%s/%s", c.artifactsHost, url.PathEscape(tagName)), true
 }
 
-func (c *Controller) locateLatest(w http.ResponseWriter, req *http.Request) (*release_controller.Release, *imagev1.TagReference, bool) {
+func (c *Controller) locateLatest(w http.ResponseWriter, req *http.Request) (*releasecontroller.Release, *imagev1.TagReference, bool) {
 	vars := mux.Vars(req)
 	streamName := vars["release"]
 	var constraint semver.Range
@@ -383,11 +383,11 @@ func (c *Controller) apiReleaseLatest(w http.ResponseWriter, req *http.Request) 
 	}
 
 	downloadURL, _ := c.urlForArtifacts(latest.Name)
-	resp := release_controller.APITag{
+	resp := releasecontroller.APITag{
 		Name:        latest.Name,
 		PullSpec:    findPublicImagePullSpec(r.Target, latest.Name),
 		DownloadURL: downloadURL,
-		Phase:       latest.Annotations[release_controller.ReleaseAnnotationPhase],
+		Phase:       latest.Annotations[releasecontroller.ReleaseAnnotationPhase],
 	}
 
 	switch req.URL.Query().Get("format") {
@@ -459,14 +459,14 @@ func (c *Controller) apiReleaseTags(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var tags []release_controller.APITag
+	var tags []releasecontroller.APITag
 	for _, tag := range r.Tags {
 		downloadURL, _ := c.urlForArtifacts(tag.Name)
-		phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
+		phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
 		if len(filterPhase) > 0 && !containsString(filterPhase, phase) {
 			continue
 		}
-		tags = append(tags, release_controller.APITag{
+		tags = append(tags, releasecontroller.APITag{
 			Name:        tag.Name,
 			PullSpec:    findPublicImagePullSpec(r.Release.Target, tag.Name),
 			DownloadURL: downloadURL,
@@ -474,7 +474,7 @@ func (c *Controller) apiReleaseTags(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 
-	resp := release_controller.APIRelease{
+	resp := releasecontroller.APIRelease{
 		Name: r.Release.Config.Name,
 		Tags: tags,
 	}
@@ -538,7 +538,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	summary := release_controller.APIReleaseInfo{
+	summary := releasecontroller.APIReleaseInfo{
 		Name:         tagInfo.Tag,
 		Results:      verificationJobs,
 		UpgradesTo:   c.graph.UpgradesTo(tagInfo.Tag),
@@ -782,10 +782,10 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
 	fmt.Fprintf(w, "<h1>%s</h1>\n", template.HTMLEscapeString(tagInfo.Tag))
 
-	switch tagInfo.Info.Tag.Annotations[release_controller.ReleaseAnnotationPhase] {
-	case release_controller.ReleasePhaseFailed:
-		fmt.Fprintf(w, `<div class="alert alert-danger"><p>%s</p>`, template.HTMLEscapeString(tagInfo.Info.Tag.Annotations[release_controller.ReleaseAnnotationMessage]))
-		if log := tagInfo.Info.Tag.Annotations[release_controller.ReleaseAnnotationLog]; len(log) > 0 {
+	switch tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase] {
+	case releasecontroller.ReleasePhaseFailed:
+		fmt.Fprintf(w, `<div class="alert alert-danger"><p>%s</p>`, template.HTMLEscapeString(tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationMessage]))
+		if log := tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationLog]; len(log) > 0 {
 			fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(log))
 		} else {
 			fmt.Fprintf(w, `<div><em>No failure log was captured</em></div>`)
@@ -809,7 +809,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		}
 		for _, from := range supportedUpgrades {
 			if !upgradeFound[from] {
-				upgradesTo = append(upgradesTo, release_controller.UpgradeHistory{
+				upgradesTo = append(upgradesTo, releasecontroller.UpgradeHistory{
 					From:  from,
 					To:    tagInfo.Tag,
 					Total: -1,
@@ -850,9 +850,9 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				if len(urls) > 2 {
 					for _, url := range urls {
 						switch upgrade.History[url].State {
-						case release_controller.ReleaseVerificationStateSucceeded:
+						case releasecontroller.ReleaseVerificationStateSucceeded:
 							fmt.Fprintf(w, ` <a class="text-success" href="%s">S</a>`, template.HTMLEscapeString(url))
-						case release_controller.ReleaseVerificationStateFailed:
+						case releasecontroller.ReleaseVerificationStateFailed:
 							fmt.Fprintf(w, ` <a class="text-danger" href="%s">F</a>`, template.HTMLEscapeString(url))
 						default:
 							fmt.Fprintf(w, ` <a class="" href="%s">P</a>`, template.HTMLEscapeString(url))
@@ -861,9 +861,9 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				} else {
 					for _, url := range urls {
 						switch upgrade.History[url].State {
-						case release_controller.ReleaseVerificationStateSucceeded:
+						case releasecontroller.ReleaseVerificationStateSucceeded:
 							fmt.Fprintf(w, ` <a class="text-success" href="%s">Success</a>`, template.HTMLEscapeString(url))
-						case release_controller.ReleaseVerificationStateFailed:
+						case releasecontroller.ReleaseVerificationStateFailed:
 							fmt.Fprintf(w, ` <a class="text-danger" href="%s">Failed</a>`, template.HTMLEscapeString(url))
 						default:
 							fmt.Fprintf(w, ` <a class="" href="%s">Pending</a>`, template.HTMLEscapeString(url))
@@ -899,9 +899,9 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				if len(urls) > 2 {
 					for _, url := range urls {
 						switch upgrade.History[url].State {
-						case release_controller.ReleaseVerificationStateSucceeded:
+						case releasecontroller.ReleaseVerificationStateSucceeded:
 							fmt.Fprintf(w, ` <a class="text-success" href="%s">S</a>`, template.HTMLEscapeString(url))
-						case release_controller.ReleaseVerificationStateFailed:
+						case releasecontroller.ReleaseVerificationStateFailed:
 							fmt.Fprintf(w, ` <a class="text-danger" href="%s">F</a>`, template.HTMLEscapeString(url))
 						default:
 							fmt.Fprintf(w, ` <a class="" href="%s">P</a>`, template.HTMLEscapeString(url))
@@ -910,9 +910,9 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				} else {
 					for _, url := range urls {
 						switch upgrade.History[url].State {
-						case release_controller.ReleaseVerificationStateSucceeded:
+						case releasecontroller.ReleaseVerificationStateSucceeded:
 							fmt.Fprintf(w, ` <a class="text-success" href="%s">Success</a>`, template.HTMLEscapeString(url))
-						case release_controller.ReleaseVerificationStateFailed:
+						case releasecontroller.ReleaseVerificationStateFailed:
 							fmt.Fprintf(w, ` <a class="text-danger" href="%s">Failed</a>`, template.HTMLEscapeString(url))
 						default:
 							fmt.Fprintf(w, ` <a class="" href="%s">Pending</a>`, template.HTMLEscapeString(url))
@@ -969,7 +969,7 @@ var (
 	errStreamTagNotFound = fmt.Errorf("no tags exist within the release that satisfy the request")
 )
 
-func (c *Controller) latestForStream(streamName string, constraint semver.Range, relativeIndex int) (*release_controller.Release, *imagev1.TagReference, error) {
+func (c *Controller) latestForStream(streamName string, constraint semver.Range, relativeIndex int) (*releasecontroller.Release, *imagev1.TagReference, error) {
 	imageStreams, err := c.releaseLister.List(labels.Everything())
 	if err != nil {
 		return nil, nil, err
@@ -983,7 +983,7 @@ func (c *Controller) latestForStream(streamName string, constraint semver.Range,
 			continue
 		}
 		// find all accepted tags, then sort by semantic version
-		tags := unsortedSemanticReleaseTags(r, release_controller.ReleasePhaseAccepted)
+		tags := unsortedSemanticReleaseTags(r, releasecontroller.ReleasePhaseAccepted)
 		sort.Sort(tags)
 		for _, ver := range tags {
 			if constraint != nil && (ver.Version == nil || !constraint(*ver.Version)) {
@@ -1073,7 +1073,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 				}
 				var out []string
 				switch r.Release.Config.As {
-				case release_controller.ReleaseConfigModeStable:
+				case releasecontroller.ReleaseConfigModeStable:
 					if len(r.Release.Config.Message) == 0 {
 						out = append(out, fmt.Sprintf(`<span>stable tags</span>`))
 					}
@@ -1153,7 +1153,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 			Tags:    sortedReleaseTags(r),
 		}
 		var delays []string
-		if r.Config.As != release_controller.ReleaseConfigModeStable && len(s.Tags) > 0 {
+		if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
 			if ok, _, queueAfter := isReleaseDelayedForInterval(r, s.Tags[0]); ok {
 				delays = append(delays, fmt.Sprintf("waiting for %s", queueAfter.Truncate(time.Second)))
 			}
@@ -1164,7 +1164,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 		if len(delays) > 0 {
 			s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
 		}
-		if r.Config.As != release_controller.ReleaseConfigModeStable {
+		if r.Config.As != releasecontroller.ReleaseConfigModeStable {
 			s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph, false)
 		}
 		page.Streams = append(page.Streams, s)
@@ -1219,7 +1219,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 				}
 				var out []string
 				switch r.Release.Config.As {
-				case release_controller.ReleaseConfigModeStable:
+				case releasecontroller.ReleaseConfigModeStable:
 					if len(r.Release.Config.Message) == 0 {
 						out = append(out, fmt.Sprintf(`<span>stable tags</span>`))
 					}
@@ -1296,7 +1296,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 			Tags:    sortedReleaseTags(r),
 		}
 		var delays []string
-		if r.Config.As != release_controller.ReleaseConfigModeStable && len(s.Tags) > 0 {
+		if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
 			if ok, _, queueAfter := isReleaseDelayedForInterval(r, s.Tags[0]); ok {
 				delays = append(delays, fmt.Sprintf("waiting for %s", queueAfter.Truncate(time.Second)))
 			}
@@ -1311,7 +1311,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 		if len(delays) > 0 {
 			s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
 		}
-		if r.Config.As != release_controller.ReleaseConfigModeStable {
+		if r.Config.As != releasecontroller.ReleaseConfigModeStable {
 			s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph, true)
 		}
 		page.Streams = append(page.Streams, s)
@@ -1330,10 +1330,10 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 func isReleaseFailing(tags []*imagev1.TagReference, maxUnready int) bool {
 	unreadyCount := 0
 	for i := 0; unreadyCount < maxUnready && i < len(tags); i++ {
-		switch tags[i].Annotations[release_controller.ReleaseAnnotationPhase] {
-		case release_controller.ReleasePhaseReady:
+		switch tags[i].Annotations[releasecontroller.ReleaseAnnotationPhase] {
+		case releasecontroller.ReleasePhaseReady:
 			continue
-		case release_controller.ReleasePhaseAccepted:
+		case releasecontroller.ReleasePhaseAccepted:
 			return false
 		default:
 			unreadyCount++
@@ -1387,7 +1387,7 @@ func (c *Controller) apiReleaseConfig(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	var release *release_controller.Release
+	var release *releasecontroller.Release
 
 	for _, stream := range imageStreams {
 		r, ok, err := c.releaseDefinition(stream)
@@ -1407,8 +1407,8 @@ func (c *Controller) apiReleaseConfig(w http.ResponseWriter, req *http.Request) 
 	}
 
 	displayConfig := false
-	periodicJobs := make(map[string]release_controller.ReleasePeriodic)
-	verificationJobs := make(map[string]release_controller.ReleaseVerification)
+	periodicJobs := make(map[string]releasecontroller.ReleasePeriodic)
+	verificationJobs := make(map[string]releasecontroller.ReleaseVerification)
 
 	if jobType == "periodic" {
 		for name, periodic := range release.Config.Periodic {

--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"io"
 	"net/url"
 	"sort"
@@ -25,7 +26,7 @@ type ReleasePage struct {
 }
 
 type ReleaseStream struct {
-	Release *Release
+	Release *release_controller.Release
 	Tags    []*imagev1.TagReference
 
 	// Delayed is set if there is a pending release
@@ -54,10 +55,10 @@ type ReleaseCheckResult struct {
 }
 
 type ReleaseStreamTag struct {
-	Release *Release
+	Release *release_controller.Release
 	Tag     *imagev1.TagReference
 
-	PreviousRelease *Release
+	PreviousRelease *release_controller.Release
 	Previous        *imagev1.TagReference
 
 	Older  []*imagev1.TagReference
@@ -82,7 +83,7 @@ func (v StableReleases) Len() int      { return len(v) }
 func (v StableReleases) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
 
 type StableRelease struct {
-	Release  *Release
+	Release  *release_controller.Release
 	Version  semver.Version
 	Versions SemanticVersions
 }
@@ -143,22 +144,22 @@ type ReleaseUpgrades struct {
 }
 
 type ReleaseTagUpgrade struct {
-	Internal []UpgradeHistory
-	External []UpgradeHistory
+	Internal []release_controller.UpgradeHistory
+	External []release_controller.UpgradeHistory
 	Visual   []ReleaseTagUpgradeVisual
 }
 
 type ReleaseTagUpgradeVisual struct {
-	Begin, Current, End *UpgradeHistory
+	Begin, Current, End *release_controller.UpgradeHistory
 }
 
 func phaseCell(tag imagev1.TagReference) string {
-	phase := tag.Annotations[releaseAnnotationPhase]
+	phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
 	switch phase {
-	case releasePhaseRejected:
+	case release_controller.ReleasePhaseRejected:
 		return fmt.Sprintf("<td class=\"%s\" title=\"%s\">%s</td>",
 			phaseAlert(tag),
-			template.HTMLEscapeString(tag.Annotations[releaseAnnotationMessage]),
+			template.HTMLEscapeString(tag.Annotations[release_controller.ReleaseAnnotationMessage]),
 			template.HTMLEscapeString(phase),
 		)
 	}
@@ -166,28 +167,28 @@ func phaseCell(tag imagev1.TagReference) string {
 }
 
 func phaseAlert(tag imagev1.TagReference) string {
-	phase := tag.Annotations[releaseAnnotationPhase]
+	phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
 	switch phase {
-	case releasePhasePending:
+	case release_controller.ReleasePhasePending:
 		return ""
-	case releasePhaseReady:
+	case release_controller.ReleasePhaseReady:
 		return ""
-	case releasePhaseAccepted:
+	case release_controller.ReleasePhaseAccepted:
 		return "text-success"
-	case releasePhaseFailed:
+	case release_controller.ReleasePhaseFailed:
 		return "text-danger"
-	case releasePhaseRejected:
+	case release_controller.ReleasePhaseRejected:
 		return "text-danger"
 	default:
 		return "text-danger"
 	}
 }
 
-func styleForUpgrade(upgrade *UpgradeHistory) string {
+func styleForUpgrade(upgrade *release_controller.UpgradeHistory) string {
 	switch upgradeSummaryState(upgrade) {
-	case releaseVerificationStateFailed:
+	case release_controller.ReleaseVerificationStateFailed:
 		return "border-color: #dc3545"
-	case releaseVerificationStateSucceeded:
+	case release_controller.ReleaseVerificationStateSucceeded:
 		return "border-color: #28a745"
 	default:
 		return "border-color: #007bff"
@@ -272,9 +273,9 @@ func upgradeJobs(upgrades *ReleaseUpgrades, index int, tagCreationTimestampStrin
 		}
 		for url, result := range visual.Begin.History {
 			switch result.State {
-			case releaseVerificationStateSucceeded:
+			case release_controller.ReleaseVerificationStateSucceeded:
 				successCount++
-			case releaseVerificationStateFailed:
+			case release_controller.ReleaseVerificationStateFailed:
 				buf.WriteString(fmt.Sprintf(`<a class="text-danger" href=%s>%s</a><br>`, url, visual.Begin.From))
 			default:
 				otherCount++
@@ -285,9 +286,9 @@ func upgradeJobs(upgrades *ReleaseUpgrades, index int, tagCreationTimestampStrin
 	for _, external := range upgrades.Tags[index].External {
 		for url, result := range external.History {
 			switch result.State {
-			case releaseVerificationStateSucceeded:
+			case release_controller.ReleaseVerificationStateSucceeded:
 				successCount++
-			case releaseVerificationStateFailed:
+			case release_controller.ReleaseVerificationStateFailed:
 				buf.WriteString(fmt.Sprintf(`<a class="text-danger" href=%s>%s</a><br>`, url, external.From))
 			default:
 				otherCount++
@@ -303,17 +304,17 @@ func upgradeJobs(upgrades *ReleaseUpgrades, index int, tagCreationTimestampStrin
 	return buf2.String()
 }
 func canLink(tag imagev1.TagReference) bool {
-	switch tag.Annotations[releaseAnnotationPhase] {
-	case releasePhasePending:
+	switch tag.Annotations[release_controller.ReleaseAnnotationPhase] {
+	case release_controller.ReleasePhasePending:
 		return false
 	default:
 		return true
 	}
 }
 
-func tableLink(config *ReleaseConfig, tag imagev1.TagReference) string {
+func tableLink(config *release_controller.ReleaseConfig, tag imagev1.TagReference) string {
 	if canLink(tag) {
-		if value, ok := tag.Annotations[releaseAnnotationKeep]; ok {
+		if value, ok := tag.Annotations[release_controller.ReleaseAnnotationKeep]; ok {
 			return fmt.Sprintf(`<td class="text-monospace"><a title="%s" class="%s" href="/releasestream/%s/release/%s">%s <span>*</span></a></td>`, template.HTMLEscapeString(value), phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
 		}
 		return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
@@ -321,12 +322,12 @@ func tableLink(config *ReleaseConfig, tag imagev1.TagReference) string {
 	return fmt.Sprintf(`<td class="text-monospace %s">%s</td>`, phaseAlert(tag), template.HTMLEscapeString(tag.Name))
 }
 
-func links(tag imagev1.TagReference, release *Release) string {
-	links := tag.Annotations[releaseAnnotationVerify]
+func links(tag imagev1.TagReference, release *release_controller.Release) string {
+	links := tag.Annotations[release_controller.ReleaseAnnotationVerify]
 	if len(links) == 0 {
 		return ""
 	}
-	var status VerificationStatusMap
+	var status release_controller.VerificationStatusMap
 	if err := json.Unmarshal([]byte(links), &status); err != nil {
 		return "error"
 	}
@@ -340,9 +341,9 @@ func links(tag imagev1.TagReference, release *Release) string {
 			continue
 		}
 		switch s.State {
-		case releaseVerificationStateSucceeded:
+		case release_controller.ReleaseVerificationStateSucceeded:
 			continue
-		case releaseVerificationStateFailed:
+		case release_controller.ReleaseVerificationStateFailed:
 			failing = append(failing, k)
 		default:
 			pending = append(pending, k)
@@ -366,9 +367,9 @@ func links(tag imagev1.TagReference, release *Release) string {
 		if s, ok := status[key]; ok {
 			if len(s.URL) > 0 {
 				switch s.State {
-				case releaseVerificationStateSucceeded:
+				case release_controller.ReleaseVerificationStateSucceeded:
 					continue
-				case releaseVerificationStateFailed:
+				case release_controller.ReleaseVerificationStateFailed:
 					buf.WriteString(" <a title=\"Failed\" class=\"text-danger\" href=\"")
 				default:
 					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
@@ -380,9 +381,9 @@ func links(tag imagev1.TagReference, release *Release) string {
 				continue
 			}
 			switch s.State {
-			case releaseVerificationStateSucceeded:
+			case release_controller.ReleaseVerificationStateSucceeded:
 				continue
-			case releaseVerificationStateFailed:
+			case release_controller.ReleaseVerificationStateFailed:
 				buf.WriteString(" <span title=\"Failed\" class=\"text-danger\">")
 			default:
 				buf.WriteString(" <span title=\"Pending\" class=\"\">")
@@ -391,7 +392,7 @@ func links(tag imagev1.TagReference, release *Release) string {
 			buf.WriteString("</span>")
 			continue
 		}
-		final := tag.Annotations[releaseAnnotationPhase] == releasePhaseRejected || tag.Annotations[releaseAnnotationPhase] == releasePhaseAccepted
+		final := tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseRejected || tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseAccepted
 		if !release.Config.Verify[key].Disabled && !final {
 			buf.WriteString(" <span title=\"Pending\">")
 			buf.WriteString(template.HTMLEscapeString(key))
@@ -416,18 +417,18 @@ func links(tag imagev1.TagReference, release *Release) string {
 	return buf.String()
 }
 
-func getVerificationJobs(tag imagev1.TagReference, release *Release) (*VerificationJobsSummary, string) {
-	links := tag.Annotations[releaseAnnotationVerify]
+func getVerificationJobs(tag imagev1.TagReference, release *release_controller.Release) (*release_controller.VerificationJobsSummary, string) {
+	links := tag.Annotations[release_controller.ReleaseAnnotationVerify]
 	if len(links) == 0 {
 		return nil, fmt.Sprintf(`<p><em>No tests for this release</em>`)
 	}
-	var status VerificationStatusMap
+	var status release_controller.VerificationStatusMap
 	if err := json.Unmarshal([]byte(links), &status); err != nil {
 		return nil, fmt.Sprintf(`<p><em class="text-danger">Unable to load test info</em>`)
 	}
-	blockingJobs := make(VerificationStatusMap)
-	informingJobs := make(VerificationStatusMap)
-	pendingJobs := make(VerificationStatusMap)
+	blockingJobs := make(release_controller.VerificationStatusMap)
+	informingJobs := make(release_controller.VerificationStatusMap)
+	pendingJobs := make(release_controller.VerificationStatusMap)
 	keys := make([]string, 0, len(release.Config.Verify))
 	for k := range release.Config.Verify {
 		keys = append(keys, k)
@@ -444,21 +445,21 @@ func getVerificationJobs(tag imagev1.TagReference, release *Release) (*Verificat
 			pendingJobs[key] = nil
 		}
 	}
-	return &VerificationJobsSummary{
+	return &release_controller.VerificationJobsSummary{
 		BlockingJobs:  blockingJobs,
 		InformingJobs: informingJobs,
 		PendingJobs:   pendingJobs,
 	}, ""
 }
 
-func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *Release) {
+func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *release_controller.Release) {
 	verificationJobs, msg := getVerificationJobs(tag, release)
 	if len(msg) > 0 {
 		fmt.Fprintf(w, msg)
 		return
 	}
 	buf := &bytes.Buffer{}
-	final := tag.Annotations[releaseAnnotationPhase] == releasePhaseRejected || tag.Annotations[releaseAnnotationPhase] == releasePhaseAccepted
+	final := tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseRejected || tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseAccepted
 	if len(verificationJobs.BlockingJobs) > 0 {
 		buf.WriteString("<li>Blocking jobs<ul>")
 		buf.WriteString(renderVerificationJobsList(verificationJobs.BlockingJobs, release, final))
@@ -481,7 +482,7 @@ func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *Release) 
 	}
 }
 
-func renderVerificationJobsList(jobs VerificationStatusMap, release *Release, final bool) string {
+func renderVerificationJobsList(jobs release_controller.VerificationStatusMap, release *release_controller.Release, final bool) string {
 	buf := &bytes.Buffer{}
 	keys := make([]string, 0, len(jobs))
 	for k := range jobs {
@@ -500,9 +501,9 @@ func renderVerificationJobsList(jobs VerificationStatusMap, release *Release, fi
 		}
 		if len(value.URL) > 0 {
 			switch value.State {
-			case releaseVerificationStateFailed:
+			case release_controller.ReleaseVerificationStateFailed:
 				buf.WriteString("<li><a class=\"text-danger\" href=\"")
-			case releaseVerificationStateSucceeded:
+			case release_controller.ReleaseVerificationStateSucceeded:
 				buf.WriteString("<li><a class=\"text-success\" href=\"")
 			default:
 				buf.WriteString("<li><a class=\"\" href=\"")
@@ -511,9 +512,9 @@ func renderVerificationJobsList(jobs VerificationStatusMap, release *Release, fi
 			buf.WriteString("\">")
 			buf.WriteString(template.HTMLEscapeString(key))
 			switch value.State {
-			case releaseVerificationStateFailed:
+			case release_controller.ReleaseVerificationStateFailed:
 				buf.WriteString(" Failed")
-			case releaseVerificationStateSucceeded:
+			case release_controller.ReleaseVerificationStateSucceeded:
 				buf.WriteString(" Succeeded")
 			default:
 				buf.WriteString(" Pending")
@@ -529,18 +530,18 @@ func renderVerificationJobsList(jobs VerificationStatusMap, release *Release, fi
 			continue
 		}
 		switch value.State {
-		case releaseVerificationStateFailed:
+		case release_controller.ReleaseVerificationStateFailed:
 			buf.WriteString("<li><span class=\"text-danger\">")
-		case releaseVerificationStateSucceeded:
+		case release_controller.ReleaseVerificationStateSucceeded:
 			buf.WriteString("<li><span class=\"text-success\">")
 		default:
 			buf.WriteString("<li><span class=\"\">")
 		}
 		buf.WriteString(template.HTMLEscapeString(key))
 		switch value.State {
-		case releaseVerificationStateFailed:
+		case release_controller.ReleaseVerificationStateFailed:
 			buf.WriteString(" Failed")
-		case releaseVerificationStateSucceeded:
+		case release_controller.ReleaseVerificationStateSucceeded:
 			buf.WriteString(" Succeeded")
 		default:
 			buf.WriteString(" Pending")
@@ -579,7 +580,7 @@ func releaseJoin(streams []ReleaseStream) string {
 	return strings.Join(releases, " | ")
 }
 
-func hasPublishTag(config *ReleaseConfig) (string, bool) {
+func hasPublishTag(config *release_controller.ReleaseConfig) (string, bool) {
 	for _, v := range config.Publish {
 		if v.TagRef != nil {
 			return v.TagRef.Name, true
@@ -588,7 +589,7 @@ func hasPublishTag(config *ReleaseConfig) (string, bool) {
 	return "", false
 }
 
-func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReference, release *Release) *imagev1.TagReference {
+func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReference, release *release_controller.Release) *imagev1.TagReference {
 	if len(older) == 0 {
 		return nil
 	}
@@ -603,7 +604,7 @@ func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReferenc
 		}
 	}
 	for _, old := range older {
-		if old.Annotations[releaseAnnotationPhase] == releasePhaseAccepted {
+		if old.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseAccepted {
 			return old
 		}
 	}
@@ -617,7 +618,7 @@ type nopFlusher struct{}
 
 func (_ nopFlusher) Flush() {}
 
-func upgradeSummaryToString(history []UpgradeHistory) string {
+func upgradeSummaryToString(history []release_controller.UpgradeHistory) string {
 	var out []string
 	for _, h := range history {
 		out = append(out, fmt.Sprintf("%s->%s", h.From, h.To))
@@ -625,7 +626,7 @@ func upgradeSummaryToString(history []UpgradeHistory) string {
 	return strings.Join(out, ",")
 }
 
-func calculateReleaseUpgrades(release *Release, tags []*imagev1.TagReference, graph *UpgradeGraph, fullHistory bool) *ReleaseUpgrades {
+func calculateReleaseUpgrades(release *release_controller.Release, tags []*imagev1.TagReference, graph *UpgradeGraph, fullHistory bool) *ReleaseUpgrades {
 	tagNames := make([]string, 0, len(tags))
 	internalTags := make(map[string]int)
 	for i, tag := range tags {
@@ -639,14 +640,14 @@ func calculateReleaseUpgrades(release *Release, tags []*imagev1.TagReference, gr
 	// tabular form with indicators whether a row is starting, continuing, or
 	// ending
 	var visual []ReleaseTagUpgradeVisual
-	var summaries []UpgradeHistory
+	var summaries []release_controller.UpgradeHistory
 	if fullHistory {
 		summaries = graph.UpgradesTo(tagNames...)
 	} else {
 		summaries = graph.SummarizeUpgradesTo(tagNames...)
 	}
 	for _, name := range tagNames {
-		var internal, external []UpgradeHistory
+		var internal, external []release_controller.UpgradeHistory
 		internal, summaries = takeUpgradesTo(summaries, name)
 		internal, external = takeUpgradesFromNames(internal, internalTags)
 		sort.Slice(internal, func(i, j int) bool {
@@ -726,19 +727,19 @@ func calculateReleaseUpgrades(release *Release, tags []*imagev1.TagReference, gr
 	}
 }
 
-func upgradeSummaryState(summary *UpgradeHistory) string {
+func upgradeSummaryState(summary *release_controller.UpgradeHistory) string {
 	if summary.Success > 0 {
-		return releaseVerificationStateSucceeded
+		return release_controller.ReleaseVerificationStateSucceeded
 	}
 	if summary.Failure > 0 {
-		return releaseVerificationStateFailed
+		return release_controller.ReleaseVerificationStateFailed
 	}
-	return releaseVerificationStatePending
+	return release_controller.ReleaseVerificationStatePending
 }
 
 // takeUpgradesTo returns all leading summaries with To equal to tag, and the rest of the
 // slice.
-func takeUpgradesTo(summaries []UpgradeHistory, tag string) ([]UpgradeHistory, []UpgradeHistory) {
+func takeUpgradesTo(summaries []release_controller.UpgradeHistory, tag string) ([]release_controller.UpgradeHistory, []release_controller.UpgradeHistory) {
 	for i, summary := range summaries {
 		if summary.To == tag {
 			continue
@@ -750,14 +751,14 @@ func takeUpgradesTo(summaries []UpgradeHistory, tag string) ([]UpgradeHistory, [
 
 // takeUpgradesFromNames splits the provided summaries slice into two slices - those with Froms
 // in names and those without.
-func takeUpgradesFromNames(summaries []UpgradeHistory, names map[string]int) (withNames []UpgradeHistory, withoutNames []UpgradeHistory) {
+func takeUpgradesFromNames(summaries []release_controller.UpgradeHistory, names map[string]int) (withNames []release_controller.UpgradeHistory, withoutNames []release_controller.UpgradeHistory) {
 	for i := range summaries {
 		if _, ok := names[summaries[i].From]; ok {
 			continue
 		}
-		left := make([]UpgradeHistory, i, len(summaries))
+		left := make([]release_controller.UpgradeHistory, i, len(summaries))
 		copy(left, summaries[:i])
-		var right []UpgradeHistory
+		var right []release_controller.UpgradeHistory
 		for j, summary := range summaries[i:] {
 			if _, ok := names[summaries[i+j].From]; ok {
 				left = append(left, summary)
@@ -772,7 +773,7 @@ func takeUpgradesFromNames(summaries []UpgradeHistory, names map[string]int) (wi
 
 // filterWithPrefix removes any summary from summaries that has a From that starts with
 // prefix.
-func filterWithPrefix(summaries []UpgradeHistory, prefix string) []UpgradeHistory {
+func filterWithPrefix(summaries []release_controller.UpgradeHistory, prefix string) []release_controller.UpgradeHistory {
 	if len(prefix) == 0 {
 		return summaries
 	}
@@ -780,7 +781,7 @@ func filterWithPrefix(summaries []UpgradeHistory, prefix string) []UpgradeHistor
 		if !strings.HasPrefix(summaries[i].From, prefix) {
 			continue
 		}
-		valid := make([]UpgradeHistory, 0, len(summaries)-i)
+		valid := make([]release_controller.UpgradeHistory, 0, len(summaries)-i)
 		for _, summary := range summaries {
 			if !strings.HasPrefix(summary.From, prefix) {
 				valid = append(valid, summary)
@@ -801,7 +802,7 @@ func (r preferredReleases) Less(i, j int) bool {
 	if a.Release.Config.Hide && !b.Release.Config.Hide {
 		return false
 	}
-	aStable, bStable := a.Release.Config.As == releaseConfigModeStable, b.Release.Config.As == releaseConfigModeStable
+	aStable, bStable := a.Release.Config.As == release_controller.ReleaseConfigModeStable, b.Release.Config.As == release_controller.ReleaseConfigModeStable
 	if aStable && !bStable {
 		return true
 	}
@@ -826,10 +827,10 @@ func (r preferredReleases) Len() int      { return len(r) }
 
 type newestSemVerFromSummaries struct {
 	versions  []semver.Version
-	summaries []UpgradeHistory
+	summaries []release_controller.UpgradeHistory
 }
 
-func newNewestSemVerFromSummaries(summaries []UpgradeHistory) newestSemVerFromSummaries {
+func newNewestSemVerFromSummaries(summaries []release_controller.UpgradeHistory) newestSemVerFromSummaries {
 	versions := make([]semver.Version, len(summaries))
 	for i, summary := range summaries {
 		if v, err := semver.Parse(summary.From); err == nil {
@@ -866,10 +867,10 @@ func (s newestSemVerFromSummaries) Len() int { return len(s.summaries) }
 
 type newestSemVerToSummaries struct {
 	versions  []semver.Version
-	summaries []UpgradeHistory
+	summaries []release_controller.UpgradeHistory
 }
 
-func newNewestSemVerToSummaries(summaries []UpgradeHistory) newestSemVerToSummaries {
+func newNewestSemVerToSummaries(summaries []release_controller.UpgradeHistory) newestSemVerToSummaries {
 	versions := make([]semver.Version, len(summaries))
 	for i, summary := range summaries {
 		if v, err := semver.Parse(summary.To); err == nil {

--- a/cmd/release-controller/http_helper.go
+++ b/cmd/release-controller/http_helper.go
@@ -26,7 +26,7 @@ type ReleasePage struct {
 }
 
 type ReleaseStream struct {
-	Release *release_controller.Release
+	Release *releasecontroller.Release
 	Tags    []*imagev1.TagReference
 
 	// Delayed is set if there is a pending release
@@ -55,10 +55,10 @@ type ReleaseCheckResult struct {
 }
 
 type ReleaseStreamTag struct {
-	Release *release_controller.Release
+	Release *releasecontroller.Release
 	Tag     *imagev1.TagReference
 
-	PreviousRelease *release_controller.Release
+	PreviousRelease *releasecontroller.Release
 	Previous        *imagev1.TagReference
 
 	Older  []*imagev1.TagReference
@@ -83,7 +83,7 @@ func (v StableReleases) Len() int      { return len(v) }
 func (v StableReleases) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
 
 type StableRelease struct {
-	Release  *release_controller.Release
+	Release  *releasecontroller.Release
 	Version  semver.Version
 	Versions SemanticVersions
 }
@@ -144,22 +144,22 @@ type ReleaseUpgrades struct {
 }
 
 type ReleaseTagUpgrade struct {
-	Internal []release_controller.UpgradeHistory
-	External []release_controller.UpgradeHistory
+	Internal []releasecontroller.UpgradeHistory
+	External []releasecontroller.UpgradeHistory
 	Visual   []ReleaseTagUpgradeVisual
 }
 
 type ReleaseTagUpgradeVisual struct {
-	Begin, Current, End *release_controller.UpgradeHistory
+	Begin, Current, End *releasecontroller.UpgradeHistory
 }
 
 func phaseCell(tag imagev1.TagReference) string {
-	phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
+	phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
 	switch phase {
-	case release_controller.ReleasePhaseRejected:
+	case releasecontroller.ReleasePhaseRejected:
 		return fmt.Sprintf("<td class=\"%s\" title=\"%s\">%s</td>",
 			phaseAlert(tag),
-			template.HTMLEscapeString(tag.Annotations[release_controller.ReleaseAnnotationMessage]),
+			template.HTMLEscapeString(tag.Annotations[releasecontroller.ReleaseAnnotationMessage]),
 			template.HTMLEscapeString(phase),
 		)
 	}
@@ -167,28 +167,28 @@ func phaseCell(tag imagev1.TagReference) string {
 }
 
 func phaseAlert(tag imagev1.TagReference) string {
-	phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
+	phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
 	switch phase {
-	case release_controller.ReleasePhasePending:
+	case releasecontroller.ReleasePhasePending:
 		return ""
-	case release_controller.ReleasePhaseReady:
+	case releasecontroller.ReleasePhaseReady:
 		return ""
-	case release_controller.ReleasePhaseAccepted:
+	case releasecontroller.ReleasePhaseAccepted:
 		return "text-success"
-	case release_controller.ReleasePhaseFailed:
+	case releasecontroller.ReleasePhaseFailed:
 		return "text-danger"
-	case release_controller.ReleasePhaseRejected:
+	case releasecontroller.ReleasePhaseRejected:
 		return "text-danger"
 	default:
 		return "text-danger"
 	}
 }
 
-func styleForUpgrade(upgrade *release_controller.UpgradeHistory) string {
+func styleForUpgrade(upgrade *releasecontroller.UpgradeHistory) string {
 	switch upgradeSummaryState(upgrade) {
-	case release_controller.ReleaseVerificationStateFailed:
+	case releasecontroller.ReleaseVerificationStateFailed:
 		return "border-color: #dc3545"
-	case release_controller.ReleaseVerificationStateSucceeded:
+	case releasecontroller.ReleaseVerificationStateSucceeded:
 		return "border-color: #28a745"
 	default:
 		return "border-color: #007bff"
@@ -273,9 +273,9 @@ func upgradeJobs(upgrades *ReleaseUpgrades, index int, tagCreationTimestampStrin
 		}
 		for url, result := range visual.Begin.History {
 			switch result.State {
-			case release_controller.ReleaseVerificationStateSucceeded:
+			case releasecontroller.ReleaseVerificationStateSucceeded:
 				successCount++
-			case release_controller.ReleaseVerificationStateFailed:
+			case releasecontroller.ReleaseVerificationStateFailed:
 				buf.WriteString(fmt.Sprintf(`<a class="text-danger" href=%s>%s</a><br>`, url, visual.Begin.From))
 			default:
 				otherCount++
@@ -286,9 +286,9 @@ func upgradeJobs(upgrades *ReleaseUpgrades, index int, tagCreationTimestampStrin
 	for _, external := range upgrades.Tags[index].External {
 		for url, result := range external.History {
 			switch result.State {
-			case release_controller.ReleaseVerificationStateSucceeded:
+			case releasecontroller.ReleaseVerificationStateSucceeded:
 				successCount++
-			case release_controller.ReleaseVerificationStateFailed:
+			case releasecontroller.ReleaseVerificationStateFailed:
 				buf.WriteString(fmt.Sprintf(`<a class="text-danger" href=%s>%s</a><br>`, url, external.From))
 			default:
 				otherCount++
@@ -304,17 +304,17 @@ func upgradeJobs(upgrades *ReleaseUpgrades, index int, tagCreationTimestampStrin
 	return buf2.String()
 }
 func canLink(tag imagev1.TagReference) bool {
-	switch tag.Annotations[release_controller.ReleaseAnnotationPhase] {
-	case release_controller.ReleasePhasePending:
+	switch tag.Annotations[releasecontroller.ReleaseAnnotationPhase] {
+	case releasecontroller.ReleasePhasePending:
 		return false
 	default:
 		return true
 	}
 }
 
-func tableLink(config *release_controller.ReleaseConfig, tag imagev1.TagReference) string {
+func tableLink(config *releasecontroller.ReleaseConfig, tag imagev1.TagReference) string {
 	if canLink(tag) {
-		if value, ok := tag.Annotations[release_controller.ReleaseAnnotationKeep]; ok {
+		if value, ok := tag.Annotations[releasecontroller.ReleaseAnnotationKeep]; ok {
 			return fmt.Sprintf(`<td class="text-monospace"><a title="%s" class="%s" href="/releasestream/%s/release/%s">%s <span>*</span></a></td>`, template.HTMLEscapeString(value), phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
 		}
 		return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
@@ -322,12 +322,12 @@ func tableLink(config *release_controller.ReleaseConfig, tag imagev1.TagReferenc
 	return fmt.Sprintf(`<td class="text-monospace %s">%s</td>`, phaseAlert(tag), template.HTMLEscapeString(tag.Name))
 }
 
-func links(tag imagev1.TagReference, release *release_controller.Release) string {
-	links := tag.Annotations[release_controller.ReleaseAnnotationVerify]
+func links(tag imagev1.TagReference, release *releasecontroller.Release) string {
+	links := tag.Annotations[releasecontroller.ReleaseAnnotationVerify]
 	if len(links) == 0 {
 		return ""
 	}
-	var status release_controller.VerificationStatusMap
+	var status releasecontroller.VerificationStatusMap
 	if err := json.Unmarshal([]byte(links), &status); err != nil {
 		return "error"
 	}
@@ -341,9 +341,9 @@ func links(tag imagev1.TagReference, release *release_controller.Release) string
 			continue
 		}
 		switch s.State {
-		case release_controller.ReleaseVerificationStateSucceeded:
+		case releasecontroller.ReleaseVerificationStateSucceeded:
 			continue
-		case release_controller.ReleaseVerificationStateFailed:
+		case releasecontroller.ReleaseVerificationStateFailed:
 			failing = append(failing, k)
 		default:
 			pending = append(pending, k)
@@ -367,9 +367,9 @@ func links(tag imagev1.TagReference, release *release_controller.Release) string
 		if s, ok := status[key]; ok {
 			if len(s.URL) > 0 {
 				switch s.State {
-				case release_controller.ReleaseVerificationStateSucceeded:
+				case releasecontroller.ReleaseVerificationStateSucceeded:
 					continue
-				case release_controller.ReleaseVerificationStateFailed:
+				case releasecontroller.ReleaseVerificationStateFailed:
 					buf.WriteString(" <a title=\"Failed\" class=\"text-danger\" href=\"")
 				default:
 					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
@@ -381,9 +381,9 @@ func links(tag imagev1.TagReference, release *release_controller.Release) string
 				continue
 			}
 			switch s.State {
-			case release_controller.ReleaseVerificationStateSucceeded:
+			case releasecontroller.ReleaseVerificationStateSucceeded:
 				continue
-			case release_controller.ReleaseVerificationStateFailed:
+			case releasecontroller.ReleaseVerificationStateFailed:
 				buf.WriteString(" <span title=\"Failed\" class=\"text-danger\">")
 			default:
 				buf.WriteString(" <span title=\"Pending\" class=\"\">")
@@ -392,7 +392,7 @@ func links(tag imagev1.TagReference, release *release_controller.Release) string
 			buf.WriteString("</span>")
 			continue
 		}
-		final := tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseRejected || tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseAccepted
+		final := tag.Annotations[releasecontroller.ReleaseAnnotationPhase] == releasecontroller.ReleasePhaseRejected || tag.Annotations[releasecontroller.ReleaseAnnotationPhase] == releasecontroller.ReleasePhaseAccepted
 		if !release.Config.Verify[key].Disabled && !final {
 			buf.WriteString(" <span title=\"Pending\">")
 			buf.WriteString(template.HTMLEscapeString(key))
@@ -417,18 +417,18 @@ func links(tag imagev1.TagReference, release *release_controller.Release) string
 	return buf.String()
 }
 
-func getVerificationJobs(tag imagev1.TagReference, release *release_controller.Release) (*release_controller.VerificationJobsSummary, string) {
-	links := tag.Annotations[release_controller.ReleaseAnnotationVerify]
+func getVerificationJobs(tag imagev1.TagReference, release *releasecontroller.Release) (*releasecontroller.VerificationJobsSummary, string) {
+	links := tag.Annotations[releasecontroller.ReleaseAnnotationVerify]
 	if len(links) == 0 {
 		return nil, fmt.Sprintf(`<p><em>No tests for this release</em>`)
 	}
-	var status release_controller.VerificationStatusMap
+	var status releasecontroller.VerificationStatusMap
 	if err := json.Unmarshal([]byte(links), &status); err != nil {
 		return nil, fmt.Sprintf(`<p><em class="text-danger">Unable to load test info</em>`)
 	}
-	blockingJobs := make(release_controller.VerificationStatusMap)
-	informingJobs := make(release_controller.VerificationStatusMap)
-	pendingJobs := make(release_controller.VerificationStatusMap)
+	blockingJobs := make(releasecontroller.VerificationStatusMap)
+	informingJobs := make(releasecontroller.VerificationStatusMap)
+	pendingJobs := make(releasecontroller.VerificationStatusMap)
 	keys := make([]string, 0, len(release.Config.Verify))
 	for k := range release.Config.Verify {
 		keys = append(keys, k)
@@ -445,21 +445,21 @@ func getVerificationJobs(tag imagev1.TagReference, release *release_controller.R
 			pendingJobs[key] = nil
 		}
 	}
-	return &release_controller.VerificationJobsSummary{
+	return &releasecontroller.VerificationJobsSummary{
 		BlockingJobs:  blockingJobs,
 		InformingJobs: informingJobs,
 		PendingJobs:   pendingJobs,
 	}, ""
 }
 
-func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *release_controller.Release) {
+func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *releasecontroller.Release) {
 	verificationJobs, msg := getVerificationJobs(tag, release)
 	if len(msg) > 0 {
 		fmt.Fprintf(w, msg)
 		return
 	}
 	buf := &bytes.Buffer{}
-	final := tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseRejected || tag.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseAccepted
+	final := tag.Annotations[releasecontroller.ReleaseAnnotationPhase] == releasecontroller.ReleasePhaseRejected || tag.Annotations[releasecontroller.ReleaseAnnotationPhase] == releasecontroller.ReleasePhaseAccepted
 	if len(verificationJobs.BlockingJobs) > 0 {
 		buf.WriteString("<li>Blocking jobs<ul>")
 		buf.WriteString(renderVerificationJobsList(verificationJobs.BlockingJobs, release, final))
@@ -482,7 +482,7 @@ func renderVerifyLinks(w io.Writer, tag imagev1.TagReference, release *release_c
 	}
 }
 
-func renderVerificationJobsList(jobs release_controller.VerificationStatusMap, release *release_controller.Release, final bool) string {
+func renderVerificationJobsList(jobs releasecontroller.VerificationStatusMap, release *releasecontroller.Release, final bool) string {
 	buf := &bytes.Buffer{}
 	keys := make([]string, 0, len(jobs))
 	for k := range jobs {
@@ -501,9 +501,9 @@ func renderVerificationJobsList(jobs release_controller.VerificationStatusMap, r
 		}
 		if len(value.URL) > 0 {
 			switch value.State {
-			case release_controller.ReleaseVerificationStateFailed:
+			case releasecontroller.ReleaseVerificationStateFailed:
 				buf.WriteString("<li><a class=\"text-danger\" href=\"")
-			case release_controller.ReleaseVerificationStateSucceeded:
+			case releasecontroller.ReleaseVerificationStateSucceeded:
 				buf.WriteString("<li><a class=\"text-success\" href=\"")
 			default:
 				buf.WriteString("<li><a class=\"\" href=\"")
@@ -512,9 +512,9 @@ func renderVerificationJobsList(jobs release_controller.VerificationStatusMap, r
 			buf.WriteString("\">")
 			buf.WriteString(template.HTMLEscapeString(key))
 			switch value.State {
-			case release_controller.ReleaseVerificationStateFailed:
+			case releasecontroller.ReleaseVerificationStateFailed:
 				buf.WriteString(" Failed")
-			case release_controller.ReleaseVerificationStateSucceeded:
+			case releasecontroller.ReleaseVerificationStateSucceeded:
 				buf.WriteString(" Succeeded")
 			default:
 				buf.WriteString(" Pending")
@@ -530,18 +530,18 @@ func renderVerificationJobsList(jobs release_controller.VerificationStatusMap, r
 			continue
 		}
 		switch value.State {
-		case release_controller.ReleaseVerificationStateFailed:
+		case releasecontroller.ReleaseVerificationStateFailed:
 			buf.WriteString("<li><span class=\"text-danger\">")
-		case release_controller.ReleaseVerificationStateSucceeded:
+		case releasecontroller.ReleaseVerificationStateSucceeded:
 			buf.WriteString("<li><span class=\"text-success\">")
 		default:
 			buf.WriteString("<li><span class=\"\">")
 		}
 		buf.WriteString(template.HTMLEscapeString(key))
 		switch value.State {
-		case release_controller.ReleaseVerificationStateFailed:
+		case releasecontroller.ReleaseVerificationStateFailed:
 			buf.WriteString(" Failed")
-		case release_controller.ReleaseVerificationStateSucceeded:
+		case releasecontroller.ReleaseVerificationStateSucceeded:
 			buf.WriteString(" Succeeded")
 		default:
 			buf.WriteString(" Pending")
@@ -580,7 +580,7 @@ func releaseJoin(streams []ReleaseStream) string {
 	return strings.Join(releases, " | ")
 }
 
-func hasPublishTag(config *release_controller.ReleaseConfig) (string, bool) {
+func hasPublishTag(config *releasecontroller.ReleaseConfig) (string, bool) {
 	for _, v := range config.Publish {
 		if v.TagRef != nil {
 			return v.TagRef.Name, true
@@ -589,7 +589,7 @@ func hasPublishTag(config *release_controller.ReleaseConfig) (string, bool) {
 	return "", false
 }
 
-func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReference, release *release_controller.Release) *imagev1.TagReference {
+func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReference, release *releasecontroller.Release) *imagev1.TagReference {
 	if len(older) == 0 {
 		return nil
 	}
@@ -604,7 +604,7 @@ func findPreviousRelease(tag *imagev1.TagReference, older []*imagev1.TagReferenc
 		}
 	}
 	for _, old := range older {
-		if old.Annotations[release_controller.ReleaseAnnotationPhase] == release_controller.ReleasePhaseAccepted {
+		if old.Annotations[releasecontroller.ReleaseAnnotationPhase] == releasecontroller.ReleasePhaseAccepted {
 			return old
 		}
 	}
@@ -618,7 +618,7 @@ type nopFlusher struct{}
 
 func (_ nopFlusher) Flush() {}
 
-func upgradeSummaryToString(history []release_controller.UpgradeHistory) string {
+func upgradeSummaryToString(history []releasecontroller.UpgradeHistory) string {
 	var out []string
 	for _, h := range history {
 		out = append(out, fmt.Sprintf("%s->%s", h.From, h.To))
@@ -626,7 +626,7 @@ func upgradeSummaryToString(history []release_controller.UpgradeHistory) string 
 	return strings.Join(out, ",")
 }
 
-func calculateReleaseUpgrades(release *release_controller.Release, tags []*imagev1.TagReference, graph *UpgradeGraph, fullHistory bool) *ReleaseUpgrades {
+func calculateReleaseUpgrades(release *releasecontroller.Release, tags []*imagev1.TagReference, graph *UpgradeGraph, fullHistory bool) *ReleaseUpgrades {
 	tagNames := make([]string, 0, len(tags))
 	internalTags := make(map[string]int)
 	for i, tag := range tags {
@@ -640,14 +640,14 @@ func calculateReleaseUpgrades(release *release_controller.Release, tags []*image
 	// tabular form with indicators whether a row is starting, continuing, or
 	// ending
 	var visual []ReleaseTagUpgradeVisual
-	var summaries []release_controller.UpgradeHistory
+	var summaries []releasecontroller.UpgradeHistory
 	if fullHistory {
 		summaries = graph.UpgradesTo(tagNames...)
 	} else {
 		summaries = graph.SummarizeUpgradesTo(tagNames...)
 	}
 	for _, name := range tagNames {
-		var internal, external []release_controller.UpgradeHistory
+		var internal, external []releasecontroller.UpgradeHistory
 		internal, summaries = takeUpgradesTo(summaries, name)
 		internal, external = takeUpgradesFromNames(internal, internalTags)
 		sort.Slice(internal, func(i, j int) bool {
@@ -727,19 +727,19 @@ func calculateReleaseUpgrades(release *release_controller.Release, tags []*image
 	}
 }
 
-func upgradeSummaryState(summary *release_controller.UpgradeHistory) string {
+func upgradeSummaryState(summary *releasecontroller.UpgradeHistory) string {
 	if summary.Success > 0 {
-		return release_controller.ReleaseVerificationStateSucceeded
+		return releasecontroller.ReleaseVerificationStateSucceeded
 	}
 	if summary.Failure > 0 {
-		return release_controller.ReleaseVerificationStateFailed
+		return releasecontroller.ReleaseVerificationStateFailed
 	}
-	return release_controller.ReleaseVerificationStatePending
+	return releasecontroller.ReleaseVerificationStatePending
 }
 
 // takeUpgradesTo returns all leading summaries with To equal to tag, and the rest of the
 // slice.
-func takeUpgradesTo(summaries []release_controller.UpgradeHistory, tag string) ([]release_controller.UpgradeHistory, []release_controller.UpgradeHistory) {
+func takeUpgradesTo(summaries []releasecontroller.UpgradeHistory, tag string) ([]releasecontroller.UpgradeHistory, []releasecontroller.UpgradeHistory) {
 	for i, summary := range summaries {
 		if summary.To == tag {
 			continue
@@ -751,14 +751,14 @@ func takeUpgradesTo(summaries []release_controller.UpgradeHistory, tag string) (
 
 // takeUpgradesFromNames splits the provided summaries slice into two slices - those with Froms
 // in names and those without.
-func takeUpgradesFromNames(summaries []release_controller.UpgradeHistory, names map[string]int) (withNames []release_controller.UpgradeHistory, withoutNames []release_controller.UpgradeHistory) {
+func takeUpgradesFromNames(summaries []releasecontroller.UpgradeHistory, names map[string]int) (withNames []releasecontroller.UpgradeHistory, withoutNames []releasecontroller.UpgradeHistory) {
 	for i := range summaries {
 		if _, ok := names[summaries[i].From]; ok {
 			continue
 		}
-		left := make([]release_controller.UpgradeHistory, i, len(summaries))
+		left := make([]releasecontroller.UpgradeHistory, i, len(summaries))
 		copy(left, summaries[:i])
-		var right []release_controller.UpgradeHistory
+		var right []releasecontroller.UpgradeHistory
 		for j, summary := range summaries[i:] {
 			if _, ok := names[summaries[i+j].From]; ok {
 				left = append(left, summary)
@@ -773,7 +773,7 @@ func takeUpgradesFromNames(summaries []release_controller.UpgradeHistory, names 
 
 // filterWithPrefix removes any summary from summaries that has a From that starts with
 // prefix.
-func filterWithPrefix(summaries []release_controller.UpgradeHistory, prefix string) []release_controller.UpgradeHistory {
+func filterWithPrefix(summaries []releasecontroller.UpgradeHistory, prefix string) []releasecontroller.UpgradeHistory {
 	if len(prefix) == 0 {
 		return summaries
 	}
@@ -781,7 +781,7 @@ func filterWithPrefix(summaries []release_controller.UpgradeHistory, prefix stri
 		if !strings.HasPrefix(summaries[i].From, prefix) {
 			continue
 		}
-		valid := make([]release_controller.UpgradeHistory, 0, len(summaries)-i)
+		valid := make([]releasecontroller.UpgradeHistory, 0, len(summaries)-i)
 		for _, summary := range summaries {
 			if !strings.HasPrefix(summary.From, prefix) {
 				valid = append(valid, summary)
@@ -802,7 +802,7 @@ func (r preferredReleases) Less(i, j int) bool {
 	if a.Release.Config.Hide && !b.Release.Config.Hide {
 		return false
 	}
-	aStable, bStable := a.Release.Config.As == release_controller.ReleaseConfigModeStable, b.Release.Config.As == release_controller.ReleaseConfigModeStable
+	aStable, bStable := a.Release.Config.As == releasecontroller.ReleaseConfigModeStable, b.Release.Config.As == releasecontroller.ReleaseConfigModeStable
 	if aStable && !bStable {
 		return true
 	}
@@ -827,10 +827,10 @@ func (r preferredReleases) Len() int      { return len(r) }
 
 type newestSemVerFromSummaries struct {
 	versions  []semver.Version
-	summaries []release_controller.UpgradeHistory
+	summaries []releasecontroller.UpgradeHistory
 }
 
-func newNewestSemVerFromSummaries(summaries []release_controller.UpgradeHistory) newestSemVerFromSummaries {
+func newNewestSemVerFromSummaries(summaries []releasecontroller.UpgradeHistory) newestSemVerFromSummaries {
 	versions := make([]semver.Version, len(summaries))
 	for i, summary := range summaries {
 		if v, err := semver.Parse(summary.From); err == nil {
@@ -867,10 +867,10 @@ func (s newestSemVerFromSummaries) Len() int { return len(s.summaries) }
 
 type newestSemVerToSummaries struct {
 	versions  []semver.Version
-	summaries []release_controller.UpgradeHistory
+	summaries []releasecontroller.UpgradeHistory
 }
 
-func newNewestSemVerToSummaries(summaries []release_controller.UpgradeHistory) newestSemVerToSummaries {
+func newNewestSemVerToSummaries(summaries []releasecontroller.UpgradeHistory) newestSemVerToSummaries {
 	versions := make([]semver.Version, len(summaries))
 	for i, summary := range summaries {
 		if v, err := semver.Parse(summary.To); err == nil {

--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"reflect"
 	"sort"
 	"testing"
@@ -13,7 +14,7 @@ import (
 func Test_calculateReleaseUpgrades(t *testing.T) {
 	tests := []struct {
 		name    string
-		release *Release
+		release *release_controller.Release
 		tags    []*imagev1.TagReference
 		graph   func() *UpgradeGraph
 		want    *ReleaseUpgrades
@@ -55,11 +56,11 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 			},
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("4.0.0", "4.0.1", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.0.0", "4.0.1", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
 				return g
 			},
 			wantFn: func() *ReleaseUpgrades {
-				internal0 := []UpgradeHistory{{From: "4.0.0", To: "4.0.1", Success: 0, Failure: 1, Total: 1}}
+				internal0 := []release_controller.UpgradeHistory{{From: "4.0.0", To: "4.0.1", Success: 0, Failure: 1, Total: 1}}
 				u := &ReleaseUpgrades{
 					Width: 1,
 					Tags: []ReleaseTagUpgrade{
@@ -90,13 +91,13 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 			},
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("4.0.4", "4.0.5", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
-				g.Add("4.0.3", "4.0.5", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
-				g.Add("4.0.0", "4.0.2", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.0.4", "4.0.5", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.0.3", "4.0.5", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.0.0", "4.0.2", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
 				return g
 			},
 			wantFn: func() *ReleaseUpgrades {
-				internal0 := []UpgradeHistory{
+				internal0 := []release_controller.UpgradeHistory{
 					{From: "4.0.4", To: "4.0.5", Success: 0, Failure: 1, Total: 1},
 					{From: "4.0.3", To: "4.0.5", Success: 1, Failure: 0, Total: 1},
 				}
@@ -123,7 +124,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 							},
 						},
 						{
-							External: []UpgradeHistory{{From: "4.0.0", To: "4.0.2", Success: 1, Total: 1}},
+							External: []release_controller.UpgradeHistory{{From: "4.0.0", To: "4.0.2", Success: 1, Total: 1}},
 						},
 						{},
 					},
@@ -142,16 +143,16 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 			},
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("4.1.0-0.test-08", "4.1.0-0.test-09", UpgradeResult{State: releaseVerificationStateFailed, URL: "https://test.com/1"})
-				g.Add("4.1.0-0.test-07", "4.1.0-0.test-08", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
-				g.Add("4.1.0-rc.0", "4.1.0-0.test-08", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.1.0-0.test-08", "4.1.0-0.test-09", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.1.0-0.test-07", "4.1.0-0.test-08", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.1.0-rc.0", "4.1.0-0.test-08", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
 				return g
 			},
 			wantFn: func() *ReleaseUpgrades {
-				internal0 := []UpgradeHistory{
+				internal0 := []release_controller.UpgradeHistory{
 					{From: "4.1.0-0.test-08", To: "4.1.0-0.test-09", Success: 0, Failure: 1, Total: 1},
 				}
-				internal1 := []UpgradeHistory{
+				internal1 := []release_controller.UpgradeHistory{
 					{From: "4.1.0-0.test-07", To: "4.1.0-0.test-08", Success: 1, Failure: 0, Total: 1},
 				}
 				u := &ReleaseUpgrades{
@@ -170,7 +171,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 								{End: &internal0[0]},
 								{Begin: &internal1[0]},
 							},
-							External: []UpgradeHistory{{From: "4.1.0-rc.0", To: "4.1.0-0.test-08", Success: 1, Total: 1}},
+							External: []release_controller.UpgradeHistory{{From: "4.1.0-rc.0", To: "4.1.0-0.test-08", Success: 1, Total: 1}},
 						},
 						{
 							Visual: []ReleaseTagUpgradeVisual{
@@ -191,8 +192,8 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				tt.want = tt.wantFn()
 			}
 			if tt.release == nil {
-				tt.release = &Release{
-					Config: &ReleaseConfig{},
+				tt.release = &release_controller.Release{
+					Config: &release_controller.ReleaseConfig{},
 				}
 			}
 			if got := calculateReleaseUpgrades(tt.release, tt.tags, tt.graph(), false); !reflect.DeepEqual(got, tt.want) {
@@ -246,45 +247,45 @@ func TestSemVer(t *testing.T) {
 func Test_takeUpgradesFromNames(t *testing.T) {
 	tests := []struct {
 		name             string
-		summaries        []UpgradeHistory
+		summaries        []release_controller.UpgradeHistory
 		names            map[string]int
-		wantWithNames    []UpgradeHistory
-		wantWithoutNames []UpgradeHistory
+		wantWithNames    []release_controller.UpgradeHistory
+		wantWithoutNames []release_controller.UpgradeHistory
 	}{
 		{
-			summaries: []UpgradeHistory{
+			summaries: []release_controller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 			names: map[string]int{"a": 1, "c": 3},
-			wantWithNames: []UpgradeHistory{
+			wantWithNames: []release_controller.UpgradeHistory{
 				{From: "a", To: "c"},
 			},
-			wantWithoutNames: []UpgradeHistory{
+			wantWithoutNames: []release_controller.UpgradeHistory{
 				{From: "b", To: "c"},
 			},
 		},
 		{
-			summaries: []UpgradeHistory{
+			summaries: []release_controller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 			names: map[string]int{"a": 1, "b": 2, "c": 3},
-			wantWithNames: []UpgradeHistory{
+			wantWithNames: []release_controller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 		},
 		{
-			summaries: []UpgradeHistory{
+			summaries: []release_controller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 			names: map[string]int{"b": 2, "c": 3},
-			wantWithNames: []UpgradeHistory{
+			wantWithNames: []release_controller.UpgradeHistory{
 				{From: "b", To: "c"},
 			},
-			wantWithoutNames: []UpgradeHistory{
+			wantWithoutNames: []release_controller.UpgradeHistory{
 				{From: "a", To: "c"},
 			},
 		},

--- a/cmd/release-controller/http_helper_test.go
+++ b/cmd/release-controller/http_helper_test.go
@@ -14,7 +14,7 @@ import (
 func Test_calculateReleaseUpgrades(t *testing.T) {
 	tests := []struct {
 		name    string
-		release *release_controller.Release
+		release *releasecontroller.Release
 		tags    []*imagev1.TagReference
 		graph   func() *UpgradeGraph
 		want    *ReleaseUpgrades
@@ -56,11 +56,11 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 			},
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("4.0.0", "4.0.1", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.0.0", "4.0.1", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
 				return g
 			},
 			wantFn: func() *ReleaseUpgrades {
-				internal0 := []release_controller.UpgradeHistory{{From: "4.0.0", To: "4.0.1", Success: 0, Failure: 1, Total: 1}}
+				internal0 := []releasecontroller.UpgradeHistory{{From: "4.0.0", To: "4.0.1", Success: 0, Failure: 1, Total: 1}}
 				u := &ReleaseUpgrades{
 					Width: 1,
 					Tags: []ReleaseTagUpgrade{
@@ -91,13 +91,13 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 			},
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("4.0.4", "4.0.5", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
-				g.Add("4.0.3", "4.0.5", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
-				g.Add("4.0.0", "4.0.2", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.0.4", "4.0.5", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.0.3", "4.0.5", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.0.0", "4.0.2", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
 				return g
 			},
 			wantFn: func() *ReleaseUpgrades {
-				internal0 := []release_controller.UpgradeHistory{
+				internal0 := []releasecontroller.UpgradeHistory{
 					{From: "4.0.4", To: "4.0.5", Success: 0, Failure: 1, Total: 1},
 					{From: "4.0.3", To: "4.0.5", Success: 1, Failure: 0, Total: 1},
 				}
@@ -124,7 +124,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 							},
 						},
 						{
-							External: []release_controller.UpgradeHistory{{From: "4.0.0", To: "4.0.2", Success: 1, Total: 1}},
+							External: []releasecontroller.UpgradeHistory{{From: "4.0.0", To: "4.0.2", Success: 1, Total: 1}},
 						},
 						{},
 					},
@@ -143,16 +143,16 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 			},
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("4.1.0-0.test-08", "4.1.0-0.test-09", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
-				g.Add("4.1.0-0.test-07", "4.1.0-0.test-08", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
-				g.Add("4.1.0-rc.0", "4.1.0-0.test-08", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.1.0-0.test-08", "4.1.0-0.test-09", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateFailed, URL: "https://test.com/1"})
+				g.Add("4.1.0-0.test-07", "4.1.0-0.test-08", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
+				g.Add("4.1.0-rc.0", "4.1.0-0.test-08", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "https://test.com/2"})
 				return g
 			},
 			wantFn: func() *ReleaseUpgrades {
-				internal0 := []release_controller.UpgradeHistory{
+				internal0 := []releasecontroller.UpgradeHistory{
 					{From: "4.1.0-0.test-08", To: "4.1.0-0.test-09", Success: 0, Failure: 1, Total: 1},
 				}
-				internal1 := []release_controller.UpgradeHistory{
+				internal1 := []releasecontroller.UpgradeHistory{
 					{From: "4.1.0-0.test-07", To: "4.1.0-0.test-08", Success: 1, Failure: 0, Total: 1},
 				}
 				u := &ReleaseUpgrades{
@@ -171,7 +171,7 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 								{End: &internal0[0]},
 								{Begin: &internal1[0]},
 							},
-							External: []release_controller.UpgradeHistory{{From: "4.1.0-rc.0", To: "4.1.0-0.test-08", Success: 1, Total: 1}},
+							External: []releasecontroller.UpgradeHistory{{From: "4.1.0-rc.0", To: "4.1.0-0.test-08", Success: 1, Total: 1}},
 						},
 						{
 							Visual: []ReleaseTagUpgradeVisual{
@@ -192,8 +192,8 @@ func Test_calculateReleaseUpgrades(t *testing.T) {
 				tt.want = tt.wantFn()
 			}
 			if tt.release == nil {
-				tt.release = &release_controller.Release{
-					Config: &release_controller.ReleaseConfig{},
+				tt.release = &releasecontroller.Release{
+					Config: &releasecontroller.ReleaseConfig{},
 				}
 			}
 			if got := calculateReleaseUpgrades(tt.release, tt.tags, tt.graph(), false); !reflect.DeepEqual(got, tt.want) {
@@ -247,45 +247,45 @@ func TestSemVer(t *testing.T) {
 func Test_takeUpgradesFromNames(t *testing.T) {
 	tests := []struct {
 		name             string
-		summaries        []release_controller.UpgradeHistory
+		summaries        []releasecontroller.UpgradeHistory
 		names            map[string]int
-		wantWithNames    []release_controller.UpgradeHistory
-		wantWithoutNames []release_controller.UpgradeHistory
+		wantWithNames    []releasecontroller.UpgradeHistory
+		wantWithoutNames []releasecontroller.UpgradeHistory
 	}{
 		{
-			summaries: []release_controller.UpgradeHistory{
+			summaries: []releasecontroller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 			names: map[string]int{"a": 1, "c": 3},
-			wantWithNames: []release_controller.UpgradeHistory{
+			wantWithNames: []releasecontroller.UpgradeHistory{
 				{From: "a", To: "c"},
 			},
-			wantWithoutNames: []release_controller.UpgradeHistory{
+			wantWithoutNames: []releasecontroller.UpgradeHistory{
 				{From: "b", To: "c"},
 			},
 		},
 		{
-			summaries: []release_controller.UpgradeHistory{
+			summaries: []releasecontroller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 			names: map[string]int{"a": 1, "b": 2, "c": 3},
-			wantWithNames: []release_controller.UpgradeHistory{
+			wantWithNames: []releasecontroller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 		},
 		{
-			summaries: []release_controller.UpgradeHistory{
+			summaries: []releasecontroller.UpgradeHistory{
 				{From: "a", To: "c"},
 				{From: "b", To: "c"},
 			},
 			names: map[string]int{"b": 2, "c": 3},
-			wantWithNames: []release_controller.UpgradeHistory{
+			wantWithNames: []releasecontroller.UpgradeHistory{
 				{From: "b", To: "c"},
 			},
-			wantWithoutNames: []release_controller.UpgradeHistory{
+			wantWithoutNames: []releasecontroller.UpgradeHistory{
 				{From: "a", To: "c"},
 			},
 		},

--- a/cmd/release-controller/http_upgrade_graph.go
+++ b/cmd/release-controller/http_upgrade_graph.go
@@ -156,7 +156,7 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 					string(viz.Shape): "record",
 					string(viz.HREF):  fmt.Sprintf(`"/releasetag/%s"`, template.HTMLEscapeString(tag.Name)),
 				}
-				if phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]; phase == release_controller.ReleasePhaseRejected {
+				if phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]; phase == releasecontroller.ReleasePhaseRejected {
 					attrs[string(viz.Color)] = "red"
 				}
 				if err := g.AddNode(subgraphName, dotNodeName(index), attrs); err != nil {

--- a/cmd/release-controller/http_upgrade_graph.go
+++ b/cmd/release-controller/http_upgrade_graph.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"net/http"
 	"os/exec"
 	"strconv"
@@ -155,7 +156,7 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 					string(viz.Shape): "record",
 					string(viz.HREF):  fmt.Sprintf(`"/releasetag/%s"`, template.HTMLEscapeString(tag.Name)),
 				}
-				if phase := tag.Annotations[releaseAnnotationPhase]; phase == releasePhaseRejected {
+				if phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]; phase == release_controller.ReleasePhaseRejected {
 					attrs[string(viz.Color)] = "red"
 				}
 				if err := g.AddNode(subgraphName, dotNodeName(index), attrs); err != nil {

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"net/http"
 	"net/url"
 	"os"
@@ -489,15 +490,15 @@ func (o *options) Run() error {
 						continue
 					}
 					annotations := job.GetAnnotations()
-					from, ok := annotations[releaseAnnotationFromTag]
+					from, ok := annotations[release_controller.ReleaseAnnotationFromTag]
 					if !ok {
 						continue
 					}
-					to, ok := annotations[releaseAnnotationToTag]
+					to, ok := annotations[release_controller.ReleaseAnnotationToTag]
 					if !ok {
 						continue
 					}
-					jobArchitecture, ok := annotations[releaseAnnotationArchitecture]
+					jobArchitecture, ok := annotations[release_controller.ReleaseAnnotationArchitecture]
 					if !ok {
 						continue
 					}
@@ -508,7 +509,7 @@ func (o *options) Run() error {
 					if !ok {
 						continue
 					}
-					graph.Add(from, to, UpgradeResult{
+					graph.Add(from, to, release_controller.UpgradeResult{
 						State: status.State,
 						URL:   status.URL,
 					})
@@ -699,7 +700,7 @@ func (c *latestImageCache) Get() (string, error) {
 			continue
 		}
 
-		value, ok := item.Annotations[releaseAnnotationConfig]
+		value, ok := item.Annotations[release_controller.ReleaseAnnotationConfig]
 		if !ok {
 			continue
 		}
@@ -710,7 +711,7 @@ func (c *latestImageCache) Get() (string, error) {
 		if err != nil {
 			continue
 		}
-		if config.As == releaseConfigModeStable {
+		if config.As == release_controller.ReleaseConfigModeStable {
 			continue
 		}
 

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -490,15 +490,15 @@ func (o *options) Run() error {
 						continue
 					}
 					annotations := job.GetAnnotations()
-					from, ok := annotations[release_controller.ReleaseAnnotationFromTag]
+					from, ok := annotations[releasecontroller.ReleaseAnnotationFromTag]
 					if !ok {
 						continue
 					}
-					to, ok := annotations[release_controller.ReleaseAnnotationToTag]
+					to, ok := annotations[releasecontroller.ReleaseAnnotationToTag]
 					if !ok {
 						continue
 					}
-					jobArchitecture, ok := annotations[release_controller.ReleaseAnnotationArchitecture]
+					jobArchitecture, ok := annotations[releasecontroller.ReleaseAnnotationArchitecture]
 					if !ok {
 						continue
 					}
@@ -509,7 +509,7 @@ func (o *options) Run() error {
 					if !ok {
 						continue
 					}
-					graph.Add(from, to, release_controller.UpgradeResult{
+					graph.Add(from, to, releasecontroller.UpgradeResult{
 						State: status.State,
 						URL:   status.URL,
 					})
@@ -700,7 +700,7 @@ func (c *latestImageCache) Get() (string, error) {
 			continue
 		}
 
-		value, ok := item.Annotations[release_controller.ReleaseAnnotationConfig]
+		value, ok := item.Annotations[releasecontroller.ReleaseAnnotationConfig]
 		if !ok {
 			continue
 		}
@@ -711,7 +711,7 @@ func (c *latestImageCache) Get() (string, error) {
 		if err != nil {
 			continue
 		}
-		if config.As == release_controller.ReleaseConfigModeStable {
+		if config.As == releasecontroller.ReleaseConfigModeStable {
 			continue
 		}
 

--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -22,10 +22,10 @@ import (
 
 type PeriodicWithRelease struct {
 	Periodic           *config.Periodic
-	Release            *release_controller.Release
+	Release            *releasecontroller.Release
 	Upgrade            bool
 	UpgradeFrom        string
-	UpgradeFromRelease *release_controller.UpgradeRelease
+	UpgradeFromRelease *releasecontroller.UpgradeRelease
 }
 
 func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, stopCh <-chan struct{}) {
@@ -143,7 +143,7 @@ func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, s
 func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease PeriodicWithRelease) error {
 	// get release info
 	release := periodicWithRelease.Release
-	acceptedTags := sortedRawReleaseTags(release, release_controller.ReleasePhaseAccepted)
+	acceptedTags := sortedRawReleaseTags(release, releasecontroller.ReleasePhaseAccepted)
 	if len(acceptedTags) == 0 {
 		return fmt.Errorf("no accepted tags found for release %s", release.Config.Name)
 	}
@@ -165,13 +165,13 @@ func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease Pe
 		return fmt.Errorf("failed to add release env to periodic %s: %v", periodicWithRelease.Periodic.Name, err)
 	}
 	prowJob := pjutil.NewProwJob(spec, periodicWithRelease.Periodic.Labels, periodicWithRelease.Periodic.Annotations)
-	prowJob.Labels[release_controller.ReleaseAnnotationVerify] = "true"
-	prowJob.Annotations[release_controller.ReleaseAnnotationSource] = fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name)
-	prowJob.Annotations[release_controller.ReleaseAnnotationToTag] = latestTag.Name
+	prowJob.Labels[releasecontroller.ReleaseAnnotationVerify] = "true"
+	prowJob.Annotations[releasecontroller.ReleaseAnnotationSource] = fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name)
+	prowJob.Annotations[releasecontroller.ReleaseAnnotationToTag] = latestTag.Name
 	if periodicWithRelease.Upgrade && len(previousTag) > 0 {
-		prowJob.Annotations[release_controller.ReleaseAnnotationFromTag] = previousTag
+		prowJob.Annotations[releasecontroller.ReleaseAnnotationFromTag] = previousTag
 	}
-	prowJob.Annotations[release_controller.ReleaseAnnotationArchitecture] = c.graph.architecture
+	prowJob.Annotations[releasecontroller.ReleaseAnnotationArchitecture] = c.graph.architecture
 
 	_, err = c.prowClient.Create(context.TODO(), objectToUnstructured(&prowJob), metav1.CreateOptions{})
 	if err != nil {

--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,10 +22,10 @@ import (
 
 type PeriodicWithRelease struct {
 	Periodic           *config.Periodic
-	Release            *Release
+	Release            *release_controller.Release
 	Upgrade            bool
 	UpgradeFrom        string
-	UpgradeFromRelease *UpgradeRelease
+	UpgradeFromRelease *release_controller.UpgradeRelease
 }
 
 func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, stopCh <-chan struct{}) {
@@ -142,7 +143,7 @@ func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, s
 func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease PeriodicWithRelease) error {
 	// get release info
 	release := periodicWithRelease.Release
-	acceptedTags := sortedRawReleaseTags(release, releasePhaseAccepted)
+	acceptedTags := sortedRawReleaseTags(release, release_controller.ReleasePhaseAccepted)
 	if len(acceptedTags) == 0 {
 		return fmt.Errorf("no accepted tags found for release %s", release.Config.Name)
 	}
@@ -164,13 +165,13 @@ func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease Pe
 		return fmt.Errorf("failed to add release env to periodic %s: %v", periodicWithRelease.Periodic.Name, err)
 	}
 	prowJob := pjutil.NewProwJob(spec, periodicWithRelease.Periodic.Labels, periodicWithRelease.Periodic.Annotations)
-	prowJob.Labels[releaseAnnotationVerify] = "true"
-	prowJob.Annotations[releaseAnnotationSource] = fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name)
-	prowJob.Annotations[releaseAnnotationToTag] = latestTag.Name
+	prowJob.Labels[release_controller.ReleaseAnnotationVerify] = "true"
+	prowJob.Annotations[release_controller.ReleaseAnnotationSource] = fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name)
+	prowJob.Annotations[release_controller.ReleaseAnnotationToTag] = latestTag.Name
 	if periodicWithRelease.Upgrade && len(previousTag) > 0 {
-		prowJob.Annotations[releaseAnnotationFromTag] = previousTag
+		prowJob.Annotations[release_controller.ReleaseAnnotationFromTag] = previousTag
 	}
-	prowJob.Annotations[releaseAnnotationArchitecture] = c.graph.architecture
+	prowJob.Annotations[release_controller.ReleaseAnnotationArchitecture] = c.graph.architecture
 
 	_, err = c.prowClient.Create(context.TODO(), objectToUnstructured(&prowJob), metav1.CreateOptions{})
 	if err != nil {

--- a/cmd/release-controller/prow.go
+++ b/cmd/release-controller/prow.go
@@ -12,27 +12,27 @@ import (
 	prowjobsv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
-func prowJobVerificationStatus(obj *unstructured.Unstructured) (*release_controller.VerificationStatus, bool) {
+func prowJobVerificationStatus(obj *unstructured.Unstructured) (*releasecontroller.VerificationStatus, bool) {
 	s, _, err := unstructured.NestedString(obj.Object, "status", "state")
 	if err != nil {
 		return nil, false
 	}
 	url, _, _ := unstructured.NestedString(obj.Object, "status", "url")
 	var transitionTime string
-	var status *release_controller.VerificationStatus
+	var status *releasecontroller.VerificationStatus
 	switch prowjobsv1.ProwJobState(s) {
 	case prowjobsv1.SuccessState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &release_controller.VerificationStatus{State: release_controller.ReleaseVerificationStateSucceeded, URL: url}
+		status = &releasecontroller.VerificationStatus{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: url}
 	case prowjobsv1.FailureState, prowjobsv1.ErrorState, prowjobsv1.AbortedState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &release_controller.VerificationStatus{State: release_controller.ReleaseVerificationStateFailed, URL: url}
+		status = &releasecontroller.VerificationStatus{State: releasecontroller.ReleaseVerificationStateFailed, URL: url}
 	case prowjobsv1.TriggeredState, prowjobsv1.PendingState, prowjobsv1.ProwJobState(""):
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "pendingTime")
 		if transitionTime == "" {
 			transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "startTime")
 		}
-		status = &release_controller.VerificationStatus{State: release_controller.ReleaseVerificationStatePending, URL: url}
+		status = &releasecontroller.VerificationStatus{State: releasecontroller.ReleaseVerificationStatePending, URL: url}
 	default:
 		klog.Errorf("Unrecognized prow job state %q on job %s", s, obj.GetName())
 		return nil, false

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"sort"
 	"strings"
 	"time"
@@ -43,12 +44,12 @@ func (c *Controller) sync(key queueKey) error {
 
 	// ensure that the target image stream always carries the annotation indicating it is
 	// a target for backreferencing from GC and other check points
-	if _, ok := release.Target.Annotations[releaseAnnotationHasReleases]; !ok {
+	if _, ok := release.Target.Annotations[release_controller.ReleaseAnnotationHasReleases]; !ok {
 		target := release.Target.DeepCopy()
 		if target.Annotations == nil {
 			target.Annotations = make(map[string]string)
 		}
-		target.Annotations[releaseAnnotationHasReleases] = "true"
+		target.Annotations[release_controller.ReleaseAnnotationHasReleases] = "true"
 		if _, err := c.imageClient.ImageStreams(target.Namespace).Update(context.TODO(), target, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
@@ -126,64 +127,64 @@ func (c *Controller) sync(key queueKey) error {
 	return nil
 }
 
-func calculateSyncActions(release *Release, now time.Time) (adoptTags, pendingTags, removeTags []*imagev1.TagReference, hasNewImages bool, inputImageHash string, queueAfter time.Duration) {
+func calculateSyncActions(release *release_controller.Release, now time.Time) (adoptTags, pendingTags, removeTags []*imagev1.TagReference, hasNewImages bool, inputImageHash string, queueAfter time.Duration) {
 	hasNewImages = true
 	inputImageHash = hashSpecTagImageDigests(release.Source)
 	var (
-		removeFailures  tagReferencesByAge
-		removeAccepted  tagReferencesByAge
-		removeRejected  tagReferencesByAge
+		removeFailures  release_controller.TagReferencesByAge
+		removeAccepted  release_controller.TagReferencesByAge
+		removeRejected  release_controller.TagReferencesByAge
 		unreadyTagCount int
 	)
 	target := release.Target
 
-	shouldAdopt := release.Config.As == releaseConfigModeStable
+	shouldAdopt := release.Config.As == release_controller.ReleaseConfigModeStable
 
 	tags := make([]*imagev1.TagReference, 0, len(target.Spec.Tags))
 	for i := range target.Spec.Tags {
 		tags = append(tags, &target.Spec.Tags[i])
 	}
-	sort.Sort(tagReferencesByAge(tags))
+	sort.Sort(release_controller.TagReferencesByAge(tags))
 
 	var firstTag *imagev1.TagReference
 	removeFailuresAfter, removeRejectedAfter := -1, -1
 	for _, tag := range tags {
 		if shouldAdopt {
-			if len(tag.Annotations[releaseAnnotationSource]) == 0 && len(tag.Annotations[releaseAnnotationPhase]) == 0 {
+			if len(tag.Annotations[release_controller.ReleaseAnnotationSource]) == 0 && len(tag.Annotations[release_controller.ReleaseAnnotationPhase]) == 0 {
 				adoptTags = append(adoptTags, tag)
 				continue
 			}
 		}
 
 		// always skip pinned tags
-		if _, ok := tag.Annotations[releaseAnnotationKeep]; ok {
+		if _, ok := tag.Annotations[release_controller.ReleaseAnnotationKeep]; ok {
 			continue
 		}
 		// check annotations when using the target as tag source
-		if release.Config.As != releaseConfigModeStable && tag.Annotations[releaseAnnotationSource] != fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name) {
+		if release.Config.As != release_controller.ReleaseConfigModeStable && tag.Annotations[release_controller.ReleaseAnnotationSource] != fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name) {
 			continue
 		}
 		// if the name has changed, consider the tag abandoned (admin is responsible for cleaning it up)
-		if tag.Annotations[releaseAnnotationName] != release.Config.Name {
+		if tag.Annotations[release_controller.ReleaseAnnotationName] != release.Config.Name {
 			continue
 		}
 		if firstTag == nil {
 			firstTag = tag
 		}
-		if tag.Annotations[releaseAnnotationImageHash] == inputImageHash {
+		if tag.Annotations[release_controller.ReleaseAnnotationImageHash] == inputImageHash {
 			hasNewImages = false
 		}
 
-		phase := tag.Annotations[releaseAnnotationPhase]
+		phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
 		switch phase {
-		case releasePhasePending, "":
+		case release_controller.ReleasePhasePending, "":
 			unreadyTagCount++
 			pendingTags = append(pendingTags, tag)
-		case releasePhaseFailed:
+		case release_controller.ReleasePhaseFailed:
 			removeFailures = append(removeFailures, tag)
-		case releasePhaseRejected:
+		case release_controller.ReleasePhaseRejected:
 			removeRejected = append(removeRejected, tag)
-		case releasePhaseAccepted:
+		case release_controller.ReleasePhaseAccepted:
 			removeAccepted = append(removeAccepted, tag)
 			removeRejectedAfter = len(removeRejected)
 			removeFailuresAfter = len(removeFailures)
@@ -215,7 +216,7 @@ func calculateSyncActions(release *Release, now time.Time) (adoptTags, pendingTa
 	if expires := release.Config.Expires.Duration(); expires > 0 && len(removeAccepted) > keepTagsOfType {
 		klog.V(5).Infof("Checking for tags that are more than %s old", expires)
 		for _, tag := range removeAccepted[keepTagsOfType:] {
-			created, err := time.Parse(time.RFC3339, tag.Annotations[releaseAnnotationCreationTimestamp])
+			created, err := time.Parse(time.RFC3339, tag.Annotations[release_controller.ReleaseAnnotationCreationTimestamp])
 			if err != nil {
 				klog.Errorf("Unparseable timestamp on release tag %s:%s: %v", release.Target.Name, tag.Name, err)
 				continue
@@ -227,7 +228,7 @@ func calculateSyncActions(release *Release, now time.Time) (adoptTags, pendingTa
 	}
 
 	switch release.Config.As {
-	case releaseConfigModeStable:
+	case release_controller.ReleaseConfigModeStable:
 		hasNewImages = false
 		inputImageHash = ""
 		removeTags = nil
@@ -250,25 +251,25 @@ func calculateSyncActions(release *Release, now time.Time) (adoptTags, pendingTa
 	return adoptTags, pendingTags, removeTags, hasNewImages, inputImageHash, queueAfter
 }
 
-func countUnreadyReleases(release *Release, tags []*imagev1.TagReference) int {
+func countUnreadyReleases(release *release_controller.Release, tags []*imagev1.TagReference) int {
 	unreadyTagCount := 0
 	for _, tag := range tags {
 		// always skip pinned tags
-		if _, ok := tag.Annotations[releaseAnnotationKeep]; ok {
+		if _, ok := tag.Annotations[release_controller.ReleaseAnnotationKeep]; ok {
 			continue
 		}
 		// check annotations when using the target as tag source
-		if release.Config.As != releaseConfigModeStable && tag.Annotations[releaseAnnotationSource] != fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name) {
+		if release.Config.As != release_controller.ReleaseConfigModeStable && tag.Annotations[release_controller.ReleaseAnnotationSource] != fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name) {
 			continue
 		}
 		// if the name has changed, consider the tag abandoned (admin is responsible for cleaning it up)
-		if tag.Annotations[releaseAnnotationName] != release.Config.Name {
+		if tag.Annotations[release_controller.ReleaseAnnotationName] != release.Config.Name {
 			continue
 		}
 
-		phase := tag.Annotations[releaseAnnotationPhase]
+		phase := tag.Annotations[release_controller.ReleaseAnnotationPhase]
 		switch phase {
-		case releasePhaseFailed, releasePhaseRejected, releasePhaseAccepted:
+		case release_controller.ReleasePhaseFailed, release_controller.ReleasePhaseRejected, release_controller.ReleasePhaseAccepted:
 			// terminal don't count
 		default:
 			unreadyTagCount++
@@ -277,14 +278,14 @@ func countUnreadyReleases(release *Release, tags []*imagev1.TagReference) int {
 	return unreadyTagCount
 }
 
-func isReleaseDelayedForInterval(release *Release, tag *imagev1.TagReference) (bool, string, time.Duration) {
+func isReleaseDelayedForInterval(release *release_controller.Release, tag *imagev1.TagReference) (bool, string, time.Duration) {
 	if release.Config.MinCreationIntervalSeconds == 0 {
 		return false, "", 0
 	}
 	if tag == nil {
 		return false, "", 0
 	}
-	created, err := time.Parse(time.RFC3339, tag.Annotations[releaseAnnotationCreationTimestamp])
+	created, err := time.Parse(time.RFC3339, tag.Annotations[release_controller.ReleaseAnnotationCreationTimestamp])
 	if err != nil {
 		return false, "", 0
 	}
@@ -295,7 +296,7 @@ func isReleaseDelayedForInterval(release *Release, tag *imagev1.TagReference) (b
 	return false, "", 0
 }
 
-func (c *Controller) syncAdopted(release *Release, adoptTags []*imagev1.TagReference, now time.Time) (changed bool, err error) {
+func (c *Controller) syncAdopted(release *release_controller.Release, adoptTags []*imagev1.TagReference, now time.Time) (changed bool, err error) {
 	names := make([]string, 0, len(adoptTags))
 	for _, tag := range adoptTags {
 		if tag.Name == "next" {
@@ -311,20 +312,20 @@ func (c *Controller) syncAdopted(release *Release, adoptTags []*imagev1.TagRefer
 	}
 	return true, c.ensureReleaseTagPhase(
 		release,
-		[]string{"", releasePhasePending},
-		releasePhasePending,
+		[]string{"", release_controller.ReleasePhasePending},
+		release_controller.ReleasePhasePending,
 		map[string]string{
-			releaseAnnotationName:              release.Config.Name,
-			releaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-			releaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
+			release_controller.ReleaseAnnotationName:              release.Config.Name,
+			release_controller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+			release_controller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
 		},
 		names...,
 	)
 }
 
-func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagReference, inputImageHash string) (err error) {
+func (c *Controller) syncPending(release *release_controller.Release, pendingTags []*imagev1.TagReference, inputImageHash string) (err error) {
 	switch release.Config.As {
-	case releaseConfigModeStable:
+	case release_controller.ReleaseConfigModeStable:
 		for _, tag := range pendingTags {
 			// wait for import, then determine whether the requested version (tag name) matches the source version (label on image)
 			id := findImageIDForTag(release.Source, tag.Name)
@@ -333,7 +334,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 				continue
 			}
 			klog.V(2).Infof("Processing pending release %s", tag.Name)
-			rewriteValue := tag.Annotations[releaseAnnotationRewrite]
+			rewriteValue := tag.Annotations[release_controller.ReleaseAnnotationRewrite]
 			if len(rewriteValue) == 0 {
 				klog.V(2).Infof("Rewriting pending release %s", tag.Name)
 				isi, err := c.imageClient.ImageStreamImages(release.Source.Namespace).Get(context.TODO(), fmt.Sprintf("%s@%s", release.Source.Name, id), metav1.GetOptions{})
@@ -352,7 +353,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 					name = metadata.Config.Labels["io.openshift.release"]
 				}
 				rewriteValue = fmt.Sprintf("%t", name != tag.Name)
-				if err := c.setReleaseAnnotation(release, tag.Annotations[releaseAnnotationPhase], map[string]string{releaseAnnotationRewrite: rewriteValue}, tag.Name); err != nil {
+				if err := c.setReleaseAnnotation(release, tag.Annotations[release_controller.ReleaseAnnotationPhase], map[string]string{release_controller.ReleaseAnnotationRewrite: rewriteValue}, tag.Name); err != nil {
 					return err
 				}
 				continue
@@ -366,13 +367,13 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 			if err != nil {
 				return err
 			}
-			if len(tag.Annotations[releaseAnnotationImageHash]) == 0 {
-				if err := c.setReleaseAnnotation(release, tag.Annotations[releaseAnnotationPhase], map[string]string{releaseAnnotationImageHash: mirror.Annotations[releaseAnnotationImageHash]}, tag.Name); err != nil {
+			if len(tag.Annotations[release_controller.ReleaseAnnotationImageHash]) == 0 {
+				if err := c.setReleaseAnnotation(release, tag.Annotations[release_controller.ReleaseAnnotationPhase], map[string]string{release_controller.ReleaseAnnotationImageHash: mirror.Annotations[release_controller.ReleaseAnnotationImageHash]}, tag.Name); err != nil {
 					return err
 				}
 				continue
 			}
-			if mirror.Annotations[releaseAnnotationImageHash] != tag.Annotations[releaseAnnotationImageHash] {
+			if mirror.Annotations[release_controller.ReleaseAnnotationImageHash] != tag.Annotations[release_controller.ReleaseAnnotationImageHash] {
 				// delete the mirror and exit
 				return fmt.Errorf("unimplemented, should regenerate contents of tag")
 			}
@@ -395,14 +396,14 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 				return c.ensureRewriteJobImageRetrieved(release, job, mirror)
 			case !success:
 				// TODO: extract termination message from the job
-				if err := c.transitionReleasePhaseFailure(release, []string{releasePhasePending}, releasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
+				if err := c.transitionReleasePhaseFailure(release, []string{release_controller.ReleasePhasePending}, release_controller.ReleasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
 					return err
 				}
 			default:
 				if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
 					return err
 				}
-				if tags := sortedRawReleaseTags(release, releasePhaseReady); len(tags) > 0 {
+				if tags := sortedRawReleaseTags(release, release_controller.ReleasePhaseReady); len(tags) > 0 {
 					go func() {
 						if _, err := c.releaseInfo.ChangeLog(tags[0].Name, tag.Name); err != nil {
 							klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
@@ -415,7 +416,7 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 	}
 
 	if len(pendingTags) > 1 {
-		if err := c.transitionReleasePhaseFailure(release, []string{releasePhasePending}, releasePhaseFailed, reasonAndMessage("Aborted", "Multiple releases were found simultaneously running."), tagNames(pendingTags[1:])...); err != nil {
+		if err := c.transitionReleasePhaseFailure(release, []string{release_controller.ReleasePhasePending}, release_controller.ReleasePhaseFailed, reasonAndMessage("Aborted", "Multiple releases were found simultaneously running."), tagNames(pendingTags[1:])...); err != nil {
 			return err
 		}
 	}
@@ -427,10 +428,10 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 		if err != nil {
 			return err
 		}
-		if len(tag.Annotations[releaseAnnotationImageHash]) == 0 {
-			return c.setReleaseAnnotation(release, releasePhasePending, map[string]string{releaseAnnotationImageHash: mirror.Annotations[releaseAnnotationImageHash]}, tag.Name)
+		if len(tag.Annotations[release_controller.ReleaseAnnotationImageHash]) == 0 {
+			return c.setReleaseAnnotation(release, release_controller.ReleasePhasePending, map[string]string{release_controller.ReleaseAnnotationImageHash: mirror.Annotations[release_controller.ReleaseAnnotationImageHash]}, tag.Name)
 		}
-		if mirror.Annotations[releaseAnnotationImageHash] != tag.Annotations[releaseAnnotationImageHash] {
+		if mirror.Annotations[release_controller.ReleaseAnnotationImageHash] != tag.Annotations[release_controller.ReleaseAnnotationImageHash] {
 			return fmt.Errorf("mirror hash for %q does not match, release cannot be created", tag.Name)
 		}
 
@@ -446,14 +447,14 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 		case !success:
 			// try to get the last termination message
 			log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "status.phase=Failed", "build", false)
-			if err := c.transitionReleasePhaseFailure(release, []string{releasePhasePending}, releasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
+			if err := c.transitionReleasePhaseFailure(release, []string{release_controller.ReleasePhasePending}, release_controller.ReleasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
 				return err
 			}
 		default:
 			if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
 				return err
 			}
-			if tags := sortedRawReleaseTags(release, releasePhaseReady); len(tags) > 0 {
+			if tags := sortedRawReleaseTags(release, release_controller.ReleasePhaseReady); len(tags) > 0 {
 				go func() {
 					if _, err := c.releaseInfo.ChangeLog(tags[0].Name, tag.Name); err != nil {
 						klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
@@ -466,8 +467,8 @@ func (c *Controller) syncPending(release *Release, pendingTags []*imagev1.TagRef
 	return nil
 }
 
-func (c *Controller) syncReady(release *Release) error {
-	readyTags := sortedRawReleaseTags(release, releasePhaseReady)
+func (c *Controller) syncReady(release *release_controller.Release) error {
+	readyTags := sortedRawReleaseTags(release, release_controller.ReleasePhaseReady)
 
 	if klog.V(5) && len(readyTags) > 0 {
 		klog.Infof("ready=%v", tagNames(readyTags))
@@ -481,26 +482,26 @@ func (c *Controller) syncReady(release *Release) error {
 
 		if names, ok := status.Incomplete(release.Config.Verify); ok {
 			klog.V(4).Infof("Verification jobs for %s are still running: %s", releaseTag.Name, strings.Join(names, ", "))
-			if err := c.markReleaseReady(release, map[string]string{releaseAnnotationVerify: toJSONString(status)}, releaseTag.Name); err != nil {
+			if err := c.markReleaseReady(release, map[string]string{release_controller.ReleaseAnnotationVerify: toJSONString(status)}, releaseTag.Name); err != nil {
 				return err
 			}
 			continue
 		}
 
 		if names, ok := status.Failures(); ok {
-			retryNames, blockingJobFailed := verificationJobsWithRetries(release.Config.Verify, status)
+			retryNames, blockingJobFailed := release_controller.VerificationJobsWithRetries(release.Config.Verify, status)
 			if !blockingJobFailed && len(retryNames) > 0 {
 				klog.V(4).Infof("Release %s has retryable job failures: %v", releaseTag.Name, strings.Join(retryNames, ", "))
-				if err := c.markReleaseReady(release, map[string]string{releaseAnnotationVerify: toJSONString(status)}, releaseTag.Name); err != nil {
+				if err := c.markReleaseReady(release, map[string]string{release_controller.ReleaseAnnotationVerify: toJSONString(status)}, releaseTag.Name); err != nil {
 					return err
 				}
 				continue
 			}
-			if !allOptional(release.Config.Verify, names...) {
+			if !release_controller.AllOptional(release.Config.Verify, names...) {
 				klog.V(4).Infof("Release %s was rejected", releaseTag.Name)
 				annotations := reasonAndMessage("VerificationFailed", fmt.Sprintf("release verification step failed: %s", strings.Join(names, ", ")))
-				annotations[releaseAnnotationVerify] = toJSONString(status)
-				if err := c.transitionReleasePhaseFailure(release, []string{releasePhaseReady}, releasePhaseRejected, annotations, releaseTag.Name); err != nil {
+				annotations[release_controller.ReleaseAnnotationVerify] = toJSONString(status)
+				if err := c.transitionReleasePhaseFailure(release, []string{release_controller.ReleasePhaseReady}, release_controller.ReleasePhaseRejected, annotations, releaseTag.Name); err != nil {
 					return err
 				}
 				continue
@@ -509,7 +510,7 @@ func (c *Controller) syncReady(release *Release) error {
 		}
 
 		// if all jobs are complete and there are no failures, this is accepted
-		if err := c.markReleaseAccepted(release, map[string]string{releaseAnnotationVerify: toJSONString(status)}, releaseTag.Name); err != nil {
+		if err := c.markReleaseAccepted(release, map[string]string{release_controller.ReleaseAnnotationVerify: toJSONString(status)}, releaseTag.Name); err != nil {
 			return err
 		}
 		klog.V(4).Infof("Release %s accepted", releaseTag.Name)
@@ -518,8 +519,8 @@ func (c *Controller) syncReady(release *Release) error {
 	return nil
 }
 
-func (c *Controller) syncAccepted(release *Release) error {
-	acceptedTags := sortedRawReleaseTags(release, releasePhaseAccepted)
+func (c *Controller) syncAccepted(release *release_controller.Release) error {
+	acceptedTags := sortedRawReleaseTags(release, release_controller.ReleasePhaseAccepted)
 
 	if klog.V(5) && len(acceptedTags) > 0 {
 		klog.Infof("release=%s accepted=%v", release.Config.Name, tagNames(acceptedTags))
@@ -557,7 +558,7 @@ func (c *Controller) syncAccepted(release *Release) error {
 	return nil
 }
 
-func (c *Controller) loadReleaseForSync(namespace, name string) (*Release, error) {
+func (c *Controller) loadReleaseForSync(namespace, name string) (*release_controller.Release, error) {
 	// locate the release definition off the image stream, or clean up any remaining
 	// artifacts if the release no longer points to those
 	isLister := c.releaseLister.ImageStreams(namespace)

--- a/cmd/release-controller/sync_analysis.go
+++ b/cmd/release-controller/sync_analysis.go
@@ -13,7 +13,7 @@ const (
 	defaultAggregateProwJobName = "release-openshift-release-analysis-aggregator"
 )
 
-func (c *Controller) launchAnalysisJobs(release *release_controller.Release, verifyName string, verifyType release_controller.ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string) error {
+func (c *Controller) launchAnalysisJobs(release *releasecontroller.Release, verifyName string, verifyType releasecontroller.ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string) error {
 	jobLabels := map[string]string{
 		"release.openshift.io/analysis": releaseTag.Name,
 	}

--- a/cmd/release-controller/sync_analysis.go
+++ b/cmd/release-controller/sync_analysis.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"time"
 )
@@ -12,7 +13,7 @@ const (
 	defaultAggregateProwJobName = "release-openshift-release-analysis-aggregator"
 )
 
-func (c *Controller) launchAnalysisJobs(release *Release, verifyName string, verifyType ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string) error {
+func (c *Controller) launchAnalysisJobs(release *release_controller.Release, verifyName string, verifyType release_controller.ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string) error {
 	jobLabels := map[string]string{
 		"release.openshift.io/analysis": releaseTag.Name,
 	}

--- a/cmd/release-controller/sync_check.go
+++ b/cmd/release-controller/sync_check.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"sort"
 	"strings"
 	"time"
@@ -9,7 +10,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func checkConsistentImages(release, parent *Release) ReleaseCheckResult {
+func checkConsistentImages(release, parent *release_controller.Release) ReleaseCheckResult {
 	var result ReleaseCheckResult
 	source := parent.Source
 	target := release.Source

--- a/cmd/release-controller/sync_check.go
+++ b/cmd/release-controller/sync_check.go
@@ -10,7 +10,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func checkConsistentImages(release, parent *release_controller.Release) ReleaseCheckResult {
+func checkConsistentImages(release, parent *releasecontroller.Release) ReleaseCheckResult {
 	var result ReleaseCheckResult
 	source := parent.Source
 	target := release.Source

--- a/cmd/release-controller/sync_gc.go
+++ b/cmd/release-controller/sync_gc.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,7 +40,7 @@ func (c *Controller) garbageCollectSync() error {
 	active := sets.NewString()
 	targets := make(map[string]int64)
 	for _, imageStream := range imageStreams {
-		if _, ok := imageStream.Annotations[releaseAnnotationHasReleases]; ok {
+		if _, ok := imageStream.Annotations[release_controller.ReleaseAnnotationHasReleases]; ok {
 			for _, tag := range imageStream.Spec.Tags {
 				active.Insert(tag.Name)
 			}
@@ -47,7 +48,7 @@ func (c *Controller) garbageCollectSync() error {
 			continue
 		}
 
-		value, ok := imageStream.Annotations[releaseAnnotationConfig]
+		value, ok := imageStream.Annotations[release_controller.ReleaseAnnotationConfig]
 		if !ok {
 			continue
 		}
@@ -55,7 +56,7 @@ func (c *Controller) garbageCollectSync() error {
 		if err != nil {
 			continue
 		}
-		if config.As == releaseConfigModeStable {
+		if config.As == release_controller.ReleaseConfigModeStable {
 			for _, tag := range imageStream.Spec.Tags {
 				active.Insert(tag.Name)
 			}
@@ -65,10 +66,10 @@ func (c *Controller) garbageCollectSync() error {
 
 	// all jobs created for a release that no longer exists should be deleted
 	for _, job := range jobs {
-		if active.Has(job.Annotations[releaseAnnotationReleaseTag]) {
+		if active.Has(job.Annotations[release_controller.ReleaseAnnotationReleaseTag]) {
 			continue
 		}
-		targetGeneration, ok := targets[job.Annotations[releaseAnnotationTarget]]
+		targetGeneration, ok := targets[job.Annotations[release_controller.ReleaseAnnotationTarget]]
 		if !ok {
 			continue
 		}
@@ -94,10 +95,10 @@ func (c *Controller) garbageCollectSync() error {
 
 	// all image mirrors created for a release that no longer exists should be deleted
 	for _, mirror := range mirrors {
-		if active.Has(mirror.Annotations[releaseAnnotationReleaseTag]) {
+		if active.Has(mirror.Annotations[release_controller.ReleaseAnnotationReleaseTag]) {
 			continue
 		}
-		targetGeneration, ok := targets[mirror.Annotations[releaseAnnotationTarget]]
+		targetGeneration, ok := targets[mirror.Annotations[release_controller.ReleaseAnnotationTarget]]
 		if !ok {
 			continue
 		}

--- a/cmd/release-controller/sync_gc.go
+++ b/cmd/release-controller/sync_gc.go
@@ -40,7 +40,7 @@ func (c *Controller) garbageCollectSync() error {
 	active := sets.NewString()
 	targets := make(map[string]int64)
 	for _, imageStream := range imageStreams {
-		if _, ok := imageStream.Annotations[release_controller.ReleaseAnnotationHasReleases]; ok {
+		if _, ok := imageStream.Annotations[releasecontroller.ReleaseAnnotationHasReleases]; ok {
 			for _, tag := range imageStream.Spec.Tags {
 				active.Insert(tag.Name)
 			}
@@ -48,7 +48,7 @@ func (c *Controller) garbageCollectSync() error {
 			continue
 		}
 
-		value, ok := imageStream.Annotations[release_controller.ReleaseAnnotationConfig]
+		value, ok := imageStream.Annotations[releasecontroller.ReleaseAnnotationConfig]
 		if !ok {
 			continue
 		}
@@ -56,7 +56,7 @@ func (c *Controller) garbageCollectSync() error {
 		if err != nil {
 			continue
 		}
-		if config.As == release_controller.ReleaseConfigModeStable {
+		if config.As == releasecontroller.ReleaseConfigModeStable {
 			for _, tag := range imageStream.Spec.Tags {
 				active.Insert(tag.Name)
 			}
@@ -66,10 +66,10 @@ func (c *Controller) garbageCollectSync() error {
 
 	// all jobs created for a release that no longer exists should be deleted
 	for _, job := range jobs {
-		if active.Has(job.Annotations[release_controller.ReleaseAnnotationReleaseTag]) {
+		if active.Has(job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]) {
 			continue
 		}
-		targetGeneration, ok := targets[job.Annotations[release_controller.ReleaseAnnotationTarget]]
+		targetGeneration, ok := targets[job.Annotations[releasecontroller.ReleaseAnnotationTarget]]
 		if !ok {
 			continue
 		}
@@ -95,10 +95,10 @@ func (c *Controller) garbageCollectSync() error {
 
 	// all image mirrors created for a release that no longer exists should be deleted
 	for _, mirror := range mirrors {
-		if active.Has(mirror.Annotations[release_controller.ReleaseAnnotationReleaseTag]) {
+		if active.Has(mirror.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]) {
 			continue
 		}
-		targetGeneration, ok := targets[mirror.Annotations[release_controller.ReleaseAnnotationTarget]]
+		targetGeneration, ok := targets[mirror.Annotations[releasecontroller.ReleaseAnnotationTarget]]
 		if !ok {
 			continue
 		}

--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -16,7 +16,7 @@ import (
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
 )
 
-func (c *Controller) ensureReleaseMirror(release *release_controller.Release, releaseTagName, inputImageHash string) (*imagev1.ImageStream, error) {
+func (c *Controller) ensureReleaseMirror(release *releasecontroller.Release, releaseTagName, inputImageHash string) (*imagev1.ImageStream, error) {
 	mirrorName := mirrorName(release, releaseTagName)
 	is, err := c.releaseLister.ImageStreams(release.Source.Namespace).Get(mirrorName)
 	if err == nil {
@@ -31,17 +31,17 @@ func (c *Controller) ensureReleaseMirror(release *release_controller.Release, re
 			Name:      mirrorName,
 			Namespace: release.Source.Namespace,
 			Annotations: map[string]string{
-				release_controller.ReleaseAnnotationSource:     fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-				release_controller.ReleaseAnnotationTarget:     fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name),
-				release_controller.ReleaseAnnotationReleaseTag: releaseTagName,
-				release_controller.ReleaseAnnotationImageHash:  inputImageHash,
-				release_controller.ReleaseAnnotationGeneration: strconv.FormatInt(release.Target.Generation, 10),
+				releasecontroller.ReleaseAnnotationSource:     fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+				releasecontroller.ReleaseAnnotationTarget:     fmt.Sprintf("%s/%s", release.Target.Namespace, release.Target.Name),
+				releasecontroller.ReleaseAnnotationReleaseTag: releaseTagName,
+				releasecontroller.ReleaseAnnotationImageHash:  inputImageHash,
+				releasecontroller.ReleaseAnnotationGeneration: strconv.FormatInt(release.Target.Generation, 10),
 			},
 		},
 	}
 
 	switch release.Config.As {
-	case release_controller.ReleaseConfigModeStable:
+	case releasecontroller.ReleaseConfigModeStable:
 		// stream will be populated later
 	default:
 		if err := calculateMirrorImageStream(release, is); err != nil {
@@ -67,13 +67,13 @@ func (c *Controller) ensureReleaseMirror(release *release_controller.Release, re
 	return is, err
 }
 
-func (c *Controller) getMirror(release *release_controller.Release, releaseTagName string) (*imagev1.ImageStream, error) {
+func (c *Controller) getMirror(release *releasecontroller.Release, releaseTagName string) (*imagev1.ImageStream, error) {
 	return c.releaseLister.ImageStreams(release.Source.Namespace).Get(mirrorName(release, releaseTagName))
 }
 
-func mirrorName(release *release_controller.Release, releaseTagName string) string {
+func mirrorName(release *releasecontroller.Release, releaseTagName string) string {
 	switch release.Config.As {
-	case release_controller.ReleaseConfigModeStable:
+	case releasecontroller.ReleaseConfigModeStable:
 		return releaseTagName
 	default:
 		suffix := strings.TrimPrefix(releaseTagName, release.Config.Name)
@@ -84,7 +84,7 @@ func mirrorName(release *release_controller.Release, releaseTagName string) stri
 	}
 }
 
-func calculateMirrorImageStream(release *release_controller.Release, is *imagev1.ImageStream) error {
+func calculateMirrorImageStream(release *releasecontroller.Release, is *imagev1.ImageStream) error {
 	// this block is mostly identical to the logic in openshift/origin pkg/oc/cli/admin/release/new which
 	// calculates the spec tags - it preserves the desired source location of the image and errors when
 	// we can't resolve or the result might be ambiguous

--- a/cmd/release-controller/sync_publish.go
+++ b/cmd/release-controller/sync_publish.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"reflect"
 	"sort"
 	"strings"
@@ -16,7 +17,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func (c *Controller) ensureTagPointsToRelease(release *Release, to, from string) error {
+func (c *Controller) ensureTagPointsToRelease(release *release_controller.Release, to, from string) error {
 	if to == from {
 		return nil
 	}
@@ -55,7 +56,7 @@ func (c *Controller) ensureTagPointsToRelease(release *Release, to, from string)
 	return nil
 }
 
-func (c *Controller) ensureImageStreamMatchesRelease(release *Release, toNamespace, toName, from string, tags, excludeTags []string) error {
+func (c *Controller) ensureImageStreamMatchesRelease(release *release_controller.Release, toNamespace, toName, from string, tags, excludeTags []string) error {
 	if len(tags) == 0 {
 		klog.V(4).Infof("Ensure image stream %s/%s has contents of %s", toNamespace, toName, from)
 	} else {

--- a/cmd/release-controller/sync_publish.go
+++ b/cmd/release-controller/sync_publish.go
@@ -17,7 +17,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func (c *Controller) ensureTagPointsToRelease(release *release_controller.Release, to, from string) error {
+func (c *Controller) ensureTagPointsToRelease(release *releasecontroller.Release, to, from string) error {
 	if to == from {
 		return nil
 	}
@@ -56,7 +56,7 @@ func (c *Controller) ensureTagPointsToRelease(release *release_controller.Releas
 	return nil
 }
 
-func (c *Controller) ensureImageStreamMatchesRelease(release *release_controller.Release, toNamespace, toName, from string, tags, excludeTags []string) error {
+func (c *Controller) ensureImageStreamMatchesRelease(release *releasecontroller.Release, toNamespace, toName, from string, tags, excludeTags []string) error {
 	if len(tags) == 0 {
 		klog.V(4).Infof("Ensure image stream %s/%s has contents of %s", toNamespace, toName, from)
 	} else {

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -18,7 +18,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func (c *Controller) ensureReleaseJob(release *release_controller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) {
+func (c *Controller) ensureReleaseJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) {
 	return c.ensureJob(name, nil, func() (*batchv1.Job, error) {
 		toImage := fmt.Sprintf("%s:%s", release.Target.Status.PublicDockerImageRepository, name)
 		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)
@@ -37,21 +37,21 @@ func (c *Controller) ensureReleaseJob(release *release_controller.Release, name 
 			name, mirror.Name, mirror.Namespace, toImage, release.Config.ReferenceMode,
 		}
 
-		job.Annotations[release_controller.ReleaseAnnotationSource] = mirror.Annotations[release_controller.ReleaseAnnotationSource]
-		job.Annotations[release_controller.ReleaseAnnotationTarget] = mirror.Annotations[release_controller.ReleaseAnnotationTarget]
-		job.Annotations[release_controller.ReleaseAnnotationGeneration] = strconv.FormatInt(release.Target.Generation, 10)
-		job.Annotations[release_controller.ReleaseAnnotationReleaseTag] = mirror.Annotations[release_controller.ReleaseAnnotationReleaseTag]
+		job.Annotations[releasecontroller.ReleaseAnnotationSource] = mirror.Annotations[releasecontroller.ReleaseAnnotationSource]
+		job.Annotations[releasecontroller.ReleaseAnnotationTarget] = mirror.Annotations[releasecontroller.ReleaseAnnotationTarget]
+		job.Annotations[releasecontroller.ReleaseAnnotationGeneration] = strconv.FormatInt(release.Target.Generation, 10)
+		job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag] = mirror.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]
 
 		klog.V(2).Infof("Running release creation job %s/%s for %s", c.jobNamespace, job.Name, name)
 		return job, nil
 	})
 }
 
-func (c *Controller) ensureRewriteJob(release *release_controller.Release, name string, mirror *imagev1.ImageStream, metadataJSON string) (*batchv1.Job, error) {
+func (c *Controller) ensureRewriteJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream, metadataJSON string) (*batchv1.Job, error) {
 	ref := findTagReference(release.Source, name)
 	generation := *ref.Generation
 	preconditions := map[string]string{
-		release_controller.ReleaseAnnotationGeneration: strconv.FormatInt(generation, 10),
+		releasecontroller.ReleaseAnnotationGeneration: strconv.FormatInt(generation, 10),
 	}
 	return c.ensureJob(name, preconditions, func() (*batchv1.Job, error) {
 		toImage := fmt.Sprintf("%s:%s", release.Source.Status.PublicDockerImageRepository, name)
@@ -87,7 +87,7 @@ func (c *Controller) ensureRewriteJob(release *release_controller.Release, name 
 			toImage, mirror.Name, mirror.Namespace,
 		}
 		// rebuild the payload using the provided metadata
-		if _, ok := ref.Annotations[release_controller.ReleaseAnnotationMirrorImages]; ok {
+		if _, ok := ref.Annotations[releasecontroller.ReleaseAnnotationMirrorImages]; ok {
 			job.Spec.Template.Spec.Containers[0].Command = []string{
 				"/bin/bash", "-c",
 				prefix + `
@@ -107,20 +107,20 @@ func (c *Controller) ensureRewriteJob(release *release_controller.Release, name 
 			}
 		}
 
-		job.Annotations[release_controller.ReleaseAnnotationSource] = mirror.Annotations[release_controller.ReleaseAnnotationSource]
-		job.Annotations[release_controller.ReleaseAnnotationTarget] = mirror.Annotations[release_controller.ReleaseAnnotationTarget]
-		job.Annotations[release_controller.ReleaseAnnotationGeneration] = strconv.FormatInt(generation, 10)
-		job.Annotations[release_controller.ReleaseAnnotationReleaseTag] = mirror.Annotations[release_controller.ReleaseAnnotationReleaseTag]
+		job.Annotations[releasecontroller.ReleaseAnnotationSource] = mirror.Annotations[releasecontroller.ReleaseAnnotationSource]
+		job.Annotations[releasecontroller.ReleaseAnnotationTarget] = mirror.Annotations[releasecontroller.ReleaseAnnotationTarget]
+		job.Annotations[releasecontroller.ReleaseAnnotationGeneration] = strconv.FormatInt(generation, 10)
+		job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag] = mirror.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]
 
 		klog.V(2).Infof("Running release rewrite job for %s", name)
 		return job, nil
 	})
 }
 
-func (c *Controller) ensureImportJob(release *release_controller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) {
+func (c *Controller) ensureImportJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) {
 	generation := *findTagReference(release.Source, name).Generation
 	preconditions := map[string]string{
-		release_controller.ReleaseAnnotationGeneration: strconv.FormatInt(generation, 10),
+		releasecontroller.ReleaseAnnotationGeneration: strconv.FormatInt(generation, 10),
 	}
 	return c.ensureJob(name, preconditions, func() (*batchv1.Job, error) {
 		toImage := fmt.Sprintf("%s:%s", release.Source.Status.PublicDockerImageRepository, name)
@@ -153,10 +153,10 @@ func (c *Controller) ensureImportJob(release *release_controller.Release, name s
 			toImage, mirror.Name, mirror.Namespace,
 		}
 
-		job.Annotations[release_controller.ReleaseAnnotationSource] = mirror.Annotations[release_controller.ReleaseAnnotationSource]
-		job.Annotations[release_controller.ReleaseAnnotationTarget] = mirror.Annotations[release_controller.ReleaseAnnotationTarget]
-		job.Annotations[release_controller.ReleaseAnnotationGeneration] = strconv.FormatInt(generation, 10)
-		job.Annotations[release_controller.ReleaseAnnotationReleaseTag] = mirror.Annotations[release_controller.ReleaseAnnotationReleaseTag]
+		job.Annotations[releasecontroller.ReleaseAnnotationSource] = mirror.Annotations[releasecontroller.ReleaseAnnotationSource]
+		job.Annotations[releasecontroller.ReleaseAnnotationTarget] = mirror.Annotations[releasecontroller.ReleaseAnnotationTarget]
+		job.Annotations[releasecontroller.ReleaseAnnotationGeneration] = strconv.FormatInt(generation, 10)
+		job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag] = mirror.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]
 
 		klog.V(2).Infof("Running release import job for %s", name)
 		return job, nil
@@ -202,7 +202,7 @@ func (c *Controller) ensureJob(name string, preconditions map[string]string, cre
 	return c.jobClient.Jobs(c.jobNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func (c *Controller) ensureRewriteJobImageRetrieved(release *release_controller.Release, job *batchv1.Job, mirror *imagev1.ImageStream) error {
+func (c *Controller) ensureRewriteJobImageRetrieved(release *releasecontroller.Release, job *batchv1.Job, mirror *imagev1.ImageStream) error {
 	if findTagReference(mirror, "cli") != nil {
 		return nil
 	}

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"reflect"
 	"time"
 
@@ -15,17 +16,17 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func (c *Controller) createReleaseTag(release *Release, now time.Time, inputImageHash string) (*imagev1.TagReference, error) {
+func (c *Controller) createReleaseTag(release *release_controller.Release, now time.Time, inputImageHash string) (*imagev1.TagReference, error) {
 	target := release.Target.DeepCopy()
 	now = now.UTC().Truncate(time.Second)
 	t := now.Format("2006-01-02-150405")
 	tag := imagev1.TagReference{
 		Name: fmt.Sprintf("%s-%s", release.Config.Name, t),
 		Annotations: map[string]string{
-			releaseAnnotationName:              release.Config.Name,
-			releaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-			releaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
-			releaseAnnotationPhase:             releasePhasePending,
+			release_controller.ReleaseAnnotationName:              release.Config.Name,
+			release_controller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+			release_controller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
+			release_controller.ReleaseAnnotationPhase:             release_controller.ReleasePhasePending,
 		},
 	}
 	target.Spec.Tags = append(target.Spec.Tags, tag)
@@ -44,7 +45,7 @@ func (c *Controller) createReleaseTag(release *Release, now time.Time, inputImag
 	return &is.Spec.Tags[len(is.Spec.Tags)-1], nil
 }
 
-func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.TagReference) error {
+func (c *Controller) replaceReleaseTagWithNext(release *release_controller.Release, tag *imagev1.TagReference) error {
 	var semanticTags []semver.Version
 	for _, tag := range sortedReleaseTags(release) {
 		version, err := semver.Parse(tag.Name)
@@ -57,7 +58,7 @@ func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.Ta
 	// we don't want to leave the tag pending, because there is no tag to increment from and
 	// a future update shouldn't change it
 	if len(semanticTags) == 0 {
-		return c.transitionReleasePhaseFailure(release, []string{"", releasePhasePending}, releasePhaseFailed, reasonAndMessage("NoExistingTags", "The next tag requires at least one existing semantic version tag in this image stream."), tag.Name)
+		return c.transitionReleasePhaseFailure(release, []string{"", release_controller.ReleasePhasePending}, release_controller.ReleasePhaseFailed, reasonAndMessage("NoExistingTags", "The next tag requires at least one existing semantic version tag in this image stream."), tag.Name)
 	}
 
 	// find the next tag
@@ -73,14 +74,14 @@ func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.Ta
 	origin := findTagReference(target, tag.Name)
 	origin.Name = next.String()
 	origin.Annotations = map[string]string{
-		releaseAnnotationName:              release.Config.Name,
-		releaseAnnotationCreationTimestamp: time.Now().Format(time.RFC3339),
-		releaseAnnotationPhase:             releasePhasePending,
-		releaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-		releaseAnnotationRewrite:           "true",
+		release_controller.ReleaseAnnotationName:              release.Config.Name,
+		release_controller.ReleaseAnnotationCreationTimestamp: time.Now().Format(time.RFC3339),
+		release_controller.ReleaseAnnotationPhase:             release_controller.ReleasePhasePending,
+		release_controller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+		release_controller.ReleaseAnnotationRewrite:           "true",
 	}
-	if value, ok := tag.Annotations[releaseAnnotationMirrorImages]; ok {
-		origin.Annotations[releaseAnnotationMirrorImages] = value
+	if value, ok := tag.Annotations[release_controller.ReleaseAnnotationMirrorImages]; ok {
+		origin.Annotations[release_controller.ReleaseAnnotationMirrorImages] = value
 	}
 	origin.From = tag.From
 	origin.ImportPolicy = tag.ImportPolicy
@@ -94,7 +95,7 @@ func (c *Controller) replaceReleaseTagWithNext(release *Release, tag *imagev1.Ta
 	return nil
 }
 
-func (c *Controller) removeReleaseTags(release *Release, removeTags []*imagev1.TagReference) error {
+func (c *Controller) removeReleaseTags(release *release_controller.Release, removeTags []*imagev1.TagReference) error {
 	for _, tag := range removeTags {
 		ctx := context.TODO()
 		name := fmt.Sprintf("%s:%s", release.Target.Name, tag.Name)
@@ -111,8 +112,8 @@ func (c *Controller) removeReleaseTags(release *Release, removeTags []*imagev1.T
 			if isTag.Annotations == nil {
 				isTag.Annotations = map[string]string{}
 			}
-			if _, ok := isTag.Annotations[releaseAnnotationSoftDelete]; !ok {
-				isTag.Annotations[releaseAnnotationSoftDelete] = time.Now().Format(time.RFC3339)
+			if _, ok := isTag.Annotations[release_controller.ReleaseAnnotationSoftDelete]; !ok {
+				isTag.Annotations[release_controller.ReleaseAnnotationSoftDelete] = time.Now().Format(time.RFC3339)
 				if _, err := c.imageClient.ImageStreamTags(release.Target.Namespace).Update(context.TODO(), isTag, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
 					return err
 				}
@@ -130,7 +131,7 @@ func (c *Controller) removeReleaseTags(release *Release, removeTags []*imagev1.T
 	return nil
 }
 
-func (c *Controller) setReleaseAnnotation(release *Release, phase string, annotations map[string]string, names ...string) error {
+func (c *Controller) setReleaseAnnotation(release *release_controller.Release, phase string, annotations map[string]string, names ...string) error {
 	is := release.Target
 
 	if len(names) == 0 {
@@ -147,7 +148,7 @@ func (c *Controller) setReleaseAnnotation(release *Release, phase string, annota
 		if tag.Annotations == nil {
 			tag.Annotations = make(map[string]string)
 		}
-		if current := tag.Annotations[releaseAnnotationPhase]; current != phase {
+		if current := tag.Annotations[release_controller.ReleaseAnnotationPhase]; current != phase {
 			return fmt.Errorf("release %s is not in phase %v (%s)", name, phase, current)
 		}
 		for k, v := range annotations {
@@ -180,15 +181,15 @@ func (c *Controller) setReleaseAnnotation(release *Release, phase string, annota
 	return nil
 }
 
-func (c *Controller) markReleaseReady(release *Release, annotations map[string]string, names ...string) error {
-	return c.ensureReleaseTagPhase(release, []string{releasePhasePending, releasePhaseReady, ""}, releasePhaseReady, annotations, names...)
+func (c *Controller) markReleaseReady(release *release_controller.Release, annotations map[string]string, names ...string) error {
+	return c.ensureReleaseTagPhase(release, []string{release_controller.ReleasePhasePending, release_controller.ReleasePhaseReady, ""}, release_controller.ReleasePhaseReady, annotations, names...)
 }
 
-func (c *Controller) markReleaseAccepted(release *Release, annotations map[string]string, names ...string) error {
-	return c.ensureReleaseTagPhase(release, []string{releasePhaseReady}, releasePhaseAccepted, annotations, names...)
+func (c *Controller) markReleaseAccepted(release *release_controller.Release, annotations map[string]string, names ...string) error {
+	return c.ensureReleaseTagPhase(release, []string{release_controller.ReleasePhaseReady}, release_controller.ReleasePhaseAccepted, annotations, names...)
 }
 
-func (c *Controller) ensureReleaseTagPhase(release *Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
+func (c *Controller) ensureReleaseTagPhase(release *release_controller.Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
 	if len(names) == 0 {
 		return nil
 	}
@@ -201,15 +202,15 @@ func (c *Controller) ensureReleaseTagPhase(release *Release, preconditionPhases 
 			return fmt.Errorf("release %s no longer exists, cannot be put into %s", name, phase)
 		}
 
-		if current := tag.Annotations[releaseAnnotationPhase]; !containsString(preconditionPhases, current) {
+		if current := tag.Annotations[release_controller.ReleaseAnnotationPhase]; !containsString(preconditionPhases, current) {
 			return fmt.Errorf("release %s is not in phase %v (%s), unable to mark %s", name, preconditionPhases, current, phase)
 		}
 		if tag.Annotations == nil {
 			tag.Annotations = make(map[string]string)
 		}
-		tag.Annotations[releaseAnnotationPhase] = phase
-		delete(tag.Annotations, releaseAnnotationReason)
-		delete(tag.Annotations, releaseAnnotationMessage)
+		tag.Annotations[release_controller.ReleaseAnnotationPhase] = phase
+		delete(tag.Annotations, release_controller.ReleaseAnnotationReason)
+		delete(tag.Annotations, release_controller.ReleaseAnnotationMessage)
 		for k, v := range annotations {
 			if len(v) == 0 {
 				delete(tag.Annotations, k)
@@ -240,18 +241,18 @@ func (c *Controller) ensureReleaseTagPhase(release *Release, preconditionPhases 
 	return nil
 }
 
-func (c *Controller) transitionReleasePhaseFailure(release *Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
+func (c *Controller) transitionReleasePhaseFailure(release *release_controller.Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
 	target := release.Target.DeepCopy()
 	changed := 0
 	for _, name := range names {
 		if tag := findTagReference(target, name); tag != nil {
-			if current := tag.Annotations[releaseAnnotationPhase]; !containsString(preconditionPhases, current) {
+			if current := tag.Annotations[release_controller.ReleaseAnnotationPhase]; !containsString(preconditionPhases, current) {
 				return fmt.Errorf("release %s is not in phase %v (%s), unable to mark %s", name, preconditionPhases, current, phase)
 			}
 			if tag.Annotations == nil {
 				tag.Annotations = make(map[string]string)
 			}
-			tag.Annotations[releaseAnnotationPhase] = phase
+			tag.Annotations[release_controller.ReleaseAnnotationPhase] = phase
 			for k, v := range annotations {
 				tag.Annotations[k] = v
 			}
@@ -293,20 +294,20 @@ func incrementSemanticVersion(v semver.Version) (semver.Version, error) {
 
 func reasonAndMessage(reason, message string) map[string]string {
 	return map[string]string{
-		releaseAnnotationReason:  reason,
-		releaseAnnotationMessage: message,
+		release_controller.ReleaseAnnotationReason:  reason,
+		release_controller.ReleaseAnnotationMessage: message,
 	}
 }
 
 func withLog(annotations map[string]string, log string) map[string]string {
 	if len(log) > 0 {
-		annotations[releaseAnnotationLog] = log
+		annotations[release_controller.ReleaseAnnotationLog] = log
 	}
 	return annotations
 }
 
-func updateReleaseTarget(release *Release, is *imagev1.ImageStream) {
-	if release.Config.As == releaseConfigModeStable {
+func updateReleaseTarget(release *release_controller.Release, is *imagev1.ImageStream) {
+	if release.Config.As == release_controller.ReleaseConfigModeStable {
 		release.Source = is
 	}
 	release.Target = is

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -16,17 +16,17 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func (c *Controller) createReleaseTag(release *release_controller.Release, now time.Time, inputImageHash string) (*imagev1.TagReference, error) {
+func (c *Controller) createReleaseTag(release *releasecontroller.Release, now time.Time, inputImageHash string) (*imagev1.TagReference, error) {
 	target := release.Target.DeepCopy()
 	now = now.UTC().Truncate(time.Second)
 	t := now.Format("2006-01-02-150405")
 	tag := imagev1.TagReference{
 		Name: fmt.Sprintf("%s-%s", release.Config.Name, t),
 		Annotations: map[string]string{
-			release_controller.ReleaseAnnotationName:              release.Config.Name,
-			release_controller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-			release_controller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
-			release_controller.ReleaseAnnotationPhase:             release_controller.ReleasePhasePending,
+			releasecontroller.ReleaseAnnotationName:              release.Config.Name,
+			releasecontroller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+			releasecontroller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
+			releasecontroller.ReleaseAnnotationPhase:             releasecontroller.ReleasePhasePending,
 		},
 	}
 	target.Spec.Tags = append(target.Spec.Tags, tag)
@@ -45,7 +45,7 @@ func (c *Controller) createReleaseTag(release *release_controller.Release, now t
 	return &is.Spec.Tags[len(is.Spec.Tags)-1], nil
 }
 
-func (c *Controller) replaceReleaseTagWithNext(release *release_controller.Release, tag *imagev1.TagReference) error {
+func (c *Controller) replaceReleaseTagWithNext(release *releasecontroller.Release, tag *imagev1.TagReference) error {
 	var semanticTags []semver.Version
 	for _, tag := range sortedReleaseTags(release) {
 		version, err := semver.Parse(tag.Name)
@@ -58,7 +58,7 @@ func (c *Controller) replaceReleaseTagWithNext(release *release_controller.Relea
 	// we don't want to leave the tag pending, because there is no tag to increment from and
 	// a future update shouldn't change it
 	if len(semanticTags) == 0 {
-		return c.transitionReleasePhaseFailure(release, []string{"", release_controller.ReleasePhasePending}, release_controller.ReleasePhaseFailed, reasonAndMessage("NoExistingTags", "The next tag requires at least one existing semantic version tag in this image stream."), tag.Name)
+		return c.transitionReleasePhaseFailure(release, []string{"", releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, reasonAndMessage("NoExistingTags", "The next tag requires at least one existing semantic version tag in this image stream."), tag.Name)
 	}
 
 	// find the next tag
@@ -74,14 +74,14 @@ func (c *Controller) replaceReleaseTagWithNext(release *release_controller.Relea
 	origin := findTagReference(target, tag.Name)
 	origin.Name = next.String()
 	origin.Annotations = map[string]string{
-		release_controller.ReleaseAnnotationName:              release.Config.Name,
-		release_controller.ReleaseAnnotationCreationTimestamp: time.Now().Format(time.RFC3339),
-		release_controller.ReleaseAnnotationPhase:             release_controller.ReleasePhasePending,
-		release_controller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-		release_controller.ReleaseAnnotationRewrite:           "true",
+		releasecontroller.ReleaseAnnotationName:              release.Config.Name,
+		releasecontroller.ReleaseAnnotationCreationTimestamp: time.Now().Format(time.RFC3339),
+		releasecontroller.ReleaseAnnotationPhase:             releasecontroller.ReleasePhasePending,
+		releasecontroller.ReleaseAnnotationSource:            fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+		releasecontroller.ReleaseAnnotationRewrite:           "true",
 	}
-	if value, ok := tag.Annotations[release_controller.ReleaseAnnotationMirrorImages]; ok {
-		origin.Annotations[release_controller.ReleaseAnnotationMirrorImages] = value
+	if value, ok := tag.Annotations[releasecontroller.ReleaseAnnotationMirrorImages]; ok {
+		origin.Annotations[releasecontroller.ReleaseAnnotationMirrorImages] = value
 	}
 	origin.From = tag.From
 	origin.ImportPolicy = tag.ImportPolicy
@@ -95,7 +95,7 @@ func (c *Controller) replaceReleaseTagWithNext(release *release_controller.Relea
 	return nil
 }
 
-func (c *Controller) removeReleaseTags(release *release_controller.Release, removeTags []*imagev1.TagReference) error {
+func (c *Controller) removeReleaseTags(release *releasecontroller.Release, removeTags []*imagev1.TagReference) error {
 	for _, tag := range removeTags {
 		ctx := context.TODO()
 		name := fmt.Sprintf("%s:%s", release.Target.Name, tag.Name)
@@ -112,8 +112,8 @@ func (c *Controller) removeReleaseTags(release *release_controller.Release, remo
 			if isTag.Annotations == nil {
 				isTag.Annotations = map[string]string{}
 			}
-			if _, ok := isTag.Annotations[release_controller.ReleaseAnnotationSoftDelete]; !ok {
-				isTag.Annotations[release_controller.ReleaseAnnotationSoftDelete] = time.Now().Format(time.RFC3339)
+			if _, ok := isTag.Annotations[releasecontroller.ReleaseAnnotationSoftDelete]; !ok {
+				isTag.Annotations[releasecontroller.ReleaseAnnotationSoftDelete] = time.Now().Format(time.RFC3339)
 				if _, err := c.imageClient.ImageStreamTags(release.Target.Namespace).Update(context.TODO(), isTag, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
 					return err
 				}
@@ -131,7 +131,7 @@ func (c *Controller) removeReleaseTags(release *release_controller.Release, remo
 	return nil
 }
 
-func (c *Controller) setReleaseAnnotation(release *release_controller.Release, phase string, annotations map[string]string, names ...string) error {
+func (c *Controller) setReleaseAnnotation(release *releasecontroller.Release, phase string, annotations map[string]string, names ...string) error {
 	is := release.Target
 
 	if len(names) == 0 {
@@ -148,7 +148,7 @@ func (c *Controller) setReleaseAnnotation(release *release_controller.Release, p
 		if tag.Annotations == nil {
 			tag.Annotations = make(map[string]string)
 		}
-		if current := tag.Annotations[release_controller.ReleaseAnnotationPhase]; current != phase {
+		if current := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]; current != phase {
 			return fmt.Errorf("release %s is not in phase %v (%s)", name, phase, current)
 		}
 		for k, v := range annotations {
@@ -181,15 +181,15 @@ func (c *Controller) setReleaseAnnotation(release *release_controller.Release, p
 	return nil
 }
 
-func (c *Controller) markReleaseReady(release *release_controller.Release, annotations map[string]string, names ...string) error {
-	return c.ensureReleaseTagPhase(release, []string{release_controller.ReleasePhasePending, release_controller.ReleasePhaseReady, ""}, release_controller.ReleasePhaseReady, annotations, names...)
+func (c *Controller) markReleaseReady(release *releasecontroller.Release, annotations map[string]string, names ...string) error {
+	return c.ensureReleaseTagPhase(release, []string{releasecontroller.ReleasePhasePending, releasecontroller.ReleasePhaseReady, ""}, releasecontroller.ReleasePhaseReady, annotations, names...)
 }
 
-func (c *Controller) markReleaseAccepted(release *release_controller.Release, annotations map[string]string, names ...string) error {
-	return c.ensureReleaseTagPhase(release, []string{release_controller.ReleasePhaseReady}, release_controller.ReleasePhaseAccepted, annotations, names...)
+func (c *Controller) markReleaseAccepted(release *releasecontroller.Release, annotations map[string]string, names ...string) error {
+	return c.ensureReleaseTagPhase(release, []string{releasecontroller.ReleasePhaseReady}, releasecontroller.ReleasePhaseAccepted, annotations, names...)
 }
 
-func (c *Controller) ensureReleaseTagPhase(release *release_controller.Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
+func (c *Controller) ensureReleaseTagPhase(release *releasecontroller.Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
 	if len(names) == 0 {
 		return nil
 	}
@@ -202,15 +202,15 @@ func (c *Controller) ensureReleaseTagPhase(release *release_controller.Release, 
 			return fmt.Errorf("release %s no longer exists, cannot be put into %s", name, phase)
 		}
 
-		if current := tag.Annotations[release_controller.ReleaseAnnotationPhase]; !containsString(preconditionPhases, current) {
+		if current := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]; !containsString(preconditionPhases, current) {
 			return fmt.Errorf("release %s is not in phase %v (%s), unable to mark %s", name, preconditionPhases, current, phase)
 		}
 		if tag.Annotations == nil {
 			tag.Annotations = make(map[string]string)
 		}
-		tag.Annotations[release_controller.ReleaseAnnotationPhase] = phase
-		delete(tag.Annotations, release_controller.ReleaseAnnotationReason)
-		delete(tag.Annotations, release_controller.ReleaseAnnotationMessage)
+		tag.Annotations[releasecontroller.ReleaseAnnotationPhase] = phase
+		delete(tag.Annotations, releasecontroller.ReleaseAnnotationReason)
+		delete(tag.Annotations, releasecontroller.ReleaseAnnotationMessage)
 		for k, v := range annotations {
 			if len(v) == 0 {
 				delete(tag.Annotations, k)
@@ -241,18 +241,18 @@ func (c *Controller) ensureReleaseTagPhase(release *release_controller.Release, 
 	return nil
 }
 
-func (c *Controller) transitionReleasePhaseFailure(release *release_controller.Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
+func (c *Controller) transitionReleasePhaseFailure(release *releasecontroller.Release, preconditionPhases []string, phase string, annotations map[string]string, names ...string) error {
 	target := release.Target.DeepCopy()
 	changed := 0
 	for _, name := range names {
 		if tag := findTagReference(target, name); tag != nil {
-			if current := tag.Annotations[release_controller.ReleaseAnnotationPhase]; !containsString(preconditionPhases, current) {
+			if current := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]; !containsString(preconditionPhases, current) {
 				return fmt.Errorf("release %s is not in phase %v (%s), unable to mark %s", name, preconditionPhases, current, phase)
 			}
 			if tag.Annotations == nil {
 				tag.Annotations = make(map[string]string)
 			}
-			tag.Annotations[release_controller.ReleaseAnnotationPhase] = phase
+			tag.Annotations[releasecontroller.ReleaseAnnotationPhase] = phase
 			for k, v := range annotations {
 				tag.Annotations[k] = v
 			}
@@ -294,20 +294,20 @@ func incrementSemanticVersion(v semver.Version) (semver.Version, error) {
 
 func reasonAndMessage(reason, message string) map[string]string {
 	return map[string]string{
-		release_controller.ReleaseAnnotationReason:  reason,
-		release_controller.ReleaseAnnotationMessage: message,
+		releasecontroller.ReleaseAnnotationReason:  reason,
+		releasecontroller.ReleaseAnnotationMessage: message,
 	}
 }
 
 func withLog(annotations map[string]string, log string) map[string]string {
 	if len(log) > 0 {
-		annotations[release_controller.ReleaseAnnotationLog] = log
+		annotations[releasecontroller.ReleaseAnnotationLog] = log
 	}
 	return annotations
 }
 
-func updateReleaseTarget(release *release_controller.Release, is *imagev1.ImageStream) {
-	if release.Config.As == release_controller.ReleaseConfigModeStable {
+func updateReleaseTarget(release *releasecontroller.Release, is *imagev1.ImageStream) {
+	if release.Config.As == releasecontroller.ReleaseConfigModeStable {
 		release.Source = is
 	}
 	release.Target = is

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"sort"
 	"strings"
 	"time"
@@ -14,8 +15,8 @@ import (
 	"k8s.io/klog"
 )
 
-func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev1.TagReference) (VerificationStatusMap, error) {
-	var verifyStatus VerificationStatusMap
+func (c *Controller) ensureVerificationJobs(release *release_controller.Release, releaseTag *imagev1.TagReference) (release_controller.VerificationStatusMap, error) {
+	var verifyStatus release_controller.VerificationStatusMap
 	retryQueueDelay := 0 * time.Second
 	for name, verifyType := range release.Config.Verify {
 		if verifyType.Disabled {
@@ -26,8 +27,8 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 		switch {
 		case verifyType.ProwJob != nil:
 			if verifyStatus == nil {
-				if data := releaseTag.Annotations[releaseAnnotationVerify]; len(data) > 0 {
-					verifyStatus = make(VerificationStatusMap)
+				if data := releaseTag.Annotations[release_controller.ReleaseAnnotationVerify]; len(data) > 0 {
+					verifyStatus = make(release_controller.VerificationStatusMap)
 					if err := json.Unmarshal([]byte(data), &verifyStatus); err != nil {
 						klog.Errorf("Release %s has invalid verification status, ignoring: %v", releaseTag.Name, err)
 					}
@@ -38,16 +39,16 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 			if status, ok := verifyStatus[name]; ok {
 				jobRetries = status.Retries
 				switch status.State {
-				case releaseVerificationStateSucceeded:
+				case release_controller.ReleaseVerificationStateSucceeded:
 					continue
-				case releaseVerificationStateFailed:
+				case release_controller.ReleaseVerificationStateFailed:
 					jobRetries++
 					if jobRetries > verifyType.MaxRetries {
 						continue
 					}
 					// find the next time, if ok run.
 					if status.TransitionTime != nil {
-						backoffDuration := calculateBackoff(jobRetries-1, status.TransitionTime, &metav1.Time{Time: time.Now()})
+						backoffDuration := release_controller.CalculateBackoff(jobRetries-1, status.TransitionTime, &metav1.Time{Time: time.Now()})
 						if backoffDuration > 0 {
 							klog.V(6).Infof("%s: Release verification step %s failed %d times, last failure: %s, backoff till: %s",
 								releaseTag.Name, name, jobRetries, status.TransitionTime.Format(time.RFC3339), time.Now().Add(backoffDuration).Format(time.RFC3339))
@@ -57,7 +58,7 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 							continue
 						}
 					}
-				case releaseVerificationStatePending:
+				case release_controller.ReleaseVerificationStatePending:
 					// we need to process this
 				default:
 					klog.V(2).Infof("Unrecognized verification status %q for type %s on release %s", status.State, name, releaseTag.Name)
@@ -95,11 +96,11 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 			if !ok {
 				return nil, fmt.Errorf("unexpected error accessing prow job definition")
 			}
-			if status.State == releaseVerificationStateSucceeded {
+			if status.State == release_controller.ReleaseVerificationStateSucceeded {
 				klog.V(2).Infof("Prow job %s for release %s succeeded, logs at %s", name, releaseTag.Name, status.URL)
 			}
 			if verifyStatus == nil {
-				verifyStatus = make(VerificationStatusMap)
+				verifyStatus = make(release_controller.VerificationStatusMap)
 			}
 			status.Retries = jobRetries
 			verifyStatus[name] = status
@@ -109,9 +110,9 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 				continue
 			}
 
-			if status.State == releaseVerificationStateFailed {
+			if status.State == release_controller.ReleaseVerificationStateFailed {
 				// Queue for retry if at least one retryable job at earliest interval
-				backoffDuration := calculateBackoff(jobRetries, status.TransitionTime, &metav1.Time{Time: time.Now()})
+				backoffDuration := release_controller.CalculateBackoff(jobRetries, status.TransitionTime, &metav1.Time{Time: time.Now()})
 				if retryQueueDelay == 0 || backoffDuration < retryQueueDelay {
 					retryQueueDelay = backoffDuration
 				}
@@ -131,39 +132,39 @@ func (c *Controller) ensureVerificationJobs(release *Release, releaseTag *imagev
 	return verifyStatus, nil
 }
 
-func (c *Controller) getUpgradeTagAndPullSpec(release *Release, releaseTag *imagev1.TagReference, name, upgradeFrom string, upgradeFromRelease *UpgradeRelease, periodic bool) (previousTag, previousReleasePullSpec string, err error) {
+func (c *Controller) getUpgradeTagAndPullSpec(release *release_controller.Release, releaseTag *imagev1.TagReference, name, upgradeFrom string, upgradeFromRelease *release_controller.UpgradeRelease, periodic bool) (previousTag, previousReleasePullSpec string, err error) {
 	if upgradeFromRelease != nil {
 		return c.resolveUpgradeRelease(upgradeFromRelease, release)
 	}
 	var upgradeType string
 	if periodic {
-		upgradeType = releaseUpgradeFromPreviousMinus1
+		upgradeType = release_controller.ReleaseUpgradeFromPreviousMinus1
 	} else {
-		upgradeType = releaseUpgradeFromPrevious
+		upgradeType = release_controller.ReleaseUpgradeFromPrevious
 	}
-	if release.Config.As == releaseConfigModeStable {
-		upgradeType = releaseUpgradeFromPreviousPatch
+	if release.Config.As == release_controller.ReleaseConfigModeStable {
+		upgradeType = release_controller.ReleaseUpgradeFromPreviousPatch
 	}
 	if len(upgradeFrom) > 0 {
 		upgradeType = upgradeFrom
 	}
 	switch upgradeType {
-	case releaseUpgradeFromPrevious:
-		if tags := sortedReleaseTags(release, releasePhaseAccepted); len(tags) > 0 {
+	case release_controller.ReleaseUpgradeFromPrevious:
+		if tags := sortedReleaseTags(release, release_controller.ReleasePhaseAccepted); len(tags) > 0 {
 			previousTag = tags[0].Name
 			previousReleasePullSpec = release.Target.Status.PublicDockerImageRepository + ":" + previousTag
 		}
-	case releaseUpgradeFromPreviousMinus1:
-		if tags := sortedReleaseTags(release, releasePhaseAccepted); len(tags) > 1 {
+	case release_controller.ReleaseUpgradeFromPreviousMinus1:
+		if tags := sortedReleaseTags(release, release_controller.ReleasePhaseAccepted); len(tags) > 1 {
 			previousTag = tags[1].Name
 			previousReleasePullSpec = release.Target.Status.PublicDockerImageRepository + ":" + previousTag
 		}
-	case releaseUpgradeFromPreviousMinor:
+	case release_controller.ReleaseUpgradeFromPreviousMinor:
 		if version, err := semver.Parse(releaseTag.Name); err == nil && version.Minor > 0 {
 			version.Minor--
 			if ref, err := c.stableReleases(); err == nil {
 				for _, stable := range ref.Releases {
-					versions := unsortedSemanticReleaseTags(stable.Release, releasePhaseAccepted)
+					versions := unsortedSemanticReleaseTags(stable.Release, release_controller.ReleasePhaseAccepted)
 					sort.Sort(versions)
 					if v := firstTagWithMajorMinorSemanticVersion(versions, version); v != nil {
 						previousTag = v.Tag.Name
@@ -173,11 +174,11 @@ func (c *Controller) getUpgradeTagAndPullSpec(release *Release, releaseTag *imag
 				}
 			}
 		}
-	case releaseUpgradeFromPreviousPatch:
+	case release_controller.ReleaseUpgradeFromPreviousPatch:
 		if version, err := semver.Parse(releaseTag.Name); err == nil {
 			if ref, err := c.stableReleases(); err == nil {
 				for _, stable := range ref.Releases {
-					versions := unsortedSemanticReleaseTags(stable.Release, releasePhaseAccepted)
+					versions := unsortedSemanticReleaseTags(stable.Release, release_controller.ReleasePhaseAccepted)
 					sort.Sort(versions)
 					if v := firstTagWithMajorMinorSemanticVersion(versions, version); v != nil {
 						previousTag = v.Tag.Name
@@ -193,7 +194,7 @@ func (c *Controller) getUpgradeTagAndPullSpec(release *Release, releaseTag *imag
 	return previousTag, previousReleasePullSpec, err
 }
 
-func (c *Controller) resolveUpgradeRelease(upgradeRelease *UpgradeRelease, release *Release) (string, string, error) {
+func (c *Controller) resolveUpgradeRelease(upgradeRelease *release_controller.UpgradeRelease, release *release_controller.Release) (string, string, error) {
 	if upgradeRelease.Prerelease != nil {
 		semverRange, err := semver.ParseRange(upgradeRelease.Prerelease.VersionBounds.Query())
 		if err != nil {

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -61,7 +62,7 @@ func generateSafeProwJobName(name, suffix string) string {
 	return jobName
 }
 
-func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName, verifySuffix string, verifyType ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string, extraLabels map[string]string) (*unstructured.Unstructured, error) {
+func (c *Controller) ensureProwJobForReleaseTag(release *release_controller.Release, verifyName, verifySuffix string, verifyType release_controller.ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string, extraLabels map[string]string) (*unstructured.Unstructured, error) {
 	jobName := verifyType.ProwJob.Name
 	fullProwJobName := fmt.Sprintf("%s-%s", releaseTag.Name, verifyName)
 	prowJobName := generateSafeProwJobName(fullProwJobName, verifySuffix)
@@ -129,7 +130,7 @@ func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName, ve
 		ok = ok && status
 	}
 	pj := prowutil.NewProwJob(spec, extraLabels, map[string]string{
-		releaseAnnotationSource: fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
+		release_controller.ReleaseAnnotationSource: fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
 	})
 	// Override default UUID naming of prowjob
 	pj.Name = prowJobName
@@ -146,11 +147,11 @@ func (c *Controller) ensureProwJobForReleaseTag(release *Release, verifyName, ve
 		return objectToUnstructured(&pj), nil
 	}
 
-	pj.Annotations[releaseAnnotationToTag] = releaseTag.Name
+	pj.Annotations[release_controller.ReleaseAnnotationToTag] = releaseTag.Name
 	if verifyType.Upgrade && len(previousTag) > 0 {
-		pj.Annotations[releaseAnnotationFromTag] = previousTag
+		pj.Annotations[release_controller.ReleaseAnnotationFromTag] = previousTag
 	}
-	pj.Annotations[releaseAnnotationArchitecture] = c.graph.architecture
+	pj.Annotations[release_controller.ReleaseAnnotationArchitecture] = c.graph.architecture
 	out, err := c.prowClient.Create(context.TODO(), objectToUnstructured(&pj), metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {
 		// find a cached version or do a live call
@@ -186,7 +187,7 @@ func objectToUnstructured(obj runtime.Object) *unstructured.Unstructured {
 	return u
 }
 
-func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *Release, mirror *imagev1.ImageStream, releaseTag *imagev1.TagReference, previousReleasePullSpec string, isUpgrade bool, architecture string) (bool, error) {
+func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *release_controller.Release, mirror *imagev1.ImageStream, releaseTag *imagev1.TagReference, previousReleasePullSpec string, isUpgrade bool, architecture string) (bool, error) {
 	if spec.PodSpec == nil {
 		// Jenkins jobs cannot be parameterized
 		return true, nil

--- a/cmd/release-controller/types_test.go
+++ b/cmd/release-controller/types_test.go
@@ -26,7 +26,7 @@ func TestBackoff(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := release_controller.CalculateBackoff(tt.step, &metav1.Time{Time: tt.initial}, &metav1.Time{Time: tt.current})
+			got := releasecontroller.CalculateBackoff(tt.step, &metav1.Time{Time: tt.initial}, &metav1.Time{Time: tt.current})
 			if got != tt.want {
 				t.Errorf("calculateBackoff(%d, %d, %d): want %v, got %v", tt.step, tt.initial.Unix(), tt.current.Unix(), tt.want, got)
 			}

--- a/cmd/release-controller/types_test.go
+++ b/cmd/release-controller/types_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestBackoff(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := calculateBackoff(tt.step, &metav1.Time{Time: tt.initial}, &metav1.Time{Time: tt.current})
+			got := release_controller.CalculateBackoff(tt.step, &metav1.Time{Time: tt.initial}, &metav1.Time{Time: tt.current})
 			if got != tt.want {
 				t.Errorf("calculateBackoff(%d, %d, %d): want %v, got %v", tt.step, tt.initial.Unix(), tt.current.Unix(), tt.want, got)
 			}

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"io"
 	"sort"
 	"sync"
@@ -19,27 +20,16 @@ import (
 	kv1core "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-type UpgradeResult struct {
-	State string `json:"state"`
-	URL   string `json:"url"`
-}
-
-type UpgradeRecord struct {
-	From    string          `json:"from"`
-	To      string          `json:"to"`
-	Results []UpgradeResult `json:"results"`
-}
-
 type UpgradeGraph struct {
 	lock         sync.Mutex
-	to           map[string]map[string]*UpgradeHistory
+	to           map[string]map[string]*release_controller.UpgradeHistory
 	from         map[string]sets.String
 	architecture string
 }
 
 func NewUpgradeGraph(architecture string) *UpgradeGraph {
 	return &UpgradeGraph{
-		to:           make(map[string]map[string]*UpgradeHistory),
+		to:           make(map[string]map[string]*release_controller.UpgradeHistory),
 		from:         make(map[string]sets.String),
 		architecture: architecture,
 	}
@@ -50,24 +40,13 @@ type upgradeEdge struct {
 	To   string
 }
 
-type UpgradeHistory struct {
-	From string
-	To   string
-
-	Success int
-	Failure int
-	Total   int
-
-	History map[string]UpgradeResult
-}
-
-func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []UpgradeHistory {
+func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []release_controller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]UpgradeHistory, 0, len(toNames)*2)
+	summaries := make([]release_controller.UpgradeHistory, 0, len(toNames)*2)
 	for _, to := range toNames {
 		for _, h := range g.to[to] {
-			summaries = append(summaries, UpgradeHistory{
+			summaries = append(summaries, release_controller.UpgradeHistory{
 				From:    h.From,
 				To:      to,
 				Success: h.Success,
@@ -79,14 +58,14 @@ func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []UpgradeHistory {
 	return summaries
 }
 
-func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []UpgradeHistory {
+func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []release_controller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]UpgradeHistory, 0, len(fromNames)*2)
+	summaries := make([]release_controller.UpgradeHistory, 0, len(fromNames)*2)
 	for _, from := range fromNames {
 		for to := range g.from[from] {
 			for _, h := range g.to[to] {
-				summaries = append(summaries, UpgradeHistory{
+				summaries = append(summaries, release_controller.UpgradeHistory{
 					From:    from,
 					To:      to,
 					Success: h.Success,
@@ -99,13 +78,13 @@ func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []UpgradeHisto
 	return summaries
 }
 
-func (g *UpgradeGraph) UpgradesTo(toNames ...string) []UpgradeHistory {
+func (g *UpgradeGraph) UpgradesTo(toNames ...string) []release_controller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]UpgradeHistory, 0, len(toNames)*2)
+	summaries := make([]release_controller.UpgradeHistory, 0, len(toNames)*2)
 	for _, to := range toNames {
 		for _, h := range g.to[to] {
-			summaries = append(summaries, UpgradeHistory{
+			summaries = append(summaries, release_controller.UpgradeHistory{
 				From:    h.From,
 				To:      to,
 				Success: h.Success,
@@ -123,11 +102,11 @@ type historyEdgeReference struct {
 	to   string
 }
 
-func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []UpgradeHistory {
+func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []release_controller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]UpgradeHistory, 0, len(fromNames)*2)
-	refs := make(map[historyEdgeReference]*UpgradeHistory)
+	summaries := make([]release_controller.UpgradeHistory, 0, len(fromNames)*2)
+	refs := make(map[historyEdgeReference]*release_controller.UpgradeHistory)
 	for _, from := range fromNames {
 		for to := range g.from[from] {
 			history := g.to[to][from]
@@ -137,10 +116,10 @@ func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []UpgradeHistory {
 			key := historyEdgeReference{from, to}
 			ref, ok := refs[key]
 			if !ok {
-				summaries = append(summaries, UpgradeHistory{
+				summaries = append(summaries, release_controller.UpgradeHistory{
 					From:    from,
 					To:      to,
-					History: make(map[string]UpgradeResult),
+					History: make(map[string]release_controller.UpgradeResult),
 				})
 				ref = &summaries[len(summaries)-1]
 				refs[key] = ref
@@ -157,15 +136,15 @@ func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []UpgradeHistory {
 	return summaries
 }
 
-func copyHistory(h map[string]UpgradeResult) map[string]UpgradeResult {
-	copied := make(map[string]UpgradeResult, len(h))
+func copyHistory(h map[string]release_controller.UpgradeResult) map[string]release_controller.UpgradeResult {
+	copied := make(map[string]release_controller.UpgradeResult, len(h))
 	for k, v := range h {
 		copied[k] = v
 	}
 	return copied
 }
 
-func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {
+func (g *UpgradeGraph) Add(fromTag, toTag string, results ...release_controller.UpgradeResult) {
 	if len(results) == 0 || len(fromTag) == 0 || len(toTag) == 0 {
 		return
 	}
@@ -175,15 +154,15 @@ func (g *UpgradeGraph) Add(fromTag, toTag string, results ...UpgradeResult) {
 	g.addWithLock(fromTag, toTag, results...)
 }
 
-func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...UpgradeResult) {
+func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...release_controller.UpgradeResult) {
 	to, ok := g.to[toTag]
 	if !ok {
-		to = make(map[string]*UpgradeHistory)
+		to = make(map[string]*release_controller.UpgradeHistory)
 		g.to[toTag] = to
 	}
 	from, ok := to[fromTag]
 	if !ok {
-		from = &UpgradeHistory{
+		from = &release_controller.UpgradeHistory{
 			From: fromTag,
 			To:   toTag,
 		}
@@ -196,30 +175,30 @@ func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...UpgradeResu
 		set.Insert(toTag)
 	}
 	if from.History == nil {
-		from.History = make(map[string]UpgradeResult)
+		from.History = make(map[string]release_controller.UpgradeResult)
 	}
 	for _, result := range results {
 		if len(result.URL) == 0 {
 			continue
 		}
 		existing, ok := from.History[result.URL]
-		if !ok || existing.State == releaseVerificationStatePending && result.State != releaseVerificationStatePending {
+		if !ok || existing.State == release_controller.ReleaseVerificationStatePending && result.State != release_controller.ReleaseVerificationStatePending {
 			from.History[result.URL] = result
 			switch result.State {
-			case releaseVerificationStateFailed:
+			case release_controller.ReleaseVerificationStateFailed:
 				from.Failure++
-			case releaseVerificationStateSucceeded:
+			case release_controller.ReleaseVerificationStateSucceeded:
 				from.Success++
 			}
 		}
 	}
 }
 
-func (g *UpgradeGraph) Histories() []UpgradeHistory {
+func (g *UpgradeGraph) Histories() []release_controller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	results := make([]UpgradeHistory, 0, len(g.to)*5)
+	results := make([]release_controller.UpgradeHistory, 0, len(g.to)*5)
 	for _, targets := range g.to {
 		for _, history := range targets {
 			copied := *history
@@ -230,14 +209,14 @@ func (g *UpgradeGraph) Histories() []UpgradeHistory {
 	return results
 }
 
-func (g *UpgradeGraph) Records() []UpgradeRecord {
+func (g *UpgradeGraph) Records() []release_controller.UpgradeRecord {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	records := make([]UpgradeRecord, 0, len(g.to)*5)
+	records := make([]release_controller.UpgradeRecord, 0, len(g.to)*5)
 	for to, targets := range g.to {
 		for from, history := range targets {
-			record := UpgradeRecord{From: from, To: to, Results: make([]UpgradeResult, 0, len(history.History))}
+			record := release_controller.UpgradeRecord{From: from, To: to, Results: make([]release_controller.UpgradeResult, 0, len(history.History))}
 			for _, result := range history.History {
 				record.Results = append(record.Results, result)
 			}
@@ -280,7 +259,7 @@ func (g *UpgradeGraph) Load(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	var records []UpgradeRecord
+	var records []release_controller.UpgradeRecord
 	if err := json.NewDecoder(gr).Decode(&records); err != nil {
 		return err
 	}

--- a/cmd/release-controller/upgrades.go
+++ b/cmd/release-controller/upgrades.go
@@ -22,14 +22,14 @@ import (
 
 type UpgradeGraph struct {
 	lock         sync.Mutex
-	to           map[string]map[string]*release_controller.UpgradeHistory
+	to           map[string]map[string]*releasecontroller.UpgradeHistory
 	from         map[string]sets.String
 	architecture string
 }
 
 func NewUpgradeGraph(architecture string) *UpgradeGraph {
 	return &UpgradeGraph{
-		to:           make(map[string]map[string]*release_controller.UpgradeHistory),
+		to:           make(map[string]map[string]*releasecontroller.UpgradeHistory),
 		from:         make(map[string]sets.String),
 		architecture: architecture,
 	}
@@ -40,13 +40,13 @@ type upgradeEdge struct {
 	To   string
 }
 
-func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []release_controller.UpgradeHistory {
+func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []releasecontroller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]release_controller.UpgradeHistory, 0, len(toNames)*2)
+	summaries := make([]releasecontroller.UpgradeHistory, 0, len(toNames)*2)
 	for _, to := range toNames {
 		for _, h := range g.to[to] {
-			summaries = append(summaries, release_controller.UpgradeHistory{
+			summaries = append(summaries, releasecontroller.UpgradeHistory{
 				From:    h.From,
 				To:      to,
 				Success: h.Success,
@@ -58,14 +58,14 @@ func (g *UpgradeGraph) SummarizeUpgradesTo(toNames ...string) []release_controll
 	return summaries
 }
 
-func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []release_controller.UpgradeHistory {
+func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []releasecontroller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]release_controller.UpgradeHistory, 0, len(fromNames)*2)
+	summaries := make([]releasecontroller.UpgradeHistory, 0, len(fromNames)*2)
 	for _, from := range fromNames {
 		for to := range g.from[from] {
 			for _, h := range g.to[to] {
-				summaries = append(summaries, release_controller.UpgradeHistory{
+				summaries = append(summaries, releasecontroller.UpgradeHistory{
 					From:    from,
 					To:      to,
 					Success: h.Success,
@@ -78,13 +78,13 @@ func (g *UpgradeGraph) SummarizeUpgradesFrom(fromNames ...string) []release_cont
 	return summaries
 }
 
-func (g *UpgradeGraph) UpgradesTo(toNames ...string) []release_controller.UpgradeHistory {
+func (g *UpgradeGraph) UpgradesTo(toNames ...string) []releasecontroller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]release_controller.UpgradeHistory, 0, len(toNames)*2)
+	summaries := make([]releasecontroller.UpgradeHistory, 0, len(toNames)*2)
 	for _, to := range toNames {
 		for _, h := range g.to[to] {
-			summaries = append(summaries, release_controller.UpgradeHistory{
+			summaries = append(summaries, releasecontroller.UpgradeHistory{
 				From:    h.From,
 				To:      to,
 				Success: h.Success,
@@ -102,11 +102,11 @@ type historyEdgeReference struct {
 	to   string
 }
 
-func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []release_controller.UpgradeHistory {
+func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []releasecontroller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	summaries := make([]release_controller.UpgradeHistory, 0, len(fromNames)*2)
-	refs := make(map[historyEdgeReference]*release_controller.UpgradeHistory)
+	summaries := make([]releasecontroller.UpgradeHistory, 0, len(fromNames)*2)
+	refs := make(map[historyEdgeReference]*releasecontroller.UpgradeHistory)
 	for _, from := range fromNames {
 		for to := range g.from[from] {
 			history := g.to[to][from]
@@ -116,10 +116,10 @@ func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []release_controller.Up
 			key := historyEdgeReference{from, to}
 			ref, ok := refs[key]
 			if !ok {
-				summaries = append(summaries, release_controller.UpgradeHistory{
+				summaries = append(summaries, releasecontroller.UpgradeHistory{
 					From:    from,
 					To:      to,
-					History: make(map[string]release_controller.UpgradeResult),
+					History: make(map[string]releasecontroller.UpgradeResult),
 				})
 				ref = &summaries[len(summaries)-1]
 				refs[key] = ref
@@ -136,15 +136,15 @@ func (g *UpgradeGraph) UpgradesFrom(fromNames ...string) []release_controller.Up
 	return summaries
 }
 
-func copyHistory(h map[string]release_controller.UpgradeResult) map[string]release_controller.UpgradeResult {
-	copied := make(map[string]release_controller.UpgradeResult, len(h))
+func copyHistory(h map[string]releasecontroller.UpgradeResult) map[string]releasecontroller.UpgradeResult {
+	copied := make(map[string]releasecontroller.UpgradeResult, len(h))
 	for k, v := range h {
 		copied[k] = v
 	}
 	return copied
 }
 
-func (g *UpgradeGraph) Add(fromTag, toTag string, results ...release_controller.UpgradeResult) {
+func (g *UpgradeGraph) Add(fromTag, toTag string, results ...releasecontroller.UpgradeResult) {
 	if len(results) == 0 || len(fromTag) == 0 || len(toTag) == 0 {
 		return
 	}
@@ -154,15 +154,15 @@ func (g *UpgradeGraph) Add(fromTag, toTag string, results ...release_controller.
 	g.addWithLock(fromTag, toTag, results...)
 }
 
-func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...release_controller.UpgradeResult) {
+func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...releasecontroller.UpgradeResult) {
 	to, ok := g.to[toTag]
 	if !ok {
-		to = make(map[string]*release_controller.UpgradeHistory)
+		to = make(map[string]*releasecontroller.UpgradeHistory)
 		g.to[toTag] = to
 	}
 	from, ok := to[fromTag]
 	if !ok {
-		from = &release_controller.UpgradeHistory{
+		from = &releasecontroller.UpgradeHistory{
 			From: fromTag,
 			To:   toTag,
 		}
@@ -175,30 +175,30 @@ func (g *UpgradeGraph) addWithLock(fromTag, toTag string, results ...release_con
 		set.Insert(toTag)
 	}
 	if from.History == nil {
-		from.History = make(map[string]release_controller.UpgradeResult)
+		from.History = make(map[string]releasecontroller.UpgradeResult)
 	}
 	for _, result := range results {
 		if len(result.URL) == 0 {
 			continue
 		}
 		existing, ok := from.History[result.URL]
-		if !ok || existing.State == release_controller.ReleaseVerificationStatePending && result.State != release_controller.ReleaseVerificationStatePending {
+		if !ok || existing.State == releasecontroller.ReleaseVerificationStatePending && result.State != releasecontroller.ReleaseVerificationStatePending {
 			from.History[result.URL] = result
 			switch result.State {
-			case release_controller.ReleaseVerificationStateFailed:
+			case releasecontroller.ReleaseVerificationStateFailed:
 				from.Failure++
-			case release_controller.ReleaseVerificationStateSucceeded:
+			case releasecontroller.ReleaseVerificationStateSucceeded:
 				from.Success++
 			}
 		}
 	}
 }
 
-func (g *UpgradeGraph) Histories() []release_controller.UpgradeHistory {
+func (g *UpgradeGraph) Histories() []releasecontroller.UpgradeHistory {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	results := make([]release_controller.UpgradeHistory, 0, len(g.to)*5)
+	results := make([]releasecontroller.UpgradeHistory, 0, len(g.to)*5)
 	for _, targets := range g.to {
 		for _, history := range targets {
 			copied := *history
@@ -209,14 +209,14 @@ func (g *UpgradeGraph) Histories() []release_controller.UpgradeHistory {
 	return results
 }
 
-func (g *UpgradeGraph) Records() []release_controller.UpgradeRecord {
+func (g *UpgradeGraph) Records() []releasecontroller.UpgradeRecord {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	records := make([]release_controller.UpgradeRecord, 0, len(g.to)*5)
+	records := make([]releasecontroller.UpgradeRecord, 0, len(g.to)*5)
 	for to, targets := range g.to {
 		for from, history := range targets {
-			record := release_controller.UpgradeRecord{From: from, To: to, Results: make([]release_controller.UpgradeResult, 0, len(history.History))}
+			record := releasecontroller.UpgradeRecord{From: from, To: to, Results: make([]releasecontroller.UpgradeResult, 0, len(history.History))}
 			for _, result := range history.History {
 				record.Results = append(record.Results, result)
 			}
@@ -259,7 +259,7 @@ func (g *UpgradeGraph) Load(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	var records []release_controller.UpgradeRecord
+	var records []releasecontroller.UpgradeRecord
 	if err := json.NewDecoder(gr).Decode(&records); err != nil {
 		return err
 	}

--- a/cmd/release-controller/upgrades_test.go
+++ b/cmd/release-controller/upgrades_test.go
@@ -14,28 +14,28 @@ func TestUpgradeGraph_UpgradesFrom(t *testing.T) {
 		name      string
 		graph     func() *UpgradeGraph
 		fromNames []string
-		want      []release_controller.UpgradeHistory
+		want      []releasecontroller.UpgradeHistory
 	}{
 		{
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"})
-				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"})
-				g.Add("1.0.1", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://3"})
-				g.Add("0.0.1", "1.0.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://4"})
-				g.Add("1.0.0", "1.1.1", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://5"})
+				g.Add("1.0.0", "1.1.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://1"})
+				g.Add("1.0.0", "1.1.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://2"})
+				g.Add("1.0.1", "1.1.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://3"})
+				g.Add("0.0.1", "1.0.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://4"})
+				g.Add("1.0.0", "1.1.1", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://5"})
 				return g
 			},
 			fromNames: []string{"1.0.0"},
-			want: []release_controller.UpgradeHistory{
+			want: []releasecontroller.UpgradeHistory{
 				{
 					From:    "1.0.0",
 					To:      "1.1.0",
 					Success: 2,
 					Total:   2,
-					History: map[string]release_controller.UpgradeResult{
-						"http://1": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"},
-						"http://2": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"},
+					History: map[string]releasecontroller.UpgradeResult{
+						"http://1": {State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://1"},
+						"http://2": {State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://2"},
 					},
 				},
 				{
@@ -43,8 +43,8 @@ func TestUpgradeGraph_UpgradesFrom(t *testing.T) {
 					To:      "1.1.1",
 					Success: 1,
 					Total:   1,
-					History: map[string]release_controller.UpgradeResult{
-						"http://5": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://5"},
+					History: map[string]releasecontroller.UpgradeResult{
+						"http://5": {State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://5"},
 					},
 				},
 			},
@@ -67,27 +67,27 @@ func TestUpgradeGraph_UpgradesTo(t *testing.T) {
 		name    string
 		graph   func() *UpgradeGraph
 		toNames []string
-		want    []release_controller.UpgradeHistory
+		want    []releasecontroller.UpgradeHistory
 	}{
 		{
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"})
-				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"})
-				g.Add("1.0.1", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://3"})
-				g.Add("0.0.1", "1.0.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://4"})
-				g.Add("1.0.0", "1.1.1", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://5"})
+				g.Add("1.0.0", "1.1.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://1"})
+				g.Add("1.0.0", "1.1.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://2"})
+				g.Add("1.0.1", "1.1.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://3"})
+				g.Add("0.0.1", "1.0.0", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://4"})
+				g.Add("1.0.0", "1.1.1", releasecontroller.UpgradeResult{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://5"})
 				return g
 			},
 			toNames: []string{"1.1.0"},
-			want: []release_controller.UpgradeHistory{
+			want: []releasecontroller.UpgradeHistory{
 				{
 					From:    "1.0.1",
 					To:      "1.1.0",
 					Success: 1,
 					Total:   1,
-					History: map[string]release_controller.UpgradeResult{
-						"http://3": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://3"},
+					History: map[string]releasecontroller.UpgradeResult{
+						"http://3": {State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://3"},
 					},
 				},
 				{
@@ -95,9 +95,9 @@ func TestUpgradeGraph_UpgradesTo(t *testing.T) {
 					To:      "1.1.0",
 					Success: 2,
 					Total:   2,
-					History: map[string]release_controller.UpgradeResult{
-						"http://1": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"},
-						"http://2": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"},
+					History: map[string]releasecontroller.UpgradeResult{
+						"http://1": {State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://1"},
+						"http://2": {State: releasecontroller.ReleaseVerificationStateSucceeded, URL: "http://2"},
 					},
 				},
 			},

--- a/cmd/release-controller/upgrades_test.go
+++ b/cmd/release-controller/upgrades_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/openshift/release-controller/pkg/release-controller"
 	"reflect"
 	"sort"
 	"testing"
@@ -13,28 +14,28 @@ func TestUpgradeGraph_UpgradesFrom(t *testing.T) {
 		name      string
 		graph     func() *UpgradeGraph
 		fromNames []string
-		want      []UpgradeHistory
+		want      []release_controller.UpgradeHistory
 	}{
 		{
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"})
-				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"})
-				g.Add("1.0.1", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"})
-				g.Add("0.0.1", "1.0.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://4"})
-				g.Add("1.0.0", "1.1.1", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://5"})
+				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"})
+				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"})
+				g.Add("1.0.1", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://3"})
+				g.Add("0.0.1", "1.0.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://4"})
+				g.Add("1.0.0", "1.1.1", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://5"})
 				return g
 			},
 			fromNames: []string{"1.0.0"},
-			want: []UpgradeHistory{
+			want: []release_controller.UpgradeHistory{
 				{
 					From:    "1.0.0",
 					To:      "1.1.0",
 					Success: 2,
 					Total:   2,
-					History: map[string]UpgradeResult{
-						"http://1": {State: releaseVerificationStateSucceeded, URL: "http://1"},
-						"http://2": {State: releaseVerificationStateSucceeded, URL: "http://2"},
+					History: map[string]release_controller.UpgradeResult{
+						"http://1": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"},
+						"http://2": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"},
 					},
 				},
 				{
@@ -42,8 +43,8 @@ func TestUpgradeGraph_UpgradesFrom(t *testing.T) {
 					To:      "1.1.1",
 					Success: 1,
 					Total:   1,
-					History: map[string]UpgradeResult{
-						"http://5": {State: releaseVerificationStateSucceeded, URL: "http://5"},
+					History: map[string]release_controller.UpgradeResult{
+						"http://5": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://5"},
 					},
 				},
 			},
@@ -66,27 +67,27 @@ func TestUpgradeGraph_UpgradesTo(t *testing.T) {
 		name    string
 		graph   func() *UpgradeGraph
 		toNames []string
-		want    []UpgradeHistory
+		want    []release_controller.UpgradeHistory
 	}{
 		{
 			graph: func() *UpgradeGraph {
 				g := NewUpgradeGraph("amd64")
-				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://1"})
-				g.Add("1.0.0", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://2"})
-				g.Add("1.0.1", "1.1.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://3"})
-				g.Add("0.0.1", "1.0.0", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://4"})
-				g.Add("1.0.0", "1.1.1", UpgradeResult{State: releaseVerificationStateSucceeded, URL: "http://5"})
+				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"})
+				g.Add("1.0.0", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"})
+				g.Add("1.0.1", "1.1.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://3"})
+				g.Add("0.0.1", "1.0.0", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://4"})
+				g.Add("1.0.0", "1.1.1", release_controller.UpgradeResult{State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://5"})
 				return g
 			},
 			toNames: []string{"1.1.0"},
-			want: []UpgradeHistory{
+			want: []release_controller.UpgradeHistory{
 				{
 					From:    "1.0.1",
 					To:      "1.1.0",
 					Success: 1,
 					Total:   1,
-					History: map[string]UpgradeResult{
-						"http://3": {State: releaseVerificationStateSucceeded, URL: "http://3"},
+					History: map[string]release_controller.UpgradeResult{
+						"http://3": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://3"},
 					},
 				},
 				{
@@ -94,9 +95,9 @@ func TestUpgradeGraph_UpgradesTo(t *testing.T) {
 					To:      "1.1.0",
 					Success: 2,
 					Total:   2,
-					History: map[string]UpgradeResult{
-						"http://1": {State: releaseVerificationStateSucceeded, URL: "http://1"},
-						"http://2": {State: releaseVerificationStateSucceeded, URL: "http://2"},
+					History: map[string]release_controller.UpgradeResult{
+						"http://1": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://1"},
+						"http://2": {State: release_controller.ReleaseVerificationStateSucceeded, URL: "http://2"},
 					},
 				},
 			},

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -1,4 +1,4 @@
-package release_controller
+package releasecontroller
 
 import (
 	"bytes"

--- a/pkg/release-controller/utils.go
+++ b/pkg/release-controller/utils.go
@@ -1,4 +1,4 @@
-package release_controller
+package releasecontroller
 
 func StringSliceContains(slice []string, s string) bool {
 	for _, item := range slice {

--- a/pkg/release-controller/utils.go
+++ b/pkg/release-controller/utils.go
@@ -1,0 +1,10 @@
+package release_controller
+
+func StringSliceContains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Having all the release-controller types buried underneath the release-controller prevents other tools from utilizing the various types.  This PR moves the `cmd/release-controller/types.go` file up into `pkg/release-controller`, Exports the various pieces, and updates all the code to utilize the new `release-controller` package.