### PR TITLE
prefer podman authentication file locations

### DIFF
--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -282,12 +282,14 @@ func newReleaseJobBase(name, cliImage, pullSecretName string) (*batchv1.Job, str
 		prefix = `
 			set -eu
 			mkdir $HOME/.docker/
+			mkdir -p "${XDG_RUNTIME_DIR}"
 			cp -Lf /tmp/pull-secret/* $HOME/.docker/
-			oc registry login
+			oc registry login --to $HOME/.docker/config.json
 			`
 	} else {
 		prefix = `
 			set -eu
+			mkdir -p "${XDG_RUNTIME_DIR}"
 			oc registry login
 			`
 	}
@@ -312,6 +314,7 @@ func newReleaseJobBase(name, cliImage, pullSecretName string) (*batchv1.Job, str
 
 							Env: []corev1.EnvVar{
 								{Name: "HOME", Value: "/tmp"},
+								{Name: "XDG_RUNTIME_DIR", Value: "/tmp/run"},
 							},
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 						},


### PR DESCRIPTION
we want to remove preference for docker auth files in favor of podman ones in https://github.com/openshift/oc/pull/1376. Since openshift/release depends on the cli (oc) to obtain and manipulate images and releases, we need to first merge the changes in https://github.com/openshift/ci-tools/pull/3345 and then here before the changes in oc can be merged. This change was announced in [4.10](https://docs.openshift.com/container-platform/4.10/release_notes/ocp-4-10-release-notes.html#ocp-4-10-oc-commands-obtain-credentials-from-podman-config) and a proper warning was shown when using oc commands that work with registries since then.

- podman ~/.docker/config.json is deprecated in favor of podman authentication file locations (default is ${XDG_RUNTIME_DIR}/containers/auth.json)
- oc registry login will try to write to this location so XDG_RUNTIME_DIR environment variable must be present and the XDG_RUNTIME_DIR directory created/accessible. Places that need to manipulate with ~/.docker/config.json for backwards compatibility reasons should specify --to or --registry-config
- other oc commands that lookup credentials from registry authentication files will first try the podman locations and if the credentials are not found, oc will fallback and check ~/.docker/config.json