### PR TITLE
add a requirements file for `release-tool.py`

### DIFF
--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,0 +1,1 @@
+openshift-client


### PR DESCRIPTION
This PR adds a requirements.txt file for `release-tool`. 
The tool has a single requirement, but since there is another [openshift](https://pypi.org/project/openshift/) module on `pypi` (besides the [required](https://pypi.org/project/openshift-client/) one), it can be confusing. 