### PR TITLE
Ensuring repeatable random ordering

### DIFF
--- a/cmd/release-controller/sync_upgrade_test.go
+++ b/cmd/release-controller/sync_upgrade_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"math/rand"
 	"reflect"
 	"testing"
 )
@@ -330,92 +329,28 @@ func TestSortedUpgradesByReleaseMap(t *testing.T) {
 
 func TestSortedVersionsMapSample(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		sampleSize           int
-		randomSeed           int64
-		supportedVersionsMap SortedVersionsMap
-		expected             []string
+		name              string
+		sampleSize        int
+		supportedUpgrades []string
+		expected          []string
 	}{
 		{
 			name:       "NotEnoughPreviousReleaseEdges",
 			sampleSize: 3,
-			randomSeed: 1337,
-			supportedVersionsMap: SortedVersionsMap{
-				SortedKeys: []string{
-					"4.10",
-					"4.11",
-				},
-				VersionMap: map[string]SemanticVersions{
-					"4.10": {
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 0,
-						},
-					},
-					"4.11": {
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 10,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 9,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 8,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 7,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 6,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 5,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 4,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 3,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 2,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 0,
-						},
-					},
-				},
+			supportedUpgrades: []string{
+				"4.10.1",
+				"4.10.0",
+				"4.11.10",
+				"4.11.9",
+				"4.11.8",
+				"4.11.7",
+				"4.11.6",
+				"4.11.5",
+				"4.11.4",
+				"4.11.3",
+				"4.11.2",
+				"4.11.1",
+				"4.11.0",
 			},
 			expected: []string{
 				// 4.Y-1.z: First N
@@ -433,91 +368,28 @@ func TestSortedVersionsMapSample(t *testing.T) {
 				"4.11.0",
 
 				// 4.y.z: Random N
-				"4.11.4",
-				"4.11.4",
 				"4.11.3",
+				"4.11.5",
+				"4.11.7",
 			},
 		},
 		{
 			name:       "NotEnoughReleaseEdges",
 			sampleSize: 3,
-			randomSeed: 1337,
-			supportedVersionsMap: SortedVersionsMap{
-				SortedKeys: []string{
-					"4.10",
-					"4.11",
-				},
-				VersionMap: map[string]SemanticVersions{
-					"4.10": {
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 10,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 9,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 8,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 7,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 6,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 5,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 4,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 3,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 2,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 0,
-						},
-					},
-					"4.11": {
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 0,
-						},
-					},
-				},
+			supportedUpgrades: []string{
+				"4.10.10",
+				"4.10.9",
+				"4.10.8",
+				"4.10.7",
+				"4.10.6",
+				"4.10.5",
+				"4.10.4",
+				"4.10.3",
+				"4.10.2",
+				"4.10.1",
+				"4.10.0",
+				"4.11.1",
+				"4.11.0",
 			},
 			expected: []string{
 				// 4.Y-1.z: First N
@@ -531,9 +403,9 @@ func TestSortedVersionsMapSample(t *testing.T) {
 				"4.10.0",
 
 				// 4.Y-1.z: Random N
-				"4.10.4",
-				"4.10.4",
 				"4.10.3",
+				"4.10.4",
+				"4.10.5",
 
 				// 4.y.z: First N
 				"4.11.1",
@@ -543,43 +415,12 @@ func TestSortedVersionsMapSample(t *testing.T) {
 		{
 			name:       "NotEnoughEdges",
 			sampleSize: 3,
-			randomSeed: 1337,
-			supportedVersionsMap: SortedVersionsMap{
-				SortedKeys: []string{
-					"4.10",
-					"4.11",
-				},
-				VersionMap: map[string]SemanticVersions{
-					"4.10": {
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 2,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 0,
-						},
-					},
-					"4.11": {
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 11,
-							Patch: 0,
-						},
-					},
-				},
+			supportedUpgrades: []string{
+				"4.10.2",
+				"4.10.1",
+				"4.10.0",
+				"4.11.1",
+				"4.11.0",
 			},
 			expected: []string{
 				// 4.Y-1.z: First N
@@ -595,123 +436,28 @@ func TestSortedVersionsMapSample(t *testing.T) {
 		{
 			name:       "FullSampleSizeAvailable",
 			sampleSize: 3,
-			randomSeed: 1337,
-			supportedVersionsMap: SortedVersionsMap{
-				SortedKeys: []string{
-					"4.09",
-					"4.10",
-				},
-				VersionMap: map[string]SemanticVersions{
-					"4.09": {
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 42,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 41,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 40,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 32,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 31,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 30,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 22,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 21,
-						},
-						{
-							Major: 4,
-							Minor: 9,
-							Patch: 20,
-						},
-					},
-					"4.10": {
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 32,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 31,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 30,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 22,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 21,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 20,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 12,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 11,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 10,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 2,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 1,
-						},
-						{
-							Major: 4,
-							Minor: 10,
-							Patch: 0,
-						},
-					},
-				},
+			supportedUpgrades: []string{
+				"4.9.42",
+				"4.9.41",
+				"4.9.40",
+				"4.9.32",
+				"4.9.31",
+				"4.9.30",
+				"4.9.22",
+				"4.9.21",
+				"4.9.20",
+				"4.10.32",
+				"4.10.31",
+				"4.10.30",
+				"4.10.22",
+				"4.10.21",
+				"4.10.20",
+				"4.10.12",
+				"4.10.11",
+				"4.10.10",
+				"4.10.2",
+				"4.10.1",
+				"4.10.0",
 			},
 			expected: []string{
 				// 4.Y-1.z: First N
@@ -725,8 +471,8 @@ func TestSortedVersionsMapSample(t *testing.T) {
 				"4.9.20",
 
 				// 4.Y-1.z: Random N
+				"4.9.32",
 				"4.9.31",
-				"4.9.30",
 				"4.9.30",
 
 				// 4.y.z: First N
@@ -740,18 +486,18 @@ func TestSortedVersionsMapSample(t *testing.T) {
 				"4.10.0",
 
 				// 4.y.z: Random N
-				"4.10.10",
-				"4.10.20",
 				"4.10.11",
+				"4.10.10",
+				"4.10.22",
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Forcing static random seed for reproducibility
-			random = rand.New(rand.NewSource(tc.randomSeed))
-			results := tc.supportedVersionsMap.Sample(tc.sampleSize)
+			sortedUpgrades := SortedUpgradesByReleaseMap(tc.supportedUpgrades)
+			seed := int64(supportedUpgradesSeed(tc.supportedUpgrades))
+			results := sortedUpgrades.Sample(seed, 3)
 			if !reflect.DeepEqual(results, tc.expected) {
 				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, results)
 			}


### PR DESCRIPTION
This PR generates a unique seed based on the `supportedUpgrades` for a given release.  This provides repeatable ordering, of the generated jobs, to prevent us from launching jobs for all the possible variations that are *not* part of the `First/Last` samples for the `supportedUpgrades`.