### PR TITLE
Legacy Results Processing

### DIFF
--- a/cmd/release-controller/legacy_results.go
+++ b/cmd/release-controller/legacy_results.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+	"time"
+)
+
+func (c *Controller) processLegacyResults(interval time.Duration, stopCh <-chan struct{}) {
+	wait.Until(func() {
+		imageStreams, err := c.releaseLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("Unable to list imagestreams: %v", err)
+			return
+		}
+		for _, stream := range imageStreams {
+			if _, ok := stream.Annotations[releasecontroller.ReleaseAnnotationConfig]; ok {
+				release, err := c.loadReleaseForSync(stream.Namespace, stream.Name)
+				if err != nil || release == nil {
+					klog.Warningf("could not load release for sync for %s/%s", stream.Namespace, stream.Name)
+					continue
+				}
+				if release.Config.As != releasecontroller.ReleaseConfigModeStable {
+					klog.V(4).Infof("Skipping non-stable imagestream: %s/%s", release.Source.Namespace, release.Source.Name)
+					continue
+				}
+				klog.Infof("Adding release imagestream: %s/%s", stream.Namespace, stream.Name)
+				c.addLegacyResultsQueueKey(queueKey{
+					namespace: stream.Namespace,
+					name:      stream.Name,
+				})
+			}
+		}
+	}, interval, stopCh)
+}
+
+func (c *Controller) syncLegacyResults(key queueKey) error {
+	defer func() {
+		if err := recover(); err != nil {
+			panic(err)
+		}
+	}()
+
+	release, err := c.loadReleaseForSync(key.namespace, key.name)
+	if err != nil || release == nil {
+		klog.V(6).Infof("could not load release for sync for %s/%s", key.namespace, key.name)
+		return err
+	}
+
+	if release.Config.As != releasecontroller.ReleaseConfigModeStable {
+		klog.V(4).Infof("Skipping non-stable imagestream: %s/%s", release.Source.Namespace, release.Source.Name)
+		return nil
+	}
+
+	imagestream := release.Source
+
+	for j := range imagestream.Spec.Tags {
+		tag := &imagestream.Spec.Tags[j]
+
+		if tag.From != nil && tag.From.Kind == "ImageStreamTag" {
+			klog.V(4).Infof("Skipping imageStreamTag: %s", tag.Name)
+			continue
+		}
+
+		// Lookup the ReleasePayload resource.  If it exists, then move on
+		_, err := c.releasePayloadLister.ReleasePayloads(key.namespace).Get(tag.Name)
+		if err == nil {
+			klog.V(4).Infof("found releasepayload: %s/%s", key.namespace, tag.Name)
+			continue
+		}
+		// If there is any error other than NotFound, there is a problem
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		klog.V(4).Infof("processing tag: %s/%s:%s", imagestream.Namespace, imagestream.Name, tag.Name)
+
+		// Get the Verification Job definitions
+		verificationJobs, err := releasecontroller.GetVerificationJobs(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, release, tag, c.artSuffix)
+		if err != nil {
+			return err
+		}
+
+		// Ensure the existing state is preserved.  This is a big hammer, but it's the only way we have to guarantee that
+		// the ReleasePayload's status matches the status of the ImageStream's Annotation.
+		releasePayload := newReleasePayload(release, tag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceImageStream)
+		setPayloadOverride(tag, releasePayload)
+
+		// Create the payload
+		payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), releasePayload, metav1.CreateOptions{})
+		switch {
+		case err == nil:
+			klog.V(4).Infof("ReleasePayload: %s/%s created", payload.Namespace, payload.Name)
+			continue
+		case errors.IsAlreadyExists(err):
+			klog.Errorf("Unable to create ReleasePayload because it already exists")
+			continue
+		default:
+			klog.Errorf("unable to create ReleasePayload: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func setPayloadOverride(tag *imagev1.TagReference, releasePayload *v1alpha1.ReleasePayload) {
+	var legacyOverride v1alpha1.ReleasePayloadOverrideType
+	phase, ok := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
+	reason, _ := tag.Annotations[releasecontroller.ReleaseAnnotationReason]
+	message, _ := tag.Annotations[releasecontroller.ReleaseAnnotationMessage]
+	if ok {
+		switch phase {
+		case releasecontroller.ReleasePhaseAccepted:
+			legacyOverride = v1alpha1.ReleasePayloadOverrideAccepted
+		case releasecontroller.ReleasePhaseRejected, releasecontroller.ReleasePhaseFailed:
+			legacyOverride = v1alpha1.ReleasePayloadOverrideRejected
+		default:
+			return
+		}
+		releasePayload.Spec.PayloadOverride = v1alpha1.ReleasePayloadOverride{
+			Override: legacyOverride,
+			Reason:   fmt.Sprintf("LegacyResult(reason=%q,message=%q)", reason, message),
+		}
+	}
+}

--- a/cmd/release-controller/legacy_results_test.go
+++ b/cmd/release-controller/legacy_results_test.go
@@ -1,0 +1,681 @@
+package main
+
+import (
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+func TestSetPayloadOverride(t *testing.T) {
+	testCases := []struct {
+		name     string
+		tag      *imagev1.TagReference
+		payload  *v1alpha1.ReleasePayload
+		expected *v1alpha1.ReleasePayload
+	}{
+		{
+			name: "PhaseAnnotationNotSet",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "AcceptedTag",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase: releasecontroller.ReleasePhaseAccepted,
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "LegacyResult(reason=\"\",message=\"\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "RejectedTag",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase: releasecontroller.ReleasePhaseRejected,
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "LegacyResult(reason=\"\",message=\"\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "PendingTag",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase: releasecontroller.ReleasePhasePending,
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "FailedTag",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase: releasecontroller.ReleasePhaseFailed,
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "LegacyResult(reason=\"\",message=\"\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "FailedTagWithReasonAndMessageAnnotationSet",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase:   releasecontroller.ReleasePhaseFailed,
+					releasecontroller.ReleaseAnnotationReason:  "CreateReleaseFailed",
+					releasecontroller.ReleaseAnnotationMessage: "Could not create the release image",
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "LegacyResult(reason=\"CreateReleaseFailed\",message=\"Could not create the release image\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "ReadyTag",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase: releasecontroller.ReleasePhaseReady,
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "RejectedTagWithReasonAnnotationSet",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase:  releasecontroller.ReleasePhaseRejected,
+					releasecontroller.ReleaseAnnotationReason: "VerificationFailed",
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "LegacyResult(reason=\"VerificationFailed\",message=\"\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "RejectedTagWithMessageAnnotationSet",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase:   releasecontroller.ReleasePhaseRejected,
+					releasecontroller.ReleaseAnnotationMessage: "release verification step failed: gcp-sdn-upgrade-4.10-micro, aws-ovn-upgrade-4.10-minor, azure-sdn-upgrade-4.10-minor, upgrade-minor-aws-ovn, gcp, upgrade, upgrade-minor",
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "LegacyResult(reason=\"\",message=\"release verification step failed: gcp-sdn-upgrade-4.10-micro, aws-ovn-upgrade-4.10-minor, azure-sdn-upgrade-4.10-minor, upgrade-minor-aws-ovn, gcp, upgrade, upgrade-minor\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+		{
+			name: "RejectedTagWithReasonAndMessageAnnotationSet",
+			tag: &imagev1.TagReference{
+				Annotations: map[string]string{
+					releasecontroller.ReleaseAnnotationPhase:   releasecontroller.ReleasePhaseRejected,
+					releasecontroller.ReleaseAnnotationReason:  "VerificationFailed",
+					releasecontroller.ReleaseAnnotationMessage: "release verification step failed: gcp-sdn-upgrade-4.10-micro, aws-ovn-upgrade-4.10-minor, azure-sdn-upgrade-4.10-minor, upgrade-minor-aws-ovn, gcp, upgrade, upgrade-minor",
+				},
+			},
+			payload: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.13.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.13.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.13.0",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "LegacyResult(reason=\"VerificationFailed\",message=\"release verification step failed: gcp-sdn-upgrade-4.10-micro, aws-ovn-upgrade-4.10-minor, azure-sdn-upgrade-4.10-minor, upgrade-minor-aws-ovn, gcp, upgrade, upgrade-minor\")",
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:  []v1alpha1.CIConfiguration{},
+						InformingJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setPayloadOverride(tc.tag, tc.payload)
+			if !reflect.DeepEqual(tc.payload, tc.expected) {
+				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, tc.payload)
+			}
+		})
+	}
+}

--- a/cmd/release-controller/sync_release_payload.go
+++ b/cmd/release-controller/sync_release_payload.go
@@ -17,7 +17,7 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 	if err != nil {
 		return nil, err
 	}
-	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade), metav1.CreateOptions{})
+	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceBuildFarm), metav1.CreateOptions{})
 	if err == nil {
 		klog.V(4).Infof("ReleasePayload: %s/%s created", payload.Namespace, payload.Name)
 		return payload, nil
@@ -28,7 +28,7 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 	return nil, err
 }
 
-func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, prowNamespace string, verificationJobs map[string]releasecontroller.ReleaseVerification, upgradeJobs map[string]releasecontroller.UpgradeVerification) *v1alpha1.ReleasePayload {
+func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, prowNamespace string, verificationJobs map[string]releasecontroller.ReleaseVerification, upgradeJobs map[string]releasecontroller.UpgradeVerification, dataSource v1alpha1.PayloadVerificationDataSource) *v1alpha1.ReleasePayload {
 	payload := v1alpha1.ReleasePayload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -48,9 +48,10 @@ func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, p
 				ProwCoordinates: v1alpha1.ProwCoordinates{Namespace: prowNamespace},
 			},
 			PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
-				BlockingJobs:  []v1alpha1.CIConfiguration{},
-				InformingJobs: []v1alpha1.CIConfiguration{},
-				UpgradeJobs:   []v1alpha1.CIConfiguration{},
+				BlockingJobs:                  []v1alpha1.CIConfiguration{},
+				InformingJobs:                 []v1alpha1.CIConfiguration{},
+				UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+				PayloadVerificationDataSource: dataSource,
 			},
 		},
 	}

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -29,6 +29,7 @@ func TestNewReleasePayload(t *testing.T) {
 		prowNamespace    string
 		verificationJobs map[string]releasecontroller.ReleaseVerification
 		upgradeJobs      map[string]releasecontroller.UpgradeVerification
+		dataSource       v1alpha1.PayloadVerificationDataSource
 		expected         *v1alpha1.ReleasePayload
 	}{
 		{
@@ -43,6 +44,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -64,9 +66,10 @@ func TestNewReleasePayload(t *testing.T) {
 						},
 					},
 					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
-						BlockingJobs:  []v1alpha1.CIConfiguration{},
-						InformingJobs: []v1alpha1.CIConfiguration{},
-						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+						BlockingJobs:                  []v1alpha1.CIConfiguration{},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -85,6 +88,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -112,8 +116,58 @@ func TestNewReleasePayload(t *testing.T) {
 								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
 							},
 						},
-						InformingJobs: []v1alpha1.CIConfiguration{},
-						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+					},
+				},
+			},
+		},
+		{
+			name:          "LegacyBlockingJob",
+			release:       release,
+			payloadName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			verificationJobs: map[string]releasecontroller.ReleaseVerification{
+				"blocking-job": {
+					ProwJob: &releasecontroller.ProwJobVerification{
+						Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+					},
+				},
+			},
+			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceImageStream,
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "blocking-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceImageStream,
 					},
 				},
 			},
@@ -133,6 +187,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -161,8 +216,9 @@ func TestNewReleasePayload(t *testing.T) {
 								MaxRetries:             3,
 							},
 						},
-						InformingJobs: []v1alpha1.CIConfiguration{},
-						UpgradeJobs:   []v1alpha1.CIConfiguration{},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -182,6 +238,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -210,7 +267,8 @@ func TestNewReleasePayload(t *testing.T) {
 								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
 							},
 						},
-						UpgradeJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -231,6 +289,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -260,7 +319,8 @@ func TestNewReleasePayload(t *testing.T) {
 								MaxRetries:             3,
 							},
 						},
-						UpgradeJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -289,6 +349,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
+			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.12.11",
@@ -326,6 +387,7 @@ func TestNewReleasePayload(t *testing.T) {
 								CIConfigurationJobName: "release-openshift-origin-installer-e2e-gcp-upgrade",
 							},
 						},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -355,6 +417,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
+			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.12.11",
@@ -388,6 +451,7 @@ func TestNewReleasePayload(t *testing.T) {
 								CIConfigurationJobName: "release-openshift-origin-installer-e2e-azure-upgrade",
 							},
 						},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -410,6 +474,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -444,7 +509,8 @@ func TestNewReleasePayload(t *testing.T) {
 								AnalysisJobCount:       10,
 							},
 						},
-						UpgradeJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -470,6 +536,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -504,7 +571,8 @@ func TestNewReleasePayload(t *testing.T) {
 								AnalysisJobCount:       10,
 							},
 						},
-						UpgradeJobs: []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -592,6 +660,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
+			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -675,6 +744,7 @@ func TestNewReleasePayload(t *testing.T) {
 								CIConfigurationJobName: "release-openshift-origin-installer-e2e-gcp-upgrade",
 							},
 						},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
 				},
 			},
@@ -683,7 +753,7 @@ func TestNewReleasePayload(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			payload := newReleasePayload(tc.release, tc.payloadName, tc.jobNamespace, tc.prowNamespace, tc.verificationJobs, tc.upgradeJobs)
+			payload := newReleasePayload(tc.release, tc.payloadName, tc.jobNamespace, tc.prowNamespace, tc.verificationJobs, tc.upgradeJobs, tc.dataSource)
 			if !reflect.DeepEqual(payload, tc.expected) {
 				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, payload)
 			}


### PR DESCRIPTION
This PR adds a sync loop to the release-controller to process `Stable` release `imagestreamtag`s that do not have a corresponding `ReleasePayload`.  The loop will only run when enabled by adding the `--process-legacy-results` flag to the commandline.  If enabled, the logic will run immediately and then every 6 hours thereafter.  The expectation is that this process only needs to run once, but it shouldn't hurt if it continues to run.