### PR TITLE
fix on locateLatest, when there is a single nightly

### DIFF
--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -506,6 +506,9 @@ func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lis
 		// find all accepted tags, then sort by semantic version
 		tags := UnsortedSemanticReleaseTags(r, ReleasePhaseAccepted)
 		sort.Sort(tags)
+		if len(tags) == 1 {
+			return r, tags[0].Tag, nil
+		}
 		for _, ver := range tags {
 			if constraint != nil && (ver.Version == nil || !constraint(*ver.Version)) {
 				continue


### PR DESCRIPTION
The logic here fails if there is a single tag:

```go
		for _, ver := range tags {
			if constraint != nil && (ver.Version == nil || !constraint(*ver.Version)) {
				continue
			}
			if relativeIndex > 0 {
				relativeIndex--
				continue
			}
			return r, ver.Tag, nil
		}
		return nil, nil, ErrStreamTagNotFound
```
In the first iteration, it will decrease the `relativeIndex`, but it will exit the loop after, since `len(tags)==1`