### PR TITLE
Validate JSON change log

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -199,7 +199,7 @@ func (r *ExecReleaseInfo) ReleaseInfo(image string) (string, error) {
 	return out.String(), nil
 }
 
-func (r *ExecReleaseInfo) ChangeLog(from, to string, json bool) (string, error) {
+func (r *ExecReleaseInfo) ChangeLog(from, to string, isJson bool) (string, error) {
 	if _, err := imagereference.Parse(from); err != nil {
 		return "", fmt.Errorf("%s is not an image reference: %v", from, err)
 	}
@@ -211,7 +211,7 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string, json bool) (string, error) 
 	}
 
 	cmd := []string{"oc", "adm", "release", "info", "--changelog=/tmp/git/", from, to}
-	if json {
+	if isJson {
 		cmd = append(cmd, "--output=json")
 	}
 	klog.V(4).Infof("Running changelog command: %s", strings.Join(cmd, " "))
@@ -239,7 +239,12 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string, json bool) (string, error) 
 		}
 		return "", fmt.Errorf("could not generate a changelog: %v", msg)
 	}
-
+	if isJson {
+		var changeLog ChangeLog
+		if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {
+			return "", err
+		}
+	}
 	return out.String(), nil
 }
 

--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -242,6 +242,7 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string, isJson bool) (string, error
 	if isJson {
 		var changeLog ChangeLog
 		if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {
+			klog.Warningf("invalid changelog JSON: %v", err)
 			return "", err
 		}
 	}


### PR DESCRIPTION
For reasons unknown at present, the change-log JSON may sometimes be incomplete. 
As of now, we are not performing any validation on the returned data. This incomplete data is being cached indefinitely, leading to this error message: `unexpected end of JSON input`, when the JSON is processed later on. 
