### PR TITLE
release-controller-api: load upgrade graph

### DIFF
--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -93,7 +93,7 @@ func (c *Controller) ensureVerificationJobs(release *releasecontroller.Release, 
 			if err != nil {
 				return nil, err
 			}
-			status, ok := prowJobVerificationStatus(job)
+			status, ok := releasecontroller.ProwJobVerificationStatus(job)
 			if !ok {
 				return nil, fmt.Errorf("unexpected error accessing prow job definition")
 			}

--- a/pkg/release-controller/prowjob.go
+++ b/pkg/release-controller/prowjob.go
@@ -1,7 +1,6 @@
-package main
+package releasecontroller
 
 import (
-	"github.com/openshift/release-controller/pkg/release-controller"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -12,27 +11,27 @@ import (
 	prowjobsv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
-func prowJobVerificationStatus(obj *unstructured.Unstructured) (*releasecontroller.VerificationStatus, bool) {
+func ProwJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationStatus, bool) {
 	s, _, err := unstructured.NestedString(obj.Object, "status", "state")
 	if err != nil {
 		return nil, false
 	}
 	url, _, _ := unstructured.NestedString(obj.Object, "status", "url")
 	var transitionTime string
-	var status *releasecontroller.VerificationStatus
+	var status *VerificationStatus
 	switch prowjobsv1.ProwJobState(s) {
 	case prowjobsv1.SuccessState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &releasecontroller.VerificationStatus{State: releasecontroller.ReleaseVerificationStateSucceeded, URL: url}
+		status = &VerificationStatus{State: ReleaseVerificationStateSucceeded, URL: url}
 	case prowjobsv1.FailureState, prowjobsv1.ErrorState, prowjobsv1.AbortedState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &releasecontroller.VerificationStatus{State: releasecontroller.ReleaseVerificationStateFailed, URL: url}
+		status = &VerificationStatus{State: ReleaseVerificationStateFailed, URL: url}
 	case prowjobsv1.TriggeredState, prowjobsv1.PendingState, prowjobsv1.ProwJobState(""):
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "pendingTime")
 		if transitionTime == "" {
 			transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "startTime")
 		}
-		status = &releasecontroller.VerificationStatus{State: releasecontroller.ReleaseVerificationStatePending, URL: url}
+		status = &VerificationStatus{State: ReleaseVerificationStatePending, URL: url}
 	default:
 		klog.Errorf("Unrecognized prow job state %q on job %s", s, obj.GetName())
 		return nil, false


### PR DESCRIPTION
This PR adds upgrade graph loading to the `release-controller-api`
binary.

/cc @bradmwilliams 