### PR TITLE
Updating ReleasePayloads when ReleaseConfigs are updated after initial creation

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -165,6 +165,7 @@ func NewController(
 	architecture string,
 	artSuffix string,
 	releasePayloadClient releasepayloadclient.ReleasePayloadsGetter,
+	releasePayloadInformer releasepayloadinformer.ReleasePayloadInformer,
 ) *Controller {
 
 	// log events at v2 and send them to the server

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -378,6 +378,10 @@ func (o *options) Run() error {
 		klog.Fatal(err)
 	}
 
+	releasePayloadInformerFactory := releasepayloadinformers.NewSharedInformerFactory(releasePayloadClient, time.Hour*24)
+	releasePayloadInformer := releasePayloadInformerFactory.Release().V1alpha1().ReleasePayloads()
+	hasSynced = append(hasSynced, releasePayloadInformer.Informer().HasSynced)
+
 	c := NewController(
 		client.CoreV1(),
 		imageClient.ImageV1(),
@@ -395,6 +399,7 @@ func (o *options) Run() error {
 		architecture,
 		o.ARTSuffix,
 		releasePayloadClient.ReleaseV1alpha1(),
+		releasePayloadInformer,
 	)
 
 	if o.VerifyJira {
@@ -467,6 +472,7 @@ func (o *options) Run() error {
 	}
 
 	batchFactory.Start(stopCh)
+	releasePayloadInformerFactory.Start(stopCh)
 
 	// register the releasepayload namespaces
 	for _, ns := range o.ReleaseNamespaces {

--- a/cmd/release-controller/sync_analysis.go
+++ b/cmd/release-controller/sync_analysis.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
 	"github.com/openshift/release-controller/pkg/release-controller"
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"time"
@@ -13,7 +14,7 @@ const (
 	defaultAggregateProwJobName = "release-openshift-release-analysis-aggregator"
 )
 
-func (c *Controller) launchAnalysisJobs(release *releasecontroller.Release, verifyName string, verifyType releasecontroller.ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string) error {
+func (c *Controller) launchAnalysisJobs(release *releasecontroller.Release, verifyName string, verifyType releasecontroller.ReleaseVerification, releaseTag *imagev1.TagReference, previousTag, previousReleasePullSpec string, payload *v1alpha1.ReleasePayload) error {
 	jobLabels := map[string]string{
 		"release.openshift.io/analysis":       releaseTag.Name,
 		releasecontroller.ReleaseLabelPayload: releaseTag.Name,
@@ -26,7 +27,7 @@ func (c *Controller) launchAnalysisJobs(release *releasecontroller.Release, veri
 	for i := 0; i < verifyType.AggregatedProwJob.AnalysisJobCount; i++ {
 		// Postfix the name to differentiate it from the aggregator job
 		jobNameSuffix := fmt.Sprintf("analysis-%d", i)
-		_, err := c.ensureProwJobForReleaseTag(release, verifyName, jobNameSuffix, *copied, releaseTag, previousTag, previousReleasePullSpec, jobLabels)
+		_, err := c.ensureProwJobForReleaseTag(release, verifyName, jobNameSuffix, *copied, releaseTag, previousTag, previousReleasePullSpec, jobLabels, payload)
 		if err != nil {
 			return err
 		}

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -760,3 +760,316 @@ func TestNewReleasePayload(t *testing.T) {
 		})
 	}
 }
+
+func TestAddVerificationJobs(t *testing.T) {
+	testCases := []struct {
+		name             string
+		payload          *v1alpha1.ReleasePayload
+		verificationName string
+		definition       releasecontroller.ReleaseVerification
+		expected         *v1alpha1.ReleasePayload
+	}{
+		{
+			name: "DisabledVerificationJob",
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			verificationName: "disabled-job",
+			definition: releasecontroller.ReleaseVerification{
+				Disabled: true,
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "InformingVerificationJob",
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			verificationName: "informing-job",
+			definition: releasecontroller.ReleaseVerification{
+				Optional: true,
+				ProwJob: &releasecontroller.ProwJobVerification{
+					Name: "periodic-ci-openshift-release-master-nightly-e2e-aws-sdn-serial",
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "informing-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-e2e-aws-sdn-serial",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "BlockingVerificationJob",
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			verificationName: "blocking-job",
+			definition: releasecontroller.ReleaseVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
+					Name: "periodic-ci-openshift-release-master-nightly-e2e-aws-sdn-serial",
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "blocking-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-e2e-aws-sdn-serial",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "SortedInsert",
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-azure-ovn-upgrade-4.12-micro",
+								CIConfigurationJobName: "aggregated-azure-ovn-upgrade-4.12-micro-release-openshift-release-analysis-aggregator",
+							},
+							{
+								CIConfigurationName:    "aggregated-gcp-ovn-upgrade-4.12-minor",
+								CIConfigurationJobName: "aggregated-gcp-ovn-upgrade-4.12-minor-release-openshift-release-analysis-aggregator",
+							},
+							{
+								CIConfigurationName:    "gcp-sdn-serial",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-sdn-serial",
+								MaxRetries:             3,
+							},
+							{
+								CIConfigurationName:    "gcp-single-node",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-single-node",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			verificationName: "blocking-job",
+			definition: releasecontroller.ReleaseVerification{
+				ProwJob: &releasecontroller.ProwJobVerification{
+					Name: "periodic-ci-openshift-release-master-nightly-e2e-gcp-sdn-serial",
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "aggregated-azure-ovn-upgrade-4.12-micro",
+								CIConfigurationJobName: "aggregated-azure-ovn-upgrade-4.12-micro-release-openshift-release-analysis-aggregator",
+							},
+							{
+								CIConfigurationName:    "aggregated-gcp-ovn-upgrade-4.12-minor",
+								CIConfigurationJobName: "aggregated-gcp-ovn-upgrade-4.12-minor-release-openshift-release-analysis-aggregator",
+							},
+							{
+								CIConfigurationName:    "blocking-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-e2e-gcp-sdn-serial",
+							},
+							{
+								CIConfigurationName:    "gcp-sdn-serial",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-sdn-serial",
+								MaxRetries:             3,
+							},
+							{
+								CIConfigurationName:    "gcp-single-node",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-single-node",
+							},
+						},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			AddVerificationJobs(tc.payload, map[string]releasecontroller.ReleaseVerification{tc.verificationName: tc.definition})
+			if !reflect.DeepEqual(tc.payload, tc.expected) {
+				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, tc.payload)
+			}
+		})
+	}
+}

--- a/pkg/releasepayload/v1alpha1helpers/helpers.go
+++ b/pkg/releasepayload/v1alpha1helpers/helpers.go
@@ -23,3 +23,18 @@ func CanonicalizeJobRunResults(jobs []v1alpha1.JobStatus) {
 		sort.Sort(jobrunresult.ByCoordinatesName(results.JobRunResults))
 	}
 }
+
+// ByCIConfigurationCIConfigurationName sorts a list of CIConfiguration's by their CIConfigurationName
+type ByCIConfigurationCIConfigurationName []v1alpha1.CIConfiguration
+
+func (in ByCIConfigurationCIConfigurationName) Less(i, j int) bool {
+	return in[i].CIConfigurationName < in[j].CIConfigurationName
+}
+
+func (in ByCIConfigurationCIConfigurationName) Len() int {
+	return len(in)
+}
+
+func (in ByCIConfigurationCIConfigurationName) Swap(i, j int) {
+	in[i], in[j] = in[j], in[i]
+}


### PR DESCRIPTION
If/When a `ReleaseConfig` is modified, and the corresponding stream has any releases that are currently in-flight (i.e. `Ready`), the release-controller will automatically create new prowjobs for any verification tests that may have been added.  This PR adds code to ensure that the respective `ReleasePayload` gets updated with the new job(s).