### PR TITLE
Temporary fix to allow bugzilla verification to proceed

### DIFF
--- a/cmd/release-controller/bugzilla.go
+++ b/cmd/release-controller/bugzilla.go
@@ -132,20 +132,13 @@ func (c *Controller) syncBugzilla(key queueKey) error {
 	}
 
 	bugs, err := c.releaseInfo.Bugs(dockerRepo+":"+prevTag.Name, dockerRepo+":"+tag.Name)
-	var bugList []int
-
-	for _, bug := range bugs {
-		if bug.Source == 0 {
-			bugList = append(bugList, bug.ID)
-		}
-	}
 	if err != nil {
 		klog.V(4).Infof("Unable to generate bug list from %s to %s: %v", prevTag.Name, tag.Name, err)
 		c.bugzillaErrorMetrics.WithLabelValues(bzUnableToGenerateBuglist).Inc()
 		return fmt.Errorf("Unable to generate bug list from %s to %s: %v", prevTag.Name, tag.Name, err)
 	}
 	var errs []error
-	if errs := append(errs, c.bugzillaVerifier.VerifyBugs(bugList, tag.Name)...); len(errs) != 0 {
+	if errs := append(errs, c.bugzillaVerifier.VerifyBugs(bugs, tag.Name)...); len(errs) != 0 {
 		klog.V(4).Infof("Error(s) in bugzilla verifier: %v", utilerrors.NewAggregate(errs))
 		c.bugzillaErrorMetrics.WithLabelValues(bzVerifier).Inc()
 		return utilerrors.NewAggregate(errs)

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -133,8 +133,8 @@ func (c *Controller) syncJira(key queueKey) error {
 	issues, err := c.releaseInfo.Bugs(dockerRepo+":"+prevTag.Name, dockerRepo+":"+tag.Name)
 	var issueList []string
 	for _, issue := range issues {
-		if issue.Source == 1 {
-			issueList = append(issueList, strconv.Itoa(issue.ID))
+		if false {
+			issueList = append(issueList, strconv.Itoa(issue))
 		}
 	}
 	if err != nil {

--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,15 +40,14 @@ func NewCachingReleaseInfo(info ReleaseInfo, size int64, architecture string) Re
 			if strings.Contains(parts[1], "\x00") || strings.Contains(parts[2], "\x00") {
 				s, err = "", fmt.Errorf("invalid from/to")
 			} else {
-				var bugDetailsArr []BugDetails
-				bugDetailsArr, err = info.Bugs(parts[1], parts[2])
+				var iArr []int
+				iArr, err = info.Bugs(parts[1], parts[2])
 				if err == nil {
-					bugDetailsByte, err := json.Marshal(bugDetailsArr)
-					if err != nil {
-						klog.V(4).Infof("Failed to Marshal Bug Details Array; from: %s to: %s; %s", parts[1], parts[2], err)
-					} else {
-						s = string(bugDetailsByte)
+					var sArr []string
+					for _, bugID := range iArr {
+						sArr = append(sArr, strconv.Itoa(bugID))
 					}
+					s = strings.Join(sArr, "\n")
 				}
 			}
 		case "changelog":
@@ -72,13 +72,13 @@ func NewCachingReleaseInfo(info ReleaseInfo, size int64, architecture string) Re
 	}
 }
 
-func (c *CachingReleaseInfo) Bugs(from, to string) ([]BugDetails, error) {
+func (c *CachingReleaseInfo) Bugs(from, to string) ([]int, error) {
 	var s string
 	err := c.cache.Get(context.TODO(), strings.Join([]string{"bugs", from, to}, "\x00"), groupcache.StringSink(&s))
 	if err != nil {
-		return []BugDetails{}, err
+		return []int{}, err
 	}
-	return bugList(s)
+	return bugListToArr(s)
 }
 
 func (c *CachingReleaseInfo) ChangeLog(from, to string) (string, error) {
@@ -110,7 +110,7 @@ func (c *CachingReleaseInfo) ImageInfo(image, archtecture string) (string, error
 
 type ReleaseInfo interface {
 	// Bugs returns a list of bugzilla bug IDs for bugs fixed between the provided release tags
-	Bugs(from, to string) ([]BugDetails, error)
+	Bugs(from, to string) ([]int, error)
 	ChangeLog(from, to string) (string, error)
 	ReleaseInfo(image string) (string, error)
 	UpgradeInfo(image string) (ReleaseUpgradeInfo, error)
@@ -212,7 +212,7 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string) (string, error) {
 	return out.String(), nil
 }
 
-func (r *ExecReleaseInfo) Bugs(from, to string) ([]BugDetails, error) {
+func (r *ExecReleaseInfo) Bugs(from, to string) ([]int, error) {
 	if _, err := imagereference.Parse(from); err != nil {
 		return nil, fmt.Errorf("%s is not an image reference: %v", from, err)
 	}
@@ -223,7 +223,7 @@ func (r *ExecReleaseInfo) Bugs(from, to string) ([]BugDetails, error) {
 		return nil, fmt.Errorf("not a valid reference")
 	}
 
-	cmd := []string{"oc", "adm", "release", "info", "--bugs=/tmp/git/", "--output=json", from, to}
+	cmd := []string{"oc", "adm", "release", "info", "--bugs=/tmp/git/", "--output=name", "--skip-bug-check", from, to}
 	klog.V(4).Infof("Running bugs command: %s", strings.Join(cmd, " "))
 	u := r.client.CoreV1().RESTClient().Post().Resource("pods").Namespace(r.namespace).Name("git-cache-0").SubResource("exec").VersionedParams(&corev1.PodExecOptions{
 		Container: "git",
@@ -247,10 +247,24 @@ func (r *ExecReleaseInfo) Bugs(from, to string) ([]BugDetails, error) {
 		if len(msg) == 0 {
 			msg = err.Error()
 		}
-		return []BugDetails{}, fmt.Errorf("could not generate a bug list: %v", msg)
+		return nil, fmt.Errorf("could not generate a bug list: %v", msg)
 	}
+	return bugListToArr(out.String())
+}
 
-	return bugList(out.String())
+func bugListToArr(s string) ([]int, error) {
+	bugs := []int{}
+	for _, bug := range strings.Split(s, "\n") {
+		if bug == "" {
+			continue
+		}
+		bugID, err := strconv.Atoi(bug)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert bug id %s to an int: %v", bug, err)
+		}
+		bugs = append(bugs, bugID)
+	}
+	return bugs, nil
 }
 
 func bugList(s string) ([]BugDetails, error) {


### PR DESCRIPTION
When we introduced the Jira integration logic there were issues with the
integration with `oc` that are preventing us from being able to process
Bugs.  This fix reverts us back to the "old" logic and should allow for
the verification logic to resume.

This PR can be reverted if/when an appropriate fix is made in `oc`.