### PR TITLE
bugfix on httpReleaseInfo lastMinor function

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1141,7 +1141,7 @@ func jumpLinks(data httpFeatureData) string {
 	return sb.String()
 }
 
-func nextMinor(tagInfo *releaseTagInfo) string {
+func previousMinor(tagInfo *releaseTagInfo) string {
 	var v semver.Versions
 	for _, release := range tagInfo.Info.Stable.Releases {
 		for _, version := range release.Versions {
@@ -1149,10 +1149,10 @@ func nextMinor(tagInfo *releaseTagInfo) string {
 		}
 	}
 	sort.Sort(sort.Reverse(v))
-	return findLastMinor(v, tagInfo.Tag)
+	return findPreviousMinor(v, tagInfo.Tag)
 }
 
-func findLastMinor(versions semver.Versions, tag string) string {
+func findPreviousMinor(versions semver.Versions, tag string) string {
 	parsedTag, err := releasecontroller.SemverParseTolerant(tag)
 	if parsedTag.Minor == 0 {
 		return ""
@@ -1166,7 +1166,7 @@ func findLastMinor(versions semver.Versions, tag string) string {
 			return v.String()
 		}
 	}
-	return findLastMinor(versions, fmt.Sprintf("%d.%d", tagMajor, tagMinor))
+	return findPreviousMinor(versions, fmt.Sprintf("%d.%d", tagMajor, tagMinor))
 }
 
 func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
@@ -1204,7 +1204,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	fmt.Fprintf(w, "<p><a href=\"/\">Back to index</a></p>\n")
 
-	if nextMinor(tagInfo) == "" {
+	if previousMinor(tagInfo) == "" {
 		fmt.Fprintf(w, "<div class=\"mb-custom\">"+
 			"<div class=\"row align-items-center\">"+
 			"<div class=\"col\">"+
@@ -1227,7 +1227,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			"<p class=\"m-0\"><a href=\"/features/%s?from=%s\">New features since version %s</a></p>"+
 			"</div>"+
 			"</div>"+
-			"</div>", template.HTMLEscapeString(tagInfo.Tag), template.HTMLEscapeString(tagInfo.Tag), nextMinor(tagInfo), nextMinor(tagInfo))
+			"</div>", template.HTMLEscapeString(tagInfo.Tag), template.HTMLEscapeString(tagInfo.Tag), previousMinor(tagInfo), previousMinor(tagInfo))
 	}
 
 	switch tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase] {

--- a/cmd/release-controller-api/http_test.go
+++ b/cmd/release-controller-api/http_test.go
@@ -79,7 +79,7 @@ func TestNextMinor(t *testing.T) {
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualTag := nextMinor(&tc.tagInfo)
+			actualTag := previousMinor(&tc.tagInfo)
 			if actualTag != tc.expectedTag {
 				t.Errorf("Expected tag %s, got %s", tc.expectedTag, actualTag)
 			}


### PR DESCRIPTION
The `findLastMinor` recursive call results in an infinite loop, in case this condition is never met:
```golang
if v.Major == tagMajor && v.Minor == tagMinor {
	return v.String()
}
``` 
This results in a stack overflow, whenever an end-of-the-line release change log is accessed (a release that does not have a previous minor).

This PR adds a break condition in the loop. When the minor is = 0, the function will return. 
When accessing an end-of-the-line release, that does not have a previous minor, the above mention condition was never met. 
The problem is with the parsing logic here: 
```golang
parsedTag, err := releasecontroller.SemverParseTolerant(tag)
tagMajor, tagMinor := parsedTag.Major, parsedTag.Minor-1
```
(when tagMinor reaches 0, tagMinor -1 is 18446744073709551615, i.e 0xFFFFFFFFFFFFFFFF, which is the maximum value that can be represented by an uint64). 

This PR also removes the "New features since..." link from the UI when an end-of-the-line version change log is accessed (since there is no previous minor to compare it with).

