### PR TITLE
Create ReleasePayloads whenever a new release is created.

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	releasepayloadclient "github.com/openshift/release-controller/pkg/client/clientset/versioned/typed/release/v1alpha1"
 	"github.com/openshift/release-controller/pkg/jira"
 	"strings"
 	"time"
@@ -92,7 +93,6 @@ type Controller struct {
 	auditQueue workqueue.RateLimitingInterface
 	// bugzillaQueue is the list of releases whose fixed bugs must be synced to bugzilla
 	bugzillaQueue workqueue.RateLimitingInterface
-
 	// jiraQueue is the list of releases whose fixed issues must be synced to jira
 	jiraQueue workqueue.RateLimitingInterface
 
@@ -145,6 +145,8 @@ type Controller struct {
 
 	architecture string
 	artSuffix    string
+
+	releasePayloadClient releasepayloadclient.ReleasePayloadsGetter
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -164,6 +166,7 @@ func NewController(
 	clusterGroups []string,
 	architecture string,
 	artSuffix string,
+	releasePayloadClient releasepayloadclient.ReleasePayloadsGetter,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -223,6 +226,8 @@ func NewController(
 
 		architecture: architecture,
 		artSuffix:    artSuffix,
+
+		releasePayloadClient: releasePayloadClient,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	releasepayloadclient "github.com/openshift/release-controller/pkg/client/clientset/versioned"
 	"github.com/openshift/release-controller/pkg/jira"
 	"net/http"
 	"net/url"
@@ -354,6 +355,11 @@ func (o *options) Run() error {
 
 	graph := releasecontroller.NewUpgradeGraph(architecture)
 
+	releasePayloadClient, err := releasepayloadclient.NewForConfig(inClusterCfg)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
 	c := NewController(
 		client.CoreV1(),
 		imageClient.ImageV1(),
@@ -370,6 +376,7 @@ func (o *options) Run() error {
 		o.ClusterGroups,
 		architecture,
 		o.ARTSuffix,
+		releasePayloadClient.ReleaseV1alpha1(),
 	)
 
 	ghClient, err := o.github.GitHubClient(false)

--- a/cmd/release-controller/sync_release_payload.go
+++ b/cmd/release-controller/sync_release_payload.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sort"
+)
+
+func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, tagName string) (*v1alpha1.ReleasePayload, error) {
+	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, tagName, c.jobNamespace, c.prowNamespace), metav1.CreateOptions{})
+	if err == nil {
+		klog.V(4).Infof("ReleasePayload: %s/%s created", payload.Namespace, payload.Name)
+		return payload, nil
+	}
+	if errors.IsAlreadyExists(err) {
+		return c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Get(context.TODO(), tagName, metav1.GetOptions{})
+	}
+	return nil, err
+}
+
+func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, prowNamespace string) *v1alpha1.ReleasePayload {
+	payload := v1alpha1.ReleasePayload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: release.Target.Namespace,
+		},
+		Spec: v1alpha1.ReleasePayloadSpec{
+			PayloadCoordinates: v1alpha1.PayloadCoordinates{
+				Namespace:          release.Target.Namespace,
+				ImagestreamName:    release.Target.Name,
+				ImagestreamTagName: name,
+			},
+			PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+				ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+					Namespace:              jobNamespace,
+					ReleaseCreationJobName: name,
+				},
+				ProwCoordinates: v1alpha1.ProwCoordinates{Namespace: prowNamespace},
+			},
+			PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+				BlockingJobs:  []v1alpha1.CIConfiguration{},
+				InformingJobs: []v1alpha1.CIConfiguration{},
+			},
+		},
+	}
+
+	// Sort the ReleaseVerification items into a consistent order
+	keys := make([]string, 0, len(release.Config.Verify))
+	for k := range release.Config.Verify {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, verifyName := range keys {
+		definition := release.Config.Verify[verifyName]
+		if definition.Disabled {
+			continue
+		}
+		ciConfig := v1alpha1.CIConfiguration{
+			CIConfigurationName:    verifyName,
+			CIConfigurationJobName: definition.ProwJob.Name,
+			MaxRetries:             definition.MaxRetries,
+		}
+
+		switch {
+		case definition.AggregatedProwJob != nil:
+			// Every Aggregated Job will contain a Blocking "Aggregator" job and an Informing "Analysis" job
+			// Adding the Blocking Job
+			blockingJobName := defaultAggregateProwJobName
+			if definition.AggregatedProwJob.ProwJob != nil && len(definition.AggregatedProwJob.ProwJob.Name) > 0 {
+				blockingJobName = definition.AggregatedProwJob.ProwJob.Name
+			}
+			ciConfig.CIConfigurationJobName = fmt.Sprintf("%s-%s", verifyName, blockingJobName)
+			payload.Spec.PayloadVerificationConfig.BlockingJobs = append(payload.Spec.PayloadVerificationConfig.BlockingJobs, ciConfig)
+
+			// Adding the Informing Job
+			informingJob := v1alpha1.CIConfiguration{
+				CIConfigurationName:    verifyName,
+				CIConfigurationJobName: definition.ProwJob.Name,
+				AnalysisJobCount:       definition.AggregatedProwJob.AnalysisJobCount,
+			}
+			payload.Spec.PayloadVerificationConfig.InformingJobs = append(payload.Spec.PayloadVerificationConfig.InformingJobs, informingJob)
+		default:
+			if definition.Optional {
+				payload.Spec.PayloadVerificationConfig.InformingJobs = append(payload.Spec.PayloadVerificationConfig.InformingJobs, ciConfig)
+			} else {
+				payload.Spec.PayloadVerificationConfig.BlockingJobs = append(payload.Spec.PayloadVerificationConfig.BlockingJobs, ciConfig)
+			}
+		}
+	}
+	return &payload
+}

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -1,0 +1,579 @@
+package main
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+func TestNewReleasePayload(t *testing.T) {
+	testCases := []struct {
+		name          string
+		release       *releasecontroller.Release
+		releaseName   string
+		jobNamespace  string
+		prowNamespace string
+		expected      *v1alpha1.ReleasePayload
+	}{
+		{
+			name: "DisabledJob",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"disabled-job": {
+							Disabled: true,
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "BlockingJob",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"blocking-job": {
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "blocking-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "BlockingJobWithRetries",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"blocking-job": {
+							MaxRetries: 3,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "blocking-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+								MaxRetries:             3,
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "InformingJob",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"informing-job": {
+							Optional: true,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "informing-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "InformingJobWithRetries",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"informing-job": {
+							Optional:   true,
+							MaxRetries: 3,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "informing-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+								MaxRetries:             3,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AggregatedJob",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"aggregated-job": {
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-upgrade",
+							},
+							Upgrade: true,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								AnalysisJobCount: 10,
+							},
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-job",
+								CIConfigurationJobName: "aggregated-job-release-openshift-release-analysis-aggregator",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-upgrade",
+								AnalysisJobCount:       10,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AggregatedJobWithOverwrittenAggregatorJob",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"aggregated-job": {
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-upgrade",
+							},
+							Upgrade: true,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								ProwJob: &releasecontroller.ProwJobVerification{
+									Name: "overwritten-prowjob-definition",
+								},
+								AnalysisJobCount: 10,
+							},
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-job",
+								CIConfigurationJobName: "aggregated-job-overwritten-prowjob-definition",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-upgrade",
+								AnalysisJobCount:       10,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "RealWorldExample",
+			release: &releasecontroller.Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"aggregated-azure-ovn-upgrade-4.12-micro": {
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-ci-4.12-e2e-azure-ovn-upgrade",
+							},
+							Upgrade: true,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								AnalysisJobCount: 10,
+							},
+						},
+						"aggregated-gcp-ovn-upgrade-4.12-minor": {
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-gcp-ovn-upgrade",
+							},
+							Upgrade:     true,
+							UpgradeFrom: releasecontroller.ReleaseUpgradeFromPreviousMinor,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								AnalysisJobCount: 10,
+							},
+						},
+						"alibaba": {
+							Optional: true,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-alibaba",
+							},
+						},
+						"aws-sdn": {
+							Optional:   true,
+							MaxRetries: 3,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn",
+							},
+						},
+						"aws-single-node": {
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-single-node",
+							},
+						},
+						"aws-sdn-serial": {
+							MaxRetries: 3,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+						"metal-ipi-upgrade": {
+							Optional: true,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-upgrade",
+							},
+							Upgrade: true,
+						},
+						"metal-ipi-upgrade-minor": {
+							Optional: true,
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-metal-ipi-upgrade",
+							},
+							Upgrade:     true,
+							UpgradeFrom: releasecontroller.ReleaseUpgradeFromPreviousMinor,
+						},
+					},
+				},
+			},
+			releaseName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-azure-ovn-upgrade-4.12-micro",
+								CIConfigurationJobName: "aggregated-azure-ovn-upgrade-4.12-micro-release-openshift-release-analysis-aggregator",
+							},
+							{
+								CIConfigurationName:    "aggregated-gcp-ovn-upgrade-4.12-minor",
+								CIConfigurationJobName: "aggregated-gcp-ovn-upgrade-4.12-minor-release-openshift-release-analysis-aggregator",
+							},
+							{
+								CIConfigurationName:    "aws-sdn-serial",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+								MaxRetries:             3,
+							},
+							{
+								CIConfigurationName:    "aws-single-node",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-single-node",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-azure-ovn-upgrade-4.12-micro",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-ci-4.12-e2e-azure-ovn-upgrade",
+								AnalysisJobCount:       10,
+							},
+							{
+								CIConfigurationName:    "aggregated-gcp-ovn-upgrade-4.12-minor",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-gcp-ovn-upgrade",
+								AnalysisJobCount:       10,
+							},
+							{
+								CIConfigurationName:    "alibaba",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-alibaba",
+							},
+							{
+								CIConfigurationName:    "aws-sdn",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn",
+								MaxRetries:             3,
+							},
+							{
+								CIConfigurationName:    "metal-ipi-upgrade",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-upgrade",
+							},
+							{
+								CIConfigurationName:    "metal-ipi-upgrade-minor",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-metal-ipi-upgrade",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := newReleasePayload(tc.release, tc.releaseName, tc.jobNamespace, tc.prowNamespace)
+			if !reflect.DeepEqual(payload, tc.expected) {
+				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, payload)
+			}
+		})
+	}
+}

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -43,6 +43,12 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 	}
 	updateReleaseTarget(release, is)
 
+	// Create the corresponding ReleasePayload object...
+	_, err = c.ensureReleasePayload(release, tag.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	return &is.Spec.Tags[len(is.Spec.Tags)-1], nil
 }
 


### PR DESCRIPTION
This PR will enable the `release-controller` to begin creating `ReleasePayload` objects whenever it creates a new release.  The `release-payload-controller` will then take over all processing of the ReleasePayloads.  The `release-controller` and the `release-payload-controller` will initially operate independently of each other and both should closely mirror reality, but ultimately the `release-controller` is still responsible for the overall acceptance/rejection of releases and is based on the imagestream annotations. 