### PR TITLE
Removing `shape="record"` from dot entries

### DIFF
--- a/cmd/release-controller-api/http_upgrade_graph.go
+++ b/cmd/release-controller-api/http_upgrade_graph.go
@@ -153,7 +153,6 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 				nodeLabels[tag.Name] = index
 				attrs := map[string]string{
 					string(viz.Label): fmt.Sprintf(`%q`, tag.Name),
-					string(viz.Shape): "record",
 					string(viz.HREF):  fmt.Sprintf(`"/releasetag/%s"`, template.HTMLEscapeString(tag.Name)),
 				}
 				if phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]; phase == releasecontroller.ReleasePhaseRejected {


### PR DESCRIPTION
The `shape="record"` has been deprecated with newer versions of Dot.  Although the command does succeed, it returns a `1` as it's exit code and we fail to generate `png` and/or `svg` representations of the upgrade graph.  Removing the entry clears the error code and we render the graph accordingly.