### PR TITLE
fix 4-stable grouping 

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -248,7 +248,7 @@ func tableLink(config *releasecontroller.ReleaseConfig, tag imagev1.TagReference
 		}
 		if strings.Contains(tag.Name, "nightly") && inconsistencies {
 			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a> <a href="/releasestream/%s/inconsistency/%s"><i title="Inconsistency detected! Click for more details" class="bi bi-exclamation-circle"></i></a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name))
-		} else if config.Name == "4-stable" {
+		} else if config.As == releasecontroller.ReleaseConfigModeStable {
 			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" style="padding-left:15px" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
 		} else {
 			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))

--- a/cmd/release-controller-api/static/htmlPageEnd.html
+++ b/cmd/release-controller-api/static/htmlPageEnd.html
@@ -1,0 +1,4 @@
+<p class="small">Source code for this page located on <a href="https://github.com/openshift/release-controller">github</a></p>
+</div>
+</body>
+</html>

--- a/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
+++ b/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
@@ -1,0 +1,93 @@
+<p class="small">Source code for this page located on <a href="https://github.com/openshift/release-controller">github</a></p>
+</div>
+<script src="static/js/jquery-1.11.3.min.js"></script>
+<script src="static/js/jquery.dataTables.js"></script>
+<script src="static/js/dataTables.rowGroup.min.js"></script>
+{{ $stableList := stableStream .Streams }}
+{{ range  $i, $a := $stableList }}
+<script>
+    $(document).ready(function() {
+        var collapsedGroups = {};
+        var table = $('#{{ $a  }}_table').DataTable({
+            columnDefs: [
+                {
+                    "targets": [ 4 ],
+                    "visible": false,
+                    "searchable": false
+                }
+            ],
+            ordering: false,
+            info: false,
+            paging: false,
+            searching: false,
+            rowGroup: {
+                dataSrc: 4,
+                startRender: function (rows, group) {
+                    var collapsed = !!collapsedGroups[group];
+                    var i = 0;
+                    j = 0;
+                    rows.nodes().each(function (r) {
+                        if (i>4) {
+                            if (collapsed == true) {
+                                j = j + 1;
+                            }
+                            r.style.display = collapsed ? '' : 'none';
+                        } else {
+                            j = j + 1;
+                            i = i + 1;
+                        }
+                    });
+                    if (rows.count() == 5) {
+                        t = '<td class="text-center" colspan="3"><div class="container"><div class="row flex-row-reverse"><div></div></div></div></td>'
+                    } else if (j == 5){
+                        t = '<td class="text-center" colspan="3"><div class="container"><div class="row flex-row-reverse"><div><a style="padding-right:15px" title="Click to show all"><i role="button" class="bi bi-plus-lg"></i></div></div></div></td>'
+                    } else if (j < 5) {
+                        t = '<td class="text-center" colspan="3"><div class="container"><div class="row flex-row-reverse"><div></div></div></div></td>'
+                    } else {
+                        t = '<td class="text-center" colspan="3"><div class="container"><div class="row flex-row-reverse"><div><a style="padding-right:15px" title="Click to collapse"><i role="button" class="bi bi-dash-lg"></i></div></div></div></td>'
+                    }
+                    return $('<tr/>')
+                        .append('<td colspan="3"  class="">' + group + ' (' + "showing " + j +  " out of " + rows.count() + ')</td>')
+                        .append(t)
+                        .attr('data-name', group)
+                        .toggleClass('collapsed', collapsed);
+                }
+            }
+        });
+        $('#{{ $a  }}_table tbody').on('click', 'tr.group-start',  function () {
+            var name = $(this).data('name');
+            collapsedGroups[name] = !collapsedGroups[name];
+            table.draw(false);
+        });
+    });
+</script>
+<script>
+    function searchTable() {
+        var input, filter, table, tr, td, i, txtValue;
+        input = document.getElementById("myInput");
+        filter = input.value.toUpperCase();
+        table = document.getElementById("{{ $a  }}_table");
+        tr = table.getElementsByTagName("tr");
+        for (i = 0; i < tr.length; i++) {
+            td = tr[i].getElementsByTagName("td")[0];
+            if (td) {
+                txtValue = td.textContent || td.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                    tr[i].style.display = "";
+                    if (txtValue.includes("showing")) {
+                        tr[i].style.display = "none";
+                    }
+                } else {
+                    tr[i].style.display = "none";
+                }
+            }
+        }
+        if (filter == "") {
+            document.location.reload();
+        }
+    }
+</script>
+{{ end }}
+<link href="static/css/custom.css" rel="stylesheet" type="text/css" />
+</body>
+</html>

--- a/cmd/release-controller-api/static/htmlPageStart.html
+++ b/cmd/release-controller-api/static/htmlPageStart.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"><title>%s</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <style>
+        @media (max-width: 992px) {
+            .container {
+                width: 100%%;
+                max-width: none;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="container">

--- a/cmd/release-controller-api/static/releaseDashboardPage.tmpl
+++ b/cmd/release-controller-api/static/releaseDashboardPage.tmpl
@@ -1,0 +1,55 @@
+<h1>Release Dashboard</h1>
+<p class="small mb-3">
+    Quick links: {{ dashboardsJoin .Dashboards }}
+</p>
+<div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
+<p><a href=https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=POST&f1=cf_internal_whiteboard&f2=status_whiteboard&j_top=OR&known_name=BuildCop&list_id=10913331&o1=substring&o2=substring&query_format=advanced&v1=buildcop&v2=buildcop>Open Build Cop Bugs</a></p>
+<p class="small mb-3">
+    Jump to: {{ releaseJoin .Streams }}
+</p>
+<div class="row">
+    <div class="col">
+        {{ range .Streams }}
+        {{ if ne .Release.Config.Name "4-stable" }}
+        <h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}"><a id="{{ .Release.Config.Name }}" href="#{{ .Release.Config.Name }}" class="text-dark">{{ .Release.Config.Name }}</a></h2>
+        {{ publishDescription . }}
+        {{ $upgrades := .Upgrades }}
+        <table class="table text-nowrap">
+            <thead>
+            <tr>
+                <th title="The name and version of the release image (as well as the tag it is published under)">Name</th>
+                <th title="The release moves through these stages:&#10;&#10;Pending - still creating release image&#10;Ready - release image created&#10;Accepted - all tests pass&#10;Rejected - some tests failed&#10;Failed - Could not create release image">Phase</th>
+                <th>Started</th>
+                <th colspan="1">Successful<br>Upgrades</th>
+                <th colspan="1">Running<br>Upgrades</th>
+                <th colspan="1">Failed<br>Upgrade From</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{ $release := .Release }}
+            {{ if .Delayed }}
+            <tr>
+                <td colspan="4"><em>{{ .Delayed.Message }}</em></td>
+                {{ if $upgrades }}<td colspan="{{ inc $upgrades.Width }}"></td>{{ end }}
+            </tr>
+            {{ end }}
+            {{ if .Failing }}
+            <div class="alert alert-danger">This release has no recently accepted payloads, investigation required.</div>
+            {{ end }}
+            {{ range $index, $tag := .Tags }}
+            {{ if lt $index 10 }}
+            {{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
+            <tr>
+                {{ tableLink $release.Config $tag $release.HasInconsistencies }}
+                {{ phaseCell . }}
+                <td title="{{ $created }}">{{ since $created }}</td>
+                {{ upgradeJobs $upgrades $index $created }}
+            </tr>
+            {{end}}
+            {{ end }}
+            </tbody>
+        </table>
+        {{ end }}
+        {{ end }}
+    </div>
+</div>

--- a/cmd/release-controller-api/static/releasePageHtml.tmpl
+++ b/cmd/release-controller-api/static/releasePageHtml.tmpl
@@ -1,0 +1,58 @@
+<h1>Release Status</h1>
+<p class="small mb-3">
+    Quick links: {{ dashboardsJoin .Dashboards }}
+</p>
+<p>Visualize upgrades in <a href="/graph">Cincinnati</a> | <a href="/graph?format=dot">dot</a> | <a href="/graph?format=svg">SVG</a> | <a href="/graph?format=png">PNG</a> format. Run the following command to make this your update server:</p>
+<pre class="ml-4">
+oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}graph"}}' --type=merge
+</pre>
+<div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
+{{ displayAuthMessage }}
+
+<p class="small mb-3">
+    Jump to: {{ releaseJoin .Streams }}
+</p>
+
+<div class="row">
+    <div class="col">
+        {{ range .Streams }}
+        {{ $isStable := .Release.Config.As }}
+        <h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}"><a id="{{ .Release.Config.Name }}" href="#{{ .Release.Config.Name }}" class="text-dark">{{ .Release.Config.Name }}</a></h2>
+        {{ publishDescription . }}
+        {{ alerts . }}
+        {{ $upgrades := .Upgrades }}
+        <table id="{{.Release.Config.Name}}_table" class="table text-nowrap">
+            <thead>
+            <tr>
+                <th title="The name and version of the release image (as well as the tag it is published under)">Name</th>
+                <th title="The release moves through these stages:&#10;&#10;Pending - still creating release image&#10;Ready - release image created&#10;Accepted - all tests pass&#10;Rejected - some tests failed&#10;Failed - Could not create release image">Phase</th>
+                <th>Started</th>
+                <th title="Tests that failed or are still pending on releases. See release page for more.">Failures</th>
+                {{ if eq $isStable  "Stable"}}<th>Version Grouping</th>{{ end }}
+                {{ if $upgrades }}<th colspan="{{ inc $upgrades.Width }}">Upgrades</th>{{ end }}
+            </tr>
+            </thead>
+            <tbody>
+            {{ $release := .Release }}
+            {{ if .Delayed }}
+            <tr>
+                <td colspan="4"><em>{{ .Delayed.Message }}</em></td>
+                {{ if $upgrades }}<td colspan="{{ inc $upgrades.Width }}"></td>{{ end }}
+            </tr>
+            {{ end }}
+            {{ range $index, $tag := .Tags }}
+            {{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
+            <tr>
+                {{ tableLink $release.Config $tag $release.HasInconsistencies }}
+                {{ phaseCell . }}
+                <td title="{{ $created }}">{{ since $created }}</td>
+                <td>{{ links . $release }}</td>
+                {{ if eq $isStable "Stable" }}<td>{{ versionGrouping $tag.Name }}</td>{{ end }}
+                {{ upgradeCells $upgrades $index }}
+            </tr>
+            {{ end }}
+            </tbody>
+        </table>
+        {{ end }}
+    </div>
+</div>


### PR DESCRIPTION
- Fix the `4-stable` configuration issue (the stable table ID was hardcoded to `4-stable`, while the table ID can be different in different architectures). The scripts are now rendered in a loop, using the data from the release streams (using the information from "stream.Release.Config.As"). The streams are grouped by version for any stream that has a "Stable" tag.

- Move the HTML code from `http.go` to the `static` dir. 

- Remove the extend/collapse icon (+/-) when the number of rows is <= 5 (where 5 is the default number of rows displayed in a group) since it's not applicable. 