### PR TITLE
OCPCRT-174: pkg/jira: ignore issues not ON_QA

### DIFF
--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -270,7 +270,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "In Progress",
-				message: "Fix included in accepted release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- issue is not in ON_QA status\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				message: "",
 			},
 		},
 		{


### PR DESCRIPTION
This PR changes the behavior of the jira verifier to ignore all issues that are not marked as `ON_QA` in jira. This previous behavior was legacy functionality that was done due to an issue in ART's automation that would mark bugs in Bugzilla as `ON_QA` very late, causing the issue to be ignored by the `release-controller`. The release-controller would make a comment so it was clear that the problem was not from the `release-controller` side. A side-effect is that this can cause the `release-controller` to make incorrect comments on bugs where not all PRs have merged. This shouldn't be an issue anymore, so the `release-controller` will now assume that all bugs are marked as `ON_QA` promptly.