### PR TITLE
jira: don't comment on github errors

### DIFF
--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -103,7 +103,7 @@ func (c *Verifier) verifyExtPRs(issue *jiraBaseClient.Issue, extPRs []pr, errs [
 			unlabeledPRs, newErr = c.ghUnlabeledPRs(extPR)
 			if newErr != nil {
 				errs = append(errs, newErr)
-				issueErrs = append(issueErrs, newErr)
+				return false, "", errs, false
 			}
 		}
 	}


### PR DESCRIPTION
This PR changes the behavior of the jira verification to not comment if an error is encountered getting issue labels from github. It also contains various changes and improvements to the jira_test file.