### PR TITLE
increase the PVC size

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -393,7 +393,7 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("40Gi"),
+							"storage": resource.MustParse("64Gi"),
 						},
 					},
 				},


### PR DESCRIPTION
Increase the PVC size from 40Gi to 64Gi. The git-cache disk is often getting full. Normally the usage is always close to the 40Gi limit, often causing issues. 