### PR TITLE
Updating the deferred recovery logic

### DIFF
--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -31,8 +31,9 @@ type AuditStore interface {
 // or to the entire namespace.
 func (c *Controller) syncAudit(key queueKey) error {
 	defer func() {
-		err := recover()
-		panic(err)
+		if err := recover(); err != nil {
+			panic(err)
+		}
 	}()
 
 	release, err := c.loadReleaseForSync(key.namespace, key.name)

--- a/cmd/release-controller/bugzilla.go
+++ b/cmd/release-controller/bugzilla.go
@@ -60,8 +60,9 @@ func getNonVerifiedTags(acceptedTags []*v1.TagReference) (current, previous *v1.
 // PR reviewed and approved by the QA contact for the bug
 func (c *Controller) syncBugzilla(key queueKey) error {
 	defer func() {
-		err := recover()
-		panic(err)
+		if err := recover(); err != nil {
+			panic(err)
+		}
 	}()
 
 	release, err := c.loadReleaseForSync(key.namespace, key.name)

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -59,8 +59,9 @@ func getNonVerifiedTagsJira(acceptedTags []*v1.TagReference) (current, previous 
 // PR reviewed and approved by the QA contact for the bug
 func (c *Controller) syncJira(key queueKey) error {
 	defer func() {
-		err := recover()
-		panic(err)
+		if err := recover(); err != nil {
+			panic(err)
+		}
 	}()
 
 	release, err := c.loadReleaseForSync(key.namespace, key.name)

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -27,8 +27,9 @@ import (
 // or to the entire namespace.
 func (c *Controller) sync(key queueKey) error {
 	defer func() {
-		err := recover()
-		panic(err)
+		if err := recover(); err != nil {
+			panic(err)
+		}
 	}()
 
 	// if we are waiting to observe the result of our previous actions, simply delay

--- a/cmd/release-controller/sync_gc.go
+++ b/cmd/release-controller/sync_gc.go
@@ -19,8 +19,9 @@ import (
 // know whether to delete the objects.
 func (c *Controller) garbageCollectSync() error {
 	defer func() {
-		err := recover()
-		panic(err)
+		if err := recover(); err != nil {
+			panic(err)
+		}
 	}()
 
 	imageStreams, err := c.releaseLister.List(labels.Everything())


### PR DESCRIPTION
I observed that in most cases there was a "begin" message, but never a corresponding
"end" message surrounding the various sync loops that occur.  It appears that this was
caused by the deferal of the recover() method followed, immediately, by a panic(nil).
I have updated the offending logic to only issue the panic() call when an error is
returned from the recover() logic.