### PR TITLE
sync_verify: run e2e tests on stable releases

### DIFF
--- a/cmd/release-controller-api/controller.go
+++ b/cmd/release-controller-api/controller.go
@@ -59,6 +59,8 @@ type Controller struct {
 	authenticationMessage string
 
 	architecture string
+
+	artSuffix string
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -69,6 +71,7 @@ func NewController(
 	graph *releasecontroller.UpgradeGraph,
 	authenticationMessage string,
 	architecture string,
+	artSuffix string,
 ) *Controller {
 	// log events at v2 and send them to the server
 	broadcaster := record.NewBroadcaster()
@@ -98,6 +101,8 @@ func NewController(
 		authenticationMessage: authenticationMessage,
 
 		architecture: architecture,
+
+		artSuffix: artSuffix,
 	}
 
 	c.dashboards = []Dashboard{

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -492,7 +492,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	verificationJobs, msg := getVerificationJobs(*tagInfo.Info.Tag, tagInfo.Info.Release)
+	verificationJobs, msg := c.getVerificationJobs(*tagInfo.Info.Tag, tagInfo.Info.Release)
 	if len(msg) > 0 {
 		klog.V(4).Infof("Unable to retrieve verification job results for: %s", tagInfo.Tag)
 	}
@@ -792,7 +792,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		renderInstallInstructions(w, mirror, tagInfo.Info.Tag, tagInfo.TagPullSpec, c.artifactsHost)
 	}
 
-	renderVerifyLinks(w, *tagInfo.Info.Tag, tagInfo.Info.Release)
+	c.renderVerifyLinks(w, *tagInfo.Info.Tag, tagInfo.Info.Release)
 
 	upgradesTo := c.graph.UpgradesTo(tagInfo.Tag)
 
@@ -1081,7 +1081,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 			"phaseCell":      phaseCell,
 			"phaseAlert":     phaseAlert,
 			"alerts":         renderAlerts,
-			"links":          links,
+			"links":          c.links,
 			"releaseJoin":    releaseJoin,
 			"dashboardsJoin": dashboardsJoin,
 			"inc":            func(i int) int { return i + 1 },

--- a/cmd/release-controller-api/main.go
+++ b/cmd/release-controller-api/main.go
@@ -57,6 +57,8 @@ type options struct {
 	ReleaseArchitecture string
 
 	AuthenticationMessage string
+
+	ARTSuffix string
 }
 
 func main() {
@@ -103,6 +105,8 @@ func main() {
 	flagset.StringVar(&opt.ReleaseArchitecture, "release-architecture", opt.ReleaseArchitecture, "The architecture of the releases to be created (defaults to 'amd64' if not specified).")
 
 	flagset.StringVar(&opt.AuthenticationMessage, "authentication-message", opt.AuthenticationMessage, "HTML formatted string to display a registry authentication message")
+
+	flagset.StringVar(&opt.ARTSuffix, "art-suffix", "", "Suffix for ART imagstreams (eg. `-art-latest`)")
 
 	flagset.AddGoFlag(original.Lookup("v"))
 	if err := setupKubeconfigWatches(opt); err != nil {
@@ -203,6 +207,7 @@ func (o *options) Run() error {
 		graph,
 		o.AuthenticationMessage,
 		architecture,
+		o.ARTSuffix,
 	)
 
 	var hasSynced []cache.InformerSynced

--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -137,6 +137,7 @@ type Controller struct {
 	buildClusterDistributions []ClusterDistribution
 
 	architecture string
+	artSuffix    string
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -155,6 +156,7 @@ func NewController(
 	authenticationMessage string,
 	clusterGroups []string,
 	architecture string,
+	artSuffix string,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -211,6 +213,7 @@ func NewController(
 		authenticationMessage: authenticationMessage,
 
 		architecture: architecture,
+		artSuffix:    artSuffix,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -93,6 +93,8 @@ type options struct {
 	Registry string
 
 	ClusterGroups []string
+
+	ARTSuffix string
 }
 
 // Add metrics for bugzilla verifier errors
@@ -175,6 +177,8 @@ func main() {
 	flagset.StringVar(&opt.AuthenticationMessage, "authentication-message", opt.AuthenticationMessage, "HTML formatted string to display a registry authentication message")
 
 	flagset.StringVar(&opt.Registry, "registry", opt.Registry, "Specify the registry, that the artifact server will use, to retrieve release images when located on remote clusters")
+
+	flagset.StringVar(&opt.ARTSuffix, "art-suffix", "", "Suffix for ART imagstreams (eg. `-art-latest`)")
 
 	// This option can be used to group, any number of, similar build cluster names into logical groups that will be used to
 	// randomly distribute prowjobs onto.  When the release-controller reads in the prowjob definition, it will check if
@@ -348,6 +352,7 @@ func (o *options) Run() error {
 		o.AuthenticationMessage,
 		o.ClusterGroups,
 		architecture,
+		o.ARTSuffix,
 	)
 	klog.V(4).Infof("7: %v", time.Now().Sub(start))
 

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -19,7 +19,11 @@ import (
 func (c *Controller) ensureVerificationJobs(release *releasecontroller.Release, releaseTag *imagev1.TagReference) (releasecontroller.VerificationStatusMap, error) {
 	var verifyStatus releasecontroller.VerificationStatusMap
 	retryQueueDelay := 0 * time.Second
-	for name, verifyType := range release.Config.Verify {
+	verificationJobs, err := releasecontroller.GetVerificationJobs(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, release, releaseTag, c.artSuffix)
+	if err != nil {
+		return nil, err
+	}
+	for name, verifyType := range verificationJobs {
 		if verifyType.Disabled {
 			klog.V(2).Infof("Release verification step %s is disabled, ignoring", name)
 			continue

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 
@@ -520,3 +521,64 @@ func GetImageInfo(releaseInfo ReleaseInfo, architecture, pullSpec string) (*imag
 	}
 	return &config, nil
 }
+
+func GetVerificationJobs(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, release *Release, releaseTag *imagev1.TagReference, artSuffix string) (map[string]ReleaseVerification, error) {
+	if release.Config.As != ReleaseConfigModeStable {
+		return release.Config.Verify, nil
+	}
+	jobs := make(map[string]ReleaseVerification)
+	for k, v := range release.Config.Verify {
+		jobs[k] = v
+	}
+	version, err := SemverParseTolerant(releaseTag.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get full stable verification jobs: %w", err)
+	}
+	isName := fmt.Sprintf("%d.%d%s", version.Major, version.Minor, artSuffix)
+	klog.Infof("Getting imagestream %s/%s", release.Target.Namespace, isName)
+	isLister := lister.ImageStreams(release.Target.Namespace)
+	if isLister == nil {
+		return nil, fmt.Errorf("failed to get imagestream %s", release.Target.Namespace)
+	}
+	imageStream, err := isLister.Get(isName)
+	if err != nil {
+		// TODO: make this an error once the artSuffix flag has been added to all commands
+		//return nil, fmt.Errorf("failed to get imagestream %s/%s: %w", release.Target.Namespace, isName, err)
+		return release.Config.Verify, nil
+	}
+	versionedRelease, ok, err := ReleaseDefinition(imageStream, rcCache, eventRecorder, *lister)
+	if err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, fmt.Errorf("failed to get release definition from stream %s/%s", release.Target.Namespace, isName)
+	}
+	nonOptionalE2EJobs := sets.NewString()
+	nonOptionalSerialJobs := sets.NewString()
+	for name, verify := range versionedRelease.Config.Verify {
+		if !verify.Optional {
+			splitName := strings.Split(name, "-")
+			if strings.HasSuffix(name, "-serial") && validTestSuffixes.Has(splitName[len(splitName)-2]) {
+				nonOptionalSerialJobs.Insert(name)
+			} else if validTestSuffixes.Has(splitName[len(splitName)-2]) {
+				nonOptionalE2EJobs.Insert(name)
+			}
+		}
+	}
+	// should we warn if there are no required e2e or e2e-serial jobs?
+	if nonOptionalE2EJobs.Len() > 0 {
+		// the List function is sorted, thus will always choose the same job on different runs (unless the versioned config changes)
+		job := versionedRelease.Config.Verify[nonOptionalE2EJobs.List()[0]]
+		job.Optional = true
+		jobs["e2e"] = job
+	}
+	if nonOptionalSerialJobs.Len() > 0 {
+		// the List function is sorted, thus will always choose the same job on different runs (unless the versioned config changes)
+		job := versionedRelease.Config.Verify[nonOptionalSerialJobs.List()[0]]
+		job.Optional = true
+		jobs["e2e-serial"] = job
+	}
+	return jobs, nil
+}
+
+// validTestSuffixes is a set containing all valid suffixes for tests used as verification jobs on stable streams
+var validTestSuffixes sets.String = sets.NewString([]string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift", "ovirt", "openstack"}...)

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -523,7 +523,7 @@ func GetImageInfo(releaseInfo ReleaseInfo, architecture, pullSpec string) (*imag
 }
 
 func GetVerificationJobs(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, release *Release, releaseTag *imagev1.TagReference, artSuffix string) (map[string]ReleaseVerification, error) {
-	if release.Config.As != ReleaseConfigModeStable {
+	if release.Config.As != ReleaseConfigModeStable || artSuffix == "" {
 		return release.Config.Verify, nil
 	}
 	jobs := make(map[string]ReleaseVerification)
@@ -542,9 +542,7 @@ func GetVerificationJobs(rcCache *lru.Cache, eventRecorder record.EventRecorder,
 	}
 	imageStream, err := isLister.Get(isName)
 	if err != nil {
-		// TODO: make this an error once the artSuffix flag has been added to all commands
-		//return nil, fmt.Errorf("failed to get imagestream %s/%s: %w", release.Target.Namespace, isName, err)
-		return release.Config.Verify, nil
+		return nil, fmt.Errorf("failed to get imagestream %s/%s: %w", release.Target.Namespace, isName, err)
 	}
 	versionedRelease, ok, err := ReleaseDefinition(imageStream, rcCache, eventRecorder, *lister)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for identifying what major point release a stable
release is part of and then running a required `e2e` and `e2e-serial`
test configured for the point release on the stable release.

/cc @bradmwilliams 