### PR TITLE
bugzilla: properly ignore already verified bugs

### DIFF
--- a/pkg/bugzilla/bugzilla.go
+++ b/pkg/bugzilla/bugzilla.go
@@ -56,7 +56,8 @@ func (c *Verifier) VerifyBugs(bugs []int, tagName string) []error {
 		if bug.Status != "ON_QA" {
 			// In case bug has already been moved to VERIFIED, completely ignore
 			if bug.Status == "VERIFIED" {
-				message = ""
+				klog.V(4).Infof("Bug %d already in VERIFIED status", bug.ID)
+				continue
 			} else {
 				bugErrs = append(bugErrs, fmt.Errorf("Bug is not in ON_QA status"))
 			}


### PR DESCRIPTION
This PR fixes an issue where the release-controller would comment that
all linked bugs have beenn approved and that the release-controller will
move the bug to VERIFIED when the bug has already been moved to
VERIFIED.