### PR TITLE
Enabling sampling of the supported upgrade tests

### DIFF
--- a/cmd/release-controller/sync_upgrade_test.go
+++ b/cmd/release-controller/sync_upgrade_test.go
@@ -1,0 +1,760 @@
+package main
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+func TestSortedUpgradesByReleaseMap(t *testing.T) {
+	testCases := []struct {
+		name              string
+		supportedUpgrades []string
+		expected          SortedVersionsMap
+	}{
+		{
+			name: "SingleDigitVersionPadding",
+			supportedUpgrades: []string{
+				"4.10.10",
+				"4.10.11",
+				"4.10.12",
+				"4.10.20",
+				"4.10.21",
+				"4.10.22",
+				"4.10.30",
+				"4.10.31",
+				"4.10.32",
+				"4.10.0",
+				"4.10.1",
+				"4.10.2",
+				"4.9.20",
+				"4.9.21",
+				"4.9.22",
+				"4.9.30",
+				"4.9.31",
+				"4.9.32",
+				"4.9.40",
+				"4.9.41",
+				"4.9.42",
+			},
+			expected: SortedVersionsMap{
+				SortedKeys: []string{
+					"4.09",
+					"4.10",
+				},
+				VersionMap: map[string]SemanticVersions{
+					"4.09": {
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 42,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 41,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 40,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 32,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 31,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 30,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 22,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 21,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 20,
+						},
+					},
+					"4.10": {
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 32,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 31,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 30,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 22,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 21,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 20,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 12,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 11,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 10,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 2,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 0,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "MixedVersions",
+			supportedUpgrades: []string{
+				"4.10.1",
+				"4.10.10",
+				"4.10.11",
+				"4.10.12",
+				"4.10.2",
+				"4.10.20",
+				"4.10.21",
+				"4.10.22",
+				"4.10.3",
+				"4.10.30",
+				"4.10.31",
+				"4.10.32",
+				"4.9.2",
+				"4.9.20",
+				"4.9.21",
+				"4.9.22",
+				"4.9.3",
+				"4.9.30",
+				"4.9.31",
+				"4.9.32",
+				"4.9.4",
+				"4.9.40",
+				"4.9.41",
+				"4.9.42",
+			},
+			expected: SortedVersionsMap{
+				SortedKeys: []string{
+					"4.09",
+					"4.10",
+				},
+				VersionMap: map[string]SemanticVersions{
+					"4.09": {
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 42,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 41,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 40,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 32,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 31,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 30,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 22,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 21,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 20,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 4,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 3,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 2,
+						},
+					},
+					"4.10": {
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 32,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 31,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 30,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 22,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 21,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 20,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 12,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 11,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 10,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 3,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 2,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			results := SortedUpgradesByReleaseMap(tc.supportedUpgrades)
+			if !reflect.DeepEqual(results, tc.expected) {
+				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, results)
+			}
+		})
+	}
+}
+
+func TestSortedVersionsMapSample(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		sampleSize           int
+		randomSeed           int64
+		supportedVersionsMap SortedVersionsMap
+		expected             []string
+	}{
+		{
+			name:       "NotEnoughPreviousReleaseEdges",
+			sampleSize: 3,
+			randomSeed: 1337,
+			supportedVersionsMap: SortedVersionsMap{
+				SortedKeys: []string{
+					"4.10",
+					"4.11",
+				},
+				VersionMap: map[string]SemanticVersions{
+					"4.10": {
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 0,
+						},
+					},
+					"4.11": {
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 10,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 9,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 8,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 7,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 6,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 5,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 4,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 3,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 2,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 0,
+						},
+					},
+				},
+			},
+			expected: []string{
+				// 4.Y-1.z: First N
+				"4.10.1",
+				"4.10.0",
+
+				// 4.y.z: First N
+				"4.11.10",
+				"4.11.9",
+				"4.11.8",
+
+				// 4.y.z: Last N
+				"4.11.2",
+				"4.11.1",
+				"4.11.0",
+
+				// 4.y.z: Random N
+				"4.11.4",
+				"4.11.4",
+				"4.11.3",
+			},
+		},
+		{
+			name:       "NotEnoughReleaseEdges",
+			sampleSize: 3,
+			randomSeed: 1337,
+			supportedVersionsMap: SortedVersionsMap{
+				SortedKeys: []string{
+					"4.10",
+					"4.11",
+				},
+				VersionMap: map[string]SemanticVersions{
+					"4.10": {
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 10,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 9,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 8,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 7,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 6,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 5,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 4,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 3,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 2,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 0,
+						},
+					},
+					"4.11": {
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 0,
+						},
+					},
+				},
+			},
+			expected: []string{
+				// 4.Y-1.z: First N
+				"4.10.10",
+				"4.10.9",
+				"4.10.8",
+
+				// 4.Y-1.z: Last N
+				"4.10.2",
+				"4.10.1",
+				"4.10.0",
+
+				// 4.Y-1.z: Random N
+				"4.10.4",
+				"4.10.4",
+				"4.10.3",
+
+				// 4.y.z: First N
+				"4.11.1",
+				"4.11.0",
+			},
+		},
+		{
+			name:       "NotEnoughEdges",
+			sampleSize: 3,
+			randomSeed: 1337,
+			supportedVersionsMap: SortedVersionsMap{
+				SortedKeys: []string{
+					"4.10",
+					"4.11",
+				},
+				VersionMap: map[string]SemanticVersions{
+					"4.10": {
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 2,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 0,
+						},
+					},
+					"4.11": {
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 11,
+							Patch: 0,
+						},
+					},
+				},
+			},
+			expected: []string{
+				// 4.Y-1.z: First N
+				"4.10.2",
+				"4.10.1",
+				"4.10.0",
+
+				// 4.y.z: First N
+				"4.11.1",
+				"4.11.0",
+			},
+		},
+		{
+			name:       "FullSampleSizeAvailable",
+			sampleSize: 3,
+			randomSeed: 1337,
+			supportedVersionsMap: SortedVersionsMap{
+				SortedKeys: []string{
+					"4.09",
+					"4.10",
+				},
+				VersionMap: map[string]SemanticVersions{
+					"4.09": {
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 42,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 41,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 40,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 32,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 31,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 30,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 22,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 21,
+						},
+						{
+							Major: 4,
+							Minor: 9,
+							Patch: 20,
+						},
+					},
+					"4.10": {
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 32,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 31,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 30,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 22,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 21,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 20,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 12,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 11,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 10,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 2,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 1,
+						},
+						{
+							Major: 4,
+							Minor: 10,
+							Patch: 0,
+						},
+					},
+				},
+			},
+			expected: []string{
+				// 4.Y-1.z: First N
+				"4.9.42",
+				"4.9.41",
+				"4.9.40",
+
+				// 4.Y-1.z: Last N
+				"4.9.22",
+				"4.9.21",
+				"4.9.20",
+
+				// 4.Y-1.z: Random N
+				"4.9.31",
+				"4.9.30",
+				"4.9.30",
+
+				// 4.y.z: First N
+				"4.10.32",
+				"4.10.31",
+				"4.10.30",
+
+				// 4.y.z: Last N
+				"4.10.2",
+				"4.10.1",
+				"4.10.0",
+
+				// 4.y.z: Random N
+				"4.10.10",
+				"4.10.20",
+				"4.10.11",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Forcing static random seed for reproducibility
+			random = rand.New(rand.NewSource(tc.randomSeed))
+			results := tc.supportedVersionsMap.Sample(tc.sampleSize)
+			if !reflect.DeepEqual(results, tc.expected) {
+				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, results)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This logic will scale down the number of support upgrade tests, performed by the release-controller, for `Stable` payloads by taking a sample of the upgrades as follows:
Currently, for 4.10.31, there are 55 `previous` upgrades:
``` bash
$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.10.31-x86_64 -o json | jq '.metadata.previous'
[
  "4.10.10",
  "4.10.11",
  "4.10.12",
  "4.10.13",
  "4.10.14",
  "4.10.15",
  "4.10.16",
  "4.10.17",
  "4.10.18",
  "4.10.20",
  "4.10.21",
  "4.10.22",
  "4.10.23",
  "4.10.24",
  "4.10.25",
  "4.10.26",
  "4.10.27",
  "4.10.28",
  "4.10.29",
  "4.10.3",
  "4.10.30",
  "4.10.4",
  "4.10.5",
  "4.10.6",
  "4.10.7",
  "4.10.8",
  "4.10.9",
  "4.9.19",
  "4.9.21",
  "4.9.22",
  "4.9.23",
  "4.9.24",
  "4.9.25",
  "4.9.26",
  "4.9.27",
  "4.9.28",
  "4.9.29",
  "4.9.30",
  "4.9.31",
  "4.9.32",
  "4.9.33",
  "4.9.34",
  "4.9.35",
  "4.9.36",
  "4.9.37",
  "4.9.38",
  "4.9.39",
  "4.9.40",
  "4.9.41",
  "4.9.42",
  "4.9.43",
  "4.9.44",
  "4.9.45",
  "4.9.46",
  "4.9.47"
]
```
Instead of running 55 jobs, this logic will return the following (with the default sample size of 3):
4.Y-1.z -> 4.9
First:
```
    "4.9.47",
    "4.9.46",
    "4.9.45",
```
Last:
```
    "4.9.22",
    "4.9.21",
    "4.9.19",
```
Random selection:
```
    "4.9.42",
    "4.9.44",
    "4.9.34",
```
4.Y.Z -> 4.10
First:
```
    "4.10.30",
    "4.10.29",
    "4.10.28",
```
Last:
```
    "4.10.5",
    "4.10.4",
    "4.10.3",
```
Random selection:
```
    "4.10.9",
    "4.10.6",
    "4.10.26"
```
Basically, with a sample size of 3, the release-controller would only produce 18 jobs per release.