### PR TITLE
bugzilla: check bug target release before verifying

### DIFF
--- a/pkg/release-controller/semver.go
+++ b/pkg/release-controller/semver.go
@@ -160,3 +160,7 @@ func SemverParseTolerant(v string) (semver.Version, error) {
 	}
 	return semver.Version{}, err
 }
+
+func SemverToMajorMinor(sr semver.Version) string {
+	return fmt.Sprintf("%d.%d", sr.Major, sr.Minor)
+}


### PR DESCRIPTION
This PR adds a check to the bugzilla verifier that makes sure that the
target release of the bug being verified matches the target release of
the bug.

/cc @bradmwilliams 