### PR TITLE
Updating kubeconfig watcher logic

### DIFF
--- a/cmd/release-controller-api/main.go
+++ b/cmd/release-controller-api/main.go
@@ -334,7 +334,7 @@ func setupKubeconfigWatches(o *options) error {
 	if err != nil {
 		return fmt.Errorf("failed to set up watcher: %w", err)
 	}
-	for _, candidate := range []string{o.ProwJobKubeconfig, o.NonProwJobKubeconfig} {
+	for _, candidate := range []string{o.ProwJobKubeconfig, o.NonProwJobKubeconfig, o.ReleasesKubeconfig, o.ToolsKubeconfig} {
 		if _, err := os.Stat(candidate); err != nil {
 			continue
 		}

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -691,7 +691,7 @@ func setupKubeconfigWatches(o *options) error {
 	if err != nil {
 		return fmt.Errorf("failed to set up watcher: %w", err)
 	}
-	for _, candidate := range []string{o.ProwJobKubeconfig, o.NonProwJobKubeconfig} {
+	for _, candidate := range []string{o.ProwJobKubeconfig, o.NonProwJobKubeconfig, o.ReleasesKubeconfig, o.ToolsKubeconfig} {
 		if _, err := os.Stat(candidate); err != nil {
 			continue
 		}


### PR DESCRIPTION
In reviewing the kubeconfig watcher logic, I noticed that a couple of the kubeconfigs were not actually being watched.  This PR adds the missing kubeconfigs to the watcher.