### PR TITLE
[OCPCRT-32] Launch supported upgrade jobs for Stable releases

### DIFF
--- a/cmd/release-controller/sync_upgrade.go
+++ b/cmd/release-controller/sync_upgrade.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	imagev1 "github.com/openshift/api/image/v1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	"k8s.io/klog"
+)
+
+func (c *Controller) ensureReleaseUpgradeJobs(release *releasecontroller.Release, releaseTag *imagev1.TagReference) error {
+	// To minimize the blast radius of these jobs, I'm limiting them to only the official ART releases (i.e. Stable)...
+	if release.Config.As != releasecontroller.ReleaseConfigModeStable {
+		klog.V(4).Infof("Supported upgrade testing is disabled for: %q", release.Config.Name)
+		return nil
+	}
+	platforms, jobs := getUpgradeProwJobs(release)
+	if len(platforms) == 0 {
+		klog.V(4).Infof("No platforms, for supported upgrade testing, defined: %q", release.Config.Name)
+		return nil
+	}
+	platformDistribution, err := NewRoundRobinClusterDistribution(platforms...)
+	if err != nil {
+		return fmt.Errorf("unable to determine platform distribution: %v", err)
+	}
+	pullSpec := releasecontroller.FindPublicImagePullSpec(release.Target, releaseTag.Name)
+	if len(pullSpec) == 0 {
+		return fmt.Errorf("unable to get determine pullSpec for for release: %s", releaseTag.Name)
+	}
+	toImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, pullSpec)
+	if err != nil {
+		return fmt.Errorf("unable to get to image info for release %s: %v", releaseTag.Name, err)
+	}
+	toPullSpec := toImage.GenerateDigestPullSpec()
+	tagUpgradeInfo, err := c.releaseInfo.UpgradeInfo(toPullSpec)
+	if err != nil {
+		return fmt.Errorf("could not get release info for tag %s: %v", toPullSpec, err)
+	}
+	var supportedUpgrades []string
+	if tagUpgradeInfo.Metadata != nil {
+		supportedUpgrades = tagUpgradeInfo.Metadata.Previous
+	}
+	for _, previousTag := range supportedUpgrades {
+		platform := platformDistribution.Get()
+		previousReleasePullSpec := generatePullSpec(previousTag, c.architecture)
+		klog.V(4).Infof("Testing upgrade from %q to %q on %q", previousReleasePullSpec, pullSpec, platform)
+		jobLabels := map[string]string{
+			releasecontroller.ReleaseLabelVerify:  "true",
+			releasecontroller.ReleaseLabelPayload: releaseTag.Name,
+		}
+		name := fmt.Sprintf("upgrade-from-%s", previousTag)
+		jobNameSuffix := platform
+		verifyType := releasecontroller.ReleaseVerification{
+			Upgrade: true,
+			ProwJob: jobs[platform],
+		}
+		_, err := c.ensureProwJobForReleaseTag(release, name, jobNameSuffix, verifyType, releaseTag, previousTag, previousReleasePullSpec, jobLabels)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func generatePullSpec(version, architecture string) string {
+	arch := architecture
+	switch architecture {
+	case "amd64":
+		arch = "x86_64"
+	case "arm64":
+		arch = "aarch64"
+	}
+	return fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:%s-%s", version, arch)
+}
+
+func getUpgradeProwJobs(release *releasecontroller.Release) ([]string, map[string]*releasecontroller.ProwJobVerification) {
+	var keys []string
+	prowJobs := make(map[string]*releasecontroller.ProwJobVerification)
+	for key, value := range release.Config.Upgrade {
+		if value.Disabled {
+			continue
+		}
+		keys = append(keys, key)
+		if value.ProwJob != nil {
+			prowJobs[key] = value.ProwJob
+		}
+	}
+	return keys, prowJobs
+}


### PR DESCRIPTION
This PR adds the ability, for the release-controller, to automatically launch upgrade jobs, evenly distributed across our various clouds, for each of the `upgrades` defined in `Stable` releases.

The upgrade job definitions are part of the standard Release Configurations and will only be executed when defined for a `Stable` stream, like: https://github.com/openshift/release/blob/master/core-services/release-controller/_releases/release-ocp-4.y-stable.json

The upgrade jobs are defined in their own stanza, where the name is the cloud provider of the job and the prowjob should point to a valid `ci-operator` prowjob definition. 

For `release-ocp-4.y-stable.json`, the values will be:
```
  "upgrade": {
    "aws": {
      "prowJob":{"name":"release-openshift-origin-installer-e2e-aws-upgrade"}
    },  
    "azure": {
      "prowJob":{"name":"release-openshift-origin-installer-e2e-azure-upgrade"}
    },  
    "gcp": {
      "prowJob":{"name":"release-openshift-origin-installer-e2e-gcp-upgrade"}
    }   
  }
```

For the `4.11.0` release, which has 20 upgrade edges defined:
```
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.0-x86_64 -o json | jq .metadata.previous
[
  "4.10.16",
  "4.10.17",
  "4.10.18",
  "4.10.20",
  "4.10.21",
  "4.10.22",
  "4.10.23",
  "4.10.24",
  "4.10.25",
  "4.10.26",
  "4.11.0-fc.0",
  "4.11.0-fc.3",
  "4.11.0-rc.0",
  "4.11.0-rc.1",
  "4.11.0-rc.2",
  "4.11.0-rc.3",
  "4.11.0-rc.4",
  "4.11.0-rc.5",
  "4.11.0-rc.6",
  "4.11.0-rc.7"
]
```
The release-controller will create 20 prowjobs, evenly distributed across the 3 cloud providers (`aws`, `azure`, `gcp`), to test each of the upgrade edges:

| From | To | Cloud |
| ------- | ------- | ------- | 
| 4.10.16 | 4.11.0 | aws |
| 4.10.17 | 4.11.0 | azure |
| 4.10.18 | 4.11.0 | gcp |
| 4.10.20 | 4.11.0 | aws |
| 4.10.21 | 4.11.0 | azure |
...

Jira Story: https://issues.redhat.com/browse/OCPCRT-32

Follow on PR to enable upgrade jobs: https://github.com/openshift/release/pull/31461