### PR TITLE
whitelist status codes for bugzilla responses

### DIFF
--- a/pkg/bugzilla/bugzilla.go
+++ b/pkg/bugzilla/bugzilla.go
@@ -55,13 +55,16 @@ func (e bugzillaRequestError) Error() string {
 }
 
 func validateBZRequestError(err error) bool {
-	acceptedReturnCodes := []int{200, 201}
+	acceptedStatusCodes := []int{200, 201}
 	if err == nil {
 		return false
 	}
-	resError := err.(*bugzillaRequestError)
-	for _, returnCode := range acceptedReturnCodes {
-		if returnCode == resError.statusCode {
+	reqError, ok := err.(*bugzillaRequestError)
+	if !ok {
+		return true
+	}
+	for _, statusCode := range acceptedStatusCodes {
+		if statusCode == reqError.statusCode {
 			return false
 		}
 	}

--- a/pkg/bugzilla/bugzilla_test.go
+++ b/pkg/bugzilla/bugzilla_test.go
@@ -1,20 +1,37 @@
 package bugzilla
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestValidateBZRequestError(t *testing.T) {
-	goodResponse := &bugzillaRequestError{statusCode: 201, bugzillaCode: 201, message: "I am an error"}
-	badResponse := &bugzillaRequestError{statusCode: 301, bugzillaCode: 301, message: "I am an error"}
-	isItAnError := validateBZRequestError(goodResponse)
-	if isItAnError {
-		t.Fatalf("failed to validate whitelisted return codes")
+	testCases := []struct {
+		name     string
+		response error
+		expected bool
+	}{
+		{
+			name:     "Status Code 201",
+			response: &bugzillaRequestError{statusCode: 201, bugzillaCode: 201, message: "message"},
+			expected: false,
+		},
+		{
+			name:     "Empty response",
+			response: nil,
+			expected: false,
+		},
+		{
+			name:     "Non whitelisted status code",
+			response: &bugzillaRequestError{statusCode: 301, bugzillaCode: 301, message: "message"},
+			expected: true,
+		},
 	}
-	isItAnError = validateBZRequestError(nil)
-	if isItAnError {
-		t.Errorf("failed to validate nil error")
-	}
-	isItAnError = validateBZRequestError(badResponse)
-	if !isItAnError {
-		t.Fatalf("wrong validataion of statusCode %d", badResponse.statusCode)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isItAnError := validateBZRequestError(tc.response)
+			if isItAnError != tc.expected {
+				t.Errorf("expected a %t validation but got %t for this response: %v", tc.expected, isItAnError, tc.response)
+			}
+		})
 	}
 }

--- a/pkg/bugzilla/bugzilla_test.go
+++ b/pkg/bugzilla/bugzilla_test.go
@@ -1,0 +1,20 @@
+package bugzilla
+
+import "testing"
+
+func TestValidateBZRequestError(t *testing.T) {
+	goodResponse := &bugzillaRequestError{statusCode: 201, bugzillaCode: 201, message: "I am an error"}
+	badResponse := &bugzillaRequestError{statusCode: 301, bugzillaCode: 301, message: "I am an error"}
+	isItAnError := validateBZRequestError(goodResponse)
+	if isItAnError {
+		t.Fatalf("failed to validate whitelisted return codes")
+	}
+	isItAnError = validateBZRequestError(nil)
+	if isItAnError {
+		t.Errorf("failed to validate nil error")
+	}
+	isItAnError = validateBZRequestError(badResponse)
+	if !isItAnError {
+		t.Fatalf("wrong validataion of statusCode %d", badResponse.statusCode)
+	}
+}


### PR DESCRIPTION
When creating a comment (`CreateComment` method), the server returns a status 201 (created). 
The comment is created as expected in the ticket, but we do not handle the response properly (hence this is considered an error, while it is not). 