### PR TITLE
prune `EOL` releases from the release summary page

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -929,3 +929,8 @@ func pruneEndOfLifeTags(page *ReleasePage, endOfLifePrefixes sets.String) {
 		}
 	}
 }
+
+func pruneTagInfo(tagInfo string) string {
+	tagInfoParts := strings.Split(tagInfo, ".")
+	return fmt.Sprintf("%s.%s", tagInfoParts[0], tagInfoParts[1])
+}


### PR DESCRIPTION
Prune EOL releases from the drop-down selector on the release summary pages. 
![image](https://user-images.githubusercontent.com/77680331/179218367-9a853ef8-54a0-4f8a-aee3-d8a66c1ca1f2.png)

The `forceRefresh=true` query parameter can be used to refresh the EOL list dynamically. 