### PR TITLE
Adding support for carrying ART annotations forward

### DIFF
--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -514,9 +514,6 @@ const (
 	// is considered an input image stream for creating releases.
 	ReleaseAnnotationConfig = "release.openshift.io/config"
 
-	// ReleaseAnnotationInconsistency an imagestream with this annotation indicates an inconsistency
-	ReleaseAnnotationInconsistency = "release.openshift.io/inconsistency"
-
 	ReleaseAnnotationKeep              = "release.openshift.io/keep"
 	ReleaseAnnotationGeneration        = "release.openshift.io/generation"
 	ReleaseAnnotationSource            = "release.openshift.io/source"
@@ -559,6 +556,18 @@ const (
 
 	// ReleaseAnnotationArchitecture indicates the architecture of the release
 	ReleaseAnnotationArchitecture = "release.openshift.io/architecture"
+
+	// The following annotations are provided by ART and are intended to be carried forward from the input imagestream
+	// into the release-controller generated Release mirror.
+
+	// ReleaseAnnotationBuildURL the URL of the corresponding ART build that produced this Release
+	ReleaseAnnotationBuildURL = "release.openshift.io/build-url"
+
+	// ReleaseAnnotationRuntimeBrewEvent the Brew event number of the corresponding ART build that produced this Release
+	ReleaseAnnotationRuntimeBrewEvent = "release.openshift.io/runtime-brew-event"
+
+	// ReleaseAnnotationInconsistency an imagestream with this annotation indicates an inconsistency
+	ReleaseAnnotationInconsistency = "release.openshift.io/inconsistency"
 
 	// ReleaseLabelVerify indicates the ProwJob is for release verification
 	ReleaseLabelVerify = "release.openshift.io/verify"


### PR DESCRIPTION
ART has requested that we interrogate the inbound imagestreams for a specific set of Annotations and if/when present we carry them forward into the release mirror that the release-controller creates.  This PR adds the necessary support as well as the list of currently supported Annotations:
1. `release.openshift.io/build-url`
2. `release.openshift.io/runtime-brew-event`
3. `release.openshift.io/inconsistency`
