### PR TITLE
Include `phase` field in the release info API

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -538,9 +538,9 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			changeLog = result
 		}
 	}
-
 	summary := releasecontroller.APIReleaseInfo{
 		Name:         tagInfo.Tag,
+		Phase:        tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
 		Results:      verificationJobs,
 		UpgradesTo:   c.graph.UpgradesTo(tagInfo.Tag),
 		UpgradesFrom: c.graph.UpgradesFrom(tagInfo.Tag),

--- a/cmd/release-controller/http.go
+++ b/cmd/release-controller/http.go
@@ -541,6 +541,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	summary := releasecontroller.APIReleaseInfo{
 		Name:         tagInfo.Tag,
+		Phase:        tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
 		Results:      verificationJobs,
 		UpgradesTo:   c.graph.UpgradesTo(tagInfo.Tag),
 		UpgradesFrom: c.graph.UpgradesFrom(tagInfo.Tag),

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -36,6 +36,8 @@ type APIRelease struct {
 type APIReleaseInfo struct {
 	// Name is the name of the release tag.
 	Name string `json:"name"`
+	// Phase is the phase of the release tag.
+	Phase string `json:"phase"`
 	// Results is the status of the release verification jobs for this release tag
 	Results *VerificationJobsSummary `json:"results,omitempty"`
 	// UpgradesTo is the list of UpgradeHistory "to" this release tag


### PR DESCRIPTION
Currently ART is using the `/api/v1/releasestream/{release}/latest` API to determine whether the release being promoted is accepted by the release controller.
This method has some timing issues when ART attempts to rerun some automation for an old release.
It would be very convenient to query the `Phase` field for a specific release with the `/api/v1/releasestream/{release}/release/{tag}` API.
With this power, ART's automation will be smarter and idempotent.