### PR TITLE
Fixing broken imagestreamtag generation logic

### DIFF
--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -49,7 +49,11 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 		return nil, err
 	}
 
-	return &is.Spec.Tags[len(is.Spec.Tags)-1], nil
+	isTag := releasecontroller.FindSpecTag(is.Spec.Tags, tag.Name)
+	if isTag == nil {
+		return nil, fmt.Errorf("unable to locate imagestreamtag: %s/%s:%s", target.Namespace, target.Name, tag.Name)
+	}
+	return isTag, nil
 }
 
 func (c *Controller) replaceReleaseTagWithNext(release *releasecontroller.Release, tag *imagev1.TagReference) error {


### PR DESCRIPTION
In looking through the logs, I observed unexpected messages like:
`Mirroring release images in ocp/4.11 to ocp/4.114.9.9`
followed eventually by a corresponding:
`Error syncing {ocp 4.11}: mirror hash for "4.9.9" does not match, release cannot be created`
and lastly:
`Event(v1.ObjectReference{Kind:"ImageStream", Namespace:"ocp", Name:"4.11", UID:"a50994e1-06bf-4949-9e5a-3fce657b6f58", APIVersion:"image.openshift.io/v1", ResourceVersion:"2792915688", FieldPath:""}): type: 'Warning' reason: 'UnableToProcessRelease' mirror hash for "4.9.9" does not match, release cannot be created`
This lead to the discovery of a handful of extra imagestreams like:
```
4.144.9.9
4.134.9.9
4.124.9.9
<and so on>
```
It turns out that the existing logic always returned the "last" `is.spec.tag`.  This worked until we crossed over into `4.10` and beyond.  Since that point, the "last" imagestreamtag has essentially been `4.9.9`. 
This PR should resolve the issue.
Once it merges, I will go ahead and prune the extraneous imagestreams.