### PR TITLE
Fixing failed job count mismatch

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -271,10 +271,7 @@ func (c *Controller) links(tag imagev1.TagReference, release *releasecontroller.
 		return "error"
 	}
 	pending, failing := make([]string, 0, len(verificationJobs)), make([]string, 0, len(verificationJobs))
-	for k, v := range verificationJobs {
-		if v.Upgrade {
-			continue
-		}
+	for k, _ := range verificationJobs {
 		s, ok := status[k]
 		if !ok {
 			continue


### PR DESCRIPTION
The "failed" jobs count on the the release summary page does not match the actual number of failed job listed on the release info page.  This PR removes the filtering of Upgrade failures from the failure count on the release summary page.