### PR TITLE
Adding support for parsing `EC` releases

### DIFF
--- a/pkg/releasepayload/utils/release-verification-job-details.go
+++ b/pkg/releasepayload/utils/release-verification-job-details.go
@@ -75,7 +75,7 @@ func parsePreRelease(prerelease []semver.PRVersion) (*PreReleaseDetails, error) 
 			details.Build = fmt.Sprintf("%d", prerelease[0].VersionNum)
 		case false:
 			switch prerelease[0].VersionStr {
-			case "fc", "rc":
+			case "ec", "fc", "rc":
 				details.Stream = StreamCandidate
 				details.Build = prerelease[0].VersionStr
 			default:
@@ -106,7 +106,7 @@ func parsePreRelease(prerelease []semver.PRVersion) (*PreReleaseDetails, error) 
 			details.Build = fmt.Sprintf("%d", prerelease[0].VersionNum)
 		case false:
 			switch prerelease[0].VersionStr {
-			case "fc", "rc":
+			case "ec", "fc", "rc":
 				details.Stream = StreamCandidate
 				splitVersion(generateCIConfigurationName(prerelease), details)
 				return details, nil

--- a/pkg/releasepayload/utils/release-verification-job-details_test.go
+++ b/pkg/releasepayload/utils/release-verification-job-details_test.go
@@ -283,6 +283,40 @@ func TestParseReleaseVerificationJobName(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:        "EngineeringCandidateJob",
+			prowjobName: "4.13.0-ec.1-aws-sdn-serial",
+			want: &ReleaseVerificationJobDetails{
+				X: 4,
+				Y: 13,
+				Z: 0,
+				PreReleaseDetails: &PreReleaseDetails{
+					Build:               "ec.1",
+					Stream:              "Candidate",
+					Timestamp:           "",
+					CIConfigurationName: "aws-sdn-serial",
+					Count:               "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "EngineeringCandidateJobWithRetries",
+			prowjobName: "4.13.0-ec.1-aws-sdn-serial-2",
+			want: &ReleaseVerificationJobDetails{
+				X: 4,
+				Y: 13,
+				Z: 0,
+				PreReleaseDetails: &PreReleaseDetails{
+					Build:               "ec.1",
+					Stream:              "Candidate",
+					Timestamp:           "",
+					CIConfigurationName: "aws-sdn-serial",
+					Count:               "2",
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The `4-dev-preview` releases have not been processing their prowjobs appropriately because the logic was not aware of the `ec` naming convention. 