### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 /release-controller
 /release-controller-api
 /release-payload-controller


### PR DESCRIPTION
Accidentally committed my goland files on the first attempt of: https://github.com/openshift/release-controller/pull/440. We should have this in the `.gitignore`.