### PR TITLE
http_helper: remove empty "Pending jobs" lists

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -378,7 +378,7 @@ func (c *Controller) getVerificationJobs(tag imagev1.TagReference, release *rele
 				blockingJobs[key] = value
 			}
 		} else {
-			pendingJobs[key] = nil
+			delete(pendingJobs, key)
 		}
 	}
 	return &releasecontroller.VerificationJobsSummary{


### PR DESCRIPTION
This is a minor visual fix to prevent empty "Pending jobs" lists in
stable releases created before the stable e2e testing feature was added.

/cc @bradmwilliams 