### PR TITLE
Adding support for manifest list based releases

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -138,6 +138,8 @@ type Controller struct {
 	authenticationMessage string
 
 	buildClusterDistributions []ClusterDistribution
+
+	architecture string
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -156,6 +158,7 @@ func NewController(
 	softDeleteReleaseTags bool,
 	authenticationMessage string,
 	clusterGroups []string,
+	architecture string,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -212,6 +215,8 @@ func NewController(
 
 		softDeleteReleaseTags: softDeleteReleaseTags,
 		authenticationMessage: authenticationMessage,
+
+		architecture: architecture,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -656,7 +656,13 @@ func (c *Controller) httpReleaseInfoJson(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	out, err := c.releaseInfo.ReleaseInfo(tagPullSpec)
+	imageInfo, err := c.getImageInfo(tagPullSpec)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("unable to determine image info for %s: %v", tagPullSpec, err), http.StatusBadRequest)
+		return
+	}
+
+	out, err := c.releaseInfo.ReleaseInfo(imageInfo.generateDigestPullSpec())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Internal error: %v", err), http.StatusInternalServerError)
 		return
@@ -1358,7 +1364,11 @@ func relTime(a, b time.Time, albl, blbl string) string {
 }
 
 func (c *Controller) getSupportedUpgrades(tagPull string) ([]string, error) {
-	tagUpgradeInfo, err := c.releaseInfo.UpgradeInfo(tagPull)
+	imageInfo, err := c.getImageInfo(tagPull)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine image info for %s: %v", tagPull, err)
+	}
+	tagUpgradeInfo, err := c.releaseInfo.UpgradeInfo(imageInfo.generateDigestPullSpec())
 	if err != nil {
 		return nil, fmt.Errorf("could not get release info for tag %s: %v", tagPull, err)
 	}

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -800,7 +800,10 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	renderInstallInstructions(w, mirror, tagInfo.Info.Tag, tagInfo.TagPullSpec, c.artifactsHost)
+	// Disable the installation instructions for manifest list based releases
+	if c.architecture != "multi" {
+		renderInstallInstructions(w, mirror, tagInfo.Info.Tag, tagInfo.TagPullSpec, c.artifactsHost)
+	}
 
 	renderVerifyLinks(w, *tagInfo.Info.Tag, tagInfo.Info.Release)
 

--- a/cmd/release-controller/http_candidate.go
+++ b/cmd/release-controller/http_candidate.go
@@ -363,8 +363,13 @@ func (c *Controller) stableReleases() (*StableReferences, error) {
 }
 
 func (c *Controller) tagPromotedFrom(tag *imagev1.TagReference) (*imagev1.TagReference, error) {
+	imageInfo, err := c.getImageInfo(tag.From.Name)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine image info for %s: %v", tag.From.Name, err)
+	}
+
 	// Call oc adm release info to get previous nightly info for the stable release
-	op, err := c.releaseInfo.ReleaseInfo(tag.From.Name)
+	op, err := c.releaseInfo.ReleaseInfo(imageInfo.generateDigestPullSpec())
 	if err != nil {
 		// releaseinfo not found, old tag
 		return nil, fmt.Errorf("could not get release info for tag %s: %v", tag.From.Name, err)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -326,7 +326,7 @@ func (o *options) Run() error {
 	start = time.Now()
 	imageCache := newLatestImageCache(tagParts[0], tagParts[1])
 	execReleaseInfo := NewExecReleaseInfo(toolsClient, toolsConfig, o.JobNamespace, releaseNamespace, imageCache.Get)
-	releaseInfo := NewCachingReleaseInfo(execReleaseInfo, 64*1024*1024)
+	releaseInfo := NewCachingReleaseInfo(execReleaseInfo, 64*1024*1024, architecture)
 
 	execReleaseFiles := NewExecReleaseFiles(toolsClient, toolsConfig, o.JobNamespace, releaseNamespace, releaseNamespace, o.Registry, imageCache.Get)
 	klog.V(4).Infof("5: %v", time.Now().Sub(start))
@@ -351,6 +351,7 @@ func (o *options) Run() error {
 		o.softDeleteReleaseTags,
 		o.AuthenticationMessage,
 		o.ClusterGroups,
+		architecture,
 	)
 	klog.V(4).Infof("7: %v", time.Now().Sub(start))
 

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -405,7 +405,19 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 				}
 				if tags := sortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
 					go func() {
-						if _, err := c.releaseInfo.ChangeLog(tags[0].Name, tag.Name); err != nil {
+						fromImage, err := c.getImageInfo(tags[0].Name)
+						if err != nil {
+							klog.Errorf("Unable to get from image info for release %s: %v", tags[0].Name, err)
+							return
+						}
+
+						toImage, err := c.getImageInfo(tag.Name)
+						if err != nil {
+							klog.Errorf("Unable to get to image info for release %s: %v", tag.Name, err)
+							return
+						}
+
+						if _, err := c.releaseInfo.ChangeLog(fromImage.generateDigestPullSpec(), toImage.generateDigestPullSpec()); err != nil {
 							klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
 						}
 					}()
@@ -456,7 +468,19 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 			}
 			if tags := sortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
 				go func() {
-					if _, err := c.releaseInfo.ChangeLog(tags[0].Name, tag.Name); err != nil {
+					fromImage, err := c.getImageInfo(tags[0].Name)
+					if err != nil {
+						klog.Errorf("Unable to get from image info for release %s: %v", tags[0].Name, err)
+						return
+					}
+
+					toImage, err := c.getImageInfo(tag.Name)
+					if err != nil {
+						klog.Errorf("Unable to get to image info for release %s: %v", tag.Name, err)
+						return
+					}
+
+					if _, err := c.releaseInfo.ChangeLog(fromImage.generateDigestPullSpec(), toImage.generateDigestPullSpec()); err != nil {
 						klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
 					}
 				}()


### PR DESCRIPTION
To handle the existance of manifest list based releases, we need to call an `oc image info` with a `--filter-by-os` option to get the respective `digest` value that can be used to call `oc adm release info` where needed.  Unfortunately, this means we have to make 2 calls down into the `git-cache` pod, so it does take a bit more time for things like the changelog.