### PR TITLE
Remove unhelpful warnings from UI

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -902,13 +902,5 @@ func checkConsistentImages(release, parent *releasecontroller.Release) ReleaseCh
 		sort.Strings(errDoesNotExist)
 		result.Errors = append(result.Errors, fmt.Sprintf("Found recent tags downstream that are not built upstream (not in %s/%s): %s", parent.Source.Namespace, parent.Source.Name, strings.Join(errDoesNotExist, ", ")))
 	}
-	if len(warnOlderThanUpstream) > 0 {
-		sort.Strings(warnOlderThanUpstream)
-		result.Warnings = append(result.Warnings, fmt.Sprintf("Some tags are significantly older than the upstream: %s", strings.Join(warnOlderThanUpstream, ", ")))
-	}
-	if len(warnNoDownstream) > 0 {
-		sort.Strings(warnNoDownstream)
-		result.Warnings = append(result.Warnings, fmt.Sprintf("No downstream builds have been pushed for these upstream tags: %s", strings.Join(warnNoDownstream, ", ")))
-	}
 	return result
 }


### PR DESCRIPTION
The two warnings being removed are essentially permanently
displayed on the release controller today.

'Some tags are significantly older ...' - This is expected as upstream
changes slow. CI may rebuild images for various reasons, but ART
will not. This is permanent in the case where a release goes EOL.

'No downstream builds have been pushed ...' - ART's imagestream
is carefully curated and pruned with automation. It is limited
to release payload components. The CI imagestream is not pruned
and has collected images unrelated to the release payload.