### PR TITLE
Add multiJobAnalysis flag to verification job

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -123,7 +123,7 @@ func (c *Controller) ensureProwJobForReleaseTag(release *releasecontroller.Relea
 	if err != nil {
 		return nil, err
 	}
-	if isAggregatedJob {
+	if isAggregatedJob || verifyType.MultiJobAnalysis {
 		status, err := addAnalysisEnvToProwJobSpec(&spec, releaseTag.Name, verifyType.ProwJob.Name)
 		if err != nil {
 			return nil, err

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -242,6 +242,10 @@ type ReleaseVerification struct {
 	MaxRetries int `json:"maxRetries,omitempty"`
 	// AggregatedProwJob defines the prow job used to run release analysis verification
 	AggregatedProwJob *AggregatedProwJobVerification `json:"aggregatedProwJob,omitempty"`
+	// MultiJobAnalysis indicates the job is used to analyze results from multiple other
+	// job runs from the payload. Thus, it needs some environment variables set, such as
+	// PAYLOAD_TAG.
+	MultiJobAnalysis bool `json:"multiJobAnalysis"`
 }
 
 // AggregatedProwJobVerification identifies the name of a prow job that will be used to


### PR DESCRIPTION
This is used to indicate that multiple job runs from the payload will be analyzed and therefore the job needs some environment variables set such as PAYLOAD-TAG. 