### PR TITLE
bugzilla: reimplement #338 with nil reference fix

### DIFF
--- a/cmd/release-controller/bugzilla.go
+++ b/cmd/release-controller/bugzilla.go
@@ -3,8 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/release-controller/pkg/release-controller"
 	"time"
+
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 
 	v1 "github.com/openshift/api/image/v1"
 	"github.com/prometheus/client_golang/prometheus"
@@ -137,7 +138,7 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 		return fmt.Errorf("Unable to generate bug list from %s to %s: %v", prevTag.Name, tag.Name, err)
 	}
 	var errs []error
-	if errs := append(errs, c.bugzillaVerifier.VerifyBugs(bugs)...); len(errs) != 0 {
+	if errs := append(errs, c.bugzillaVerifier.VerifyBugs(bugs, tag.Name)...); len(errs) != 0 {
 		klog.V(4).Infof("Error(s) in bugzilla verifier: %v", utilerrors.NewAggregate(errs))
 		c.bugzillaErrorMetrics.WithLabelValues(bzVerifier).Inc()
 		return utilerrors.NewAggregate(errs)

--- a/pkg/bugzilla/bugzilla.go
+++ b/pkg/bugzilla/bugzilla.go
@@ -53,7 +53,7 @@ var (
 
 // VerifyBugs takes a list of bugzilla bug IDs and for each bug changes the bug status to VERIFIED if bug was reviewed and
 // lgtm'd by the bug's QA Contect
-func (c *Verifier) VerifyBugs(bugs []int) []error {
+func (c *Verifier) VerifyBugs(bugs []int, tagName string) []error {
 	bzPRs, errs := getPRs(bugs, c.bzClient)
 	for bugID, extPRs := range bzPRs {
 		bug, err := c.bzClient.GetBug(bugID)
@@ -62,16 +62,16 @@ func (c *Verifier) VerifyBugs(bugs []int) []error {
 			continue
 		}
 		var success bool
-		message := ""
+		message := fmt.Sprintf("Bugfix included in accepted release %s", tagName)
 		if bug.Status != "ON_QA" {
 			// In case bug has already been moved to VERIFIED, completely ignore
-			if bug.Status != "VERIFIED" {
-				message = "Bug is not in ON_QA status; bug will not be automatically moved to VERIFIED"
+			if bug.Status == "VERIFIED" {
+				message = ""
+			} else {
+				message = fmt.Sprintf("%s\nBug is not in ON_QA status; bug will not be automatically moved to VERIFIED", message)
 			}
-			continue
 		} else {
 			var unapprovedPRs []pr
-			var unlabeledPRs []pr
 			var bugErrs []error
 			for _, extPR := range extPRs {
 				comments, err := c.ghClient.ListIssueComments(extPR.org, extPR.repo, extPR.prNum)
@@ -91,44 +91,26 @@ func (c *Verifier) VerifyBugs(bugs []int) []error {
 				if !prReviewedByQA(comments, reviews, c.pluginConfig.LgtmFor(extPR.org, extPR.repo).ReviewActsAsLgtm) {
 					unapprovedPRs = append(unapprovedPRs, extPR)
 				}
-				labels, err := c.ghClient.GetIssueLabels(extPR.org, extPR.repo, extPR.prNum)
-				if err != nil {
-					newErr := fmt.Errorf("Unable to get labels for github pull %s/%s#%d: %v", extPR.org, extPR.repo, extPR.prNum, err)
-					errs = append(errs, newErr)
-					bugErrs = append(bugErrs, newErr)
-				}
-				var hasLabel bool
-				for _, label := range labels {
-					if label.Name == "qe-approved" {
-						hasLabel = true
-						break
-					}
-				}
-				if !hasLabel {
-					unlabeledPRs = append(unlabeledPRs, extPR)
-				}
 			}
-			bzCFVerified := (len(bug.Verified) == 1 && bug.Verified[0] == "Tested")
-			if len(unapprovedPRs) > 0 || len(unlabeledPRs) > 0 || len(bugErrs) > 0 || !bzCFVerified {
-				message = "Bug will not be automatically moved to VERIFIED for the following reasons:"
+			if len(unapprovedPRs) > 0 || len(bugErrs) > 0 {
+				message = fmt.Sprintf("%s\nBug will not be automatically moved to VERIFIED for the following reasons:", message)
 				for _, extPR := range unapprovedPRs {
-					message = fmt.Sprintf("%s\n- PR %s/%s#%d not appoved by QA contact", message, extPR.org, extPR.repo, extPR.prNum)
-				}
-				for _, extPR := range unlabeledPRs {
-					message = fmt.Sprintf("%s\n- PR %s/%s#%d does not have the qe-approved label", message, extPR.org, extPR.repo, extPR.prNum)
-				}
-				if !bzCFVerified {
-					message = fmt.Sprintf("%s\n- `Verified` field of this bug is not set to `Tested`", message)
+					message = fmt.Sprintf("%s\n- PR %s/%s#%d not approved by QA contact", message, extPR.org, extPR.repo, extPR.prNum)
 				}
 				for _, err := range bugErrs {
 					message = fmt.Sprintf("%s\n- %s", message, err)
+				}
+				message = fmt.Sprintf("%s\n\nThis bug must now be manually moved to VERIFIED", message)
+				// Sometimes the QAContactDetail is nil; if not nil, include name of QA contact in message
+				if bug.QAContactDetail != nil {
+					message = fmt.Sprintf("%s by %s", message, bug.QAContactDetail.Name)
 				}
 			} else {
 				success = true
 			}
 		}
 		if success {
-			message = "All linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED"
+			message = fmt.Sprintf("%s\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED", message)
 		}
 		if message != "" {
 			comments, err := c.bzClient.GetComments(bugID)


### PR DESCRIPTION
PR #338 was reverted due to a bug that was crashlooping the
release-controller. The bug was a nil pointer dereference on the
`bug.QAContactDetail` field. This PR reimplements #338 and adds a check
for the field to make sure it is not nil before dereferencing it.