### PR TITLE
Adding ReleasePayload support to the UI

### DIFF
--- a/cmd/release-controller-api/controller.go
+++ b/cmd/release-controller-api/controller.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	releasepayloadlister "github.com/openshift/release-controller/pkg/client/listers/release/v1alpha1"
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -60,6 +61,9 @@ type Controller struct {
 	architecture string
 
 	artSuffix string
+
+	releasePayloadNamespace string
+	releasePayloadLister    releasepayloadlister.ReleasePayloadLister
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -71,6 +75,8 @@ func NewController(
 	authenticationMessage string,
 	architecture string,
 	artSuffix string,
+	releasePayloadNamespace string,
+	releasePayloadLister releasepayloadlister.ReleasePayloadLister,
 ) *Controller {
 	// log events at v2 and send them to the server
 	broadcaster := record.NewBroadcaster()
@@ -102,6 +108,9 @@ func NewController(
 		architecture: architecture,
 
 		artSuffix: artSuffix,
+
+		releasePayloadNamespace: releasePayloadNamespace,
+		releasePayloadLister:    releasePayloadLister,
 	}
 
 	c.dashboards = []Dashboard{

--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -603,7 +603,10 @@ func (r *ExecReleaseInfo) GetFeatureChildren(featuresList []string, validityPeri
 	var mu sync.Mutex
 	limit := make(chan struct{}, 10) // set the limit to 10 concurrent goroutines
 	results := make(map[string][]jiraBaseClient.Issue)
-
+	// This will prevent a Panic if/when the release-controller's are run without the necessary jira flags
+	if r.jiraClient == nil {
+		return "", fmt.Errorf("unable to communicate with Jira")
+	}
 	// loop to start goroutines
 	for _, feature := range featuresList {
 		wg.Add(1)
@@ -639,6 +642,10 @@ func (r *ExecReleaseInfo) GetFeatureChildren(featuresList []string, validityPeri
 }
 
 func (r *ExecReleaseInfo) GetIssuesWithChunks(issues []string) (result []jiraBaseClient.Issue, err error) {
+	// This will prevent a Panic if/when the release-controller's are run without the necessary jira flags
+	if r.jiraClient == nil {
+		return result, fmt.Errorf("unable to communicate with Jira")
+	}
 	// Keep the chunk on the small side, it is much faster
 	// There is a limit for API calls per second in Akamai for Jira, don't chunk too much
 	chunk := len(issues) / 10

--- a/pkg/releasepayload/utils.go
+++ b/pkg/releasepayload/utils.go
@@ -1,0 +1,95 @@
+package releasepayload
+
+import (
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+)
+
+func GenerateVerificationStatusMap(payload *v1alpha1.ReleasePayload, status *releasecontroller.VerificationStatusMap) bool {
+	if status == nil {
+		return false
+	}
+	if *status == nil {
+		*status = map[string]*releasecontroller.VerificationStatus{}
+	}
+
+	for _, job := range payload.Status.InformingJobResults {
+		if result, ok := convertToVerificationStatusMapResult(job); ok {
+			(*status)[job.CIConfigurationName] = result
+		}
+	}
+
+	for _, job := range payload.Status.BlockingJobResults {
+		if result, ok := convertToVerificationStatusMapResult(job); ok {
+			(*status)[job.CIConfigurationName] = result
+		}
+	}
+
+	return true
+}
+
+func convertToVerificationStatusMapResult(job v1alpha1.JobStatus) (*releasecontroller.VerificationStatus, bool) {
+	status := &releasecontroller.VerificationStatus{
+		Retries: getVerificationStatusRetries(job),
+		State:   getVerificationStatusState(job.AggregateState),
+		URL:     getVerificationStatusUrl(job.JobRunResults),
+	}
+	return status, true
+}
+
+func getVerificationStatusRetries(job v1alpha1.JobStatus) int {
+	// For any individual job, there should always be at least a single JobRunResult.  Retries are consecutive
+	// attempts of the initial job that ended in a failure state.  Therefore, the maximum number of JobRunResults
+	// should amount to 1 + job.MaxRetries.  This *must* be enforced by the ReleaseController because the
+	// ReleasePayloadController does not care.  It simply keeps track of all the results of a job that are
+	// attributable back to a particular ReleasePayload.
+	results := len(job.JobRunResults)
+	maxResults := job.MaxRetries + 1
+	switch {
+	case results == 0:
+		// Nothing to figure out
+		return 0
+	case results == 1:
+		// A singular result without any retries
+		return 0
+	case results <= maxResults:
+		// First result and at least 1 retry
+		return results - 1
+	case results > job.MaxRetries:
+		// More results than are allowed by the ReleaseController
+		return job.MaxRetries
+	default:
+		return 0
+	}
+}
+
+func getVerificationStatusState(state v1alpha1.JobState) string {
+	switch state {
+	case v1alpha1.JobStateSuccess:
+		return releasecontroller.ReleaseVerificationStateSucceeded
+	case v1alpha1.JobStateFailure:
+		return releasecontroller.ReleaseVerificationStateFailed
+	case v1alpha1.JobStateUnknown:
+		// I don't like this, but the existing behavior of the release-controller is to create a "synthetic" job
+		// if/when it's impossible to generate the prowjob for the specified verification.  Those jobs will never
+		// have any JobRunResults and therefore an "Unknown" JobState. Ultimately, they are considered a "Success"
+		// to not Reject the respective release for an invalid configuration...
+		return releasecontroller.ReleaseVerificationStateSucceeded
+	default:
+		return releasecontroller.ReleaseVerificationStatePending
+	}
+}
+
+func getVerificationStatusUrl(jobRunResults []v1alpha1.JobRunResult) string {
+	// If there was any successful run, then return that URL
+	for _, result := range jobRunResults {
+		if result.State == v1alpha1.JobRunStateSuccess {
+			return result.HumanProwResultsURL
+		}
+	}
+	// Otherwise, return the URL of the "last" attempt
+	if len(jobRunResults) >= 1 {
+		return jobRunResults[len(jobRunResults)-1].HumanProwResultsURL
+	}
+	return ""
+}

--- a/pkg/releasepayload/utils_test.go
+++ b/pkg/releasepayload/utils_test.go
@@ -1,0 +1,268 @@
+package releasepayload
+
+import (
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	"testing"
+)
+
+func Test_getVerificationStatusRetries(t *testing.T) {
+	tests := []struct {
+		name string
+		job  v1alpha1.JobStatus
+		want int
+	}{
+		{
+			name: "No Results",
+			job:  v1alpha1.JobStatus{},
+			want: 0,
+		},
+		{
+			name: "Single Result",
+			job:  v1alpha1.JobStatus{},
+			want: 0,
+		},
+		{
+			name: "Multiple Results Without MaxRetries",
+			job: v1alpha1.JobStatus{
+				JobRunResults: []v1alpha1.JobRunResult{
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "Multiple Result With MaxRetries - No Retries",
+			job: v1alpha1.JobStatus{
+				MaxRetries: 3,
+				JobRunResults: []v1alpha1.JobRunResult{
+					{
+						State: v1alpha1.JobRunStateSuccess,
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "Multiple Result With MaxRetries - Single Retry",
+			job: v1alpha1.JobStatus{
+				MaxRetries: 3,
+				JobRunResults: []v1alpha1.JobRunResult{
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateSuccess,
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "Multiple Result With MaxRetries - Multiple Retries",
+			job: v1alpha1.JobStatus{
+				MaxRetries: 3,
+				JobRunResults: []v1alpha1.JobRunResult{
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateSuccess,
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "Multiple Result With MaxRetries - Max Retries",
+			job: v1alpha1.JobStatus{
+				MaxRetries: 3,
+				JobRunResults: []v1alpha1.JobRunResult{
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+				},
+			},
+			want: 3,
+		},
+		{
+			name: "Multiple Result With MaxRetries - Extra Retries",
+			job: v1alpha1.JobStatus{
+				MaxRetries: 3,
+				JobRunResults: []v1alpha1.JobRunResult{
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
+					{
+						State: v1alpha1.JobRunStateSuccess,
+					},
+				},
+			},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getVerificationStatusRetries(tt.job)
+			if tt.want != got {
+				t.Errorf("%s: Expected %v, got %v", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_getVerificationStatusState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state v1alpha1.JobState
+		want  string
+	}{
+		{
+			name:  "Succeeded",
+			state: v1alpha1.JobStateSuccess,
+			want:  releasecontroller.ReleaseVerificationStateSucceeded,
+		},
+		{
+			name:  "Pending",
+			state: v1alpha1.JobStatePending,
+			want:  releasecontroller.ReleaseVerificationStatePending,
+		},
+		{
+			name:  "Failed",
+			state: v1alpha1.JobStateFailure,
+			want:  releasecontroller.ReleaseVerificationStateFailed,
+		},
+		{
+			name:  "Default",
+			state: v1alpha1.JobStateUnknown,
+			want:  releasecontroller.ReleaseVerificationStateSucceeded,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getVerificationStatusState(tt.state)
+			if tt.want != got {
+				t.Errorf("%s: Expected %v, got %v", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_getVerificationStatusUrl(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []v1alpha1.JobRunResult
+		want    string
+	}{
+		{
+			name:    "No Results",
+			results: []v1alpha1.JobRunResult{},
+			want:    "",
+		},
+		{
+			name: "Single Result - No URL",
+			results: []v1alpha1.JobRunResult{
+				{
+					State: v1alpha1.JobRunStateSuccess,
+				},
+			},
+			want: "",
+		},
+		{
+			name: "Single Successful Result",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateSuccess,
+				},
+			},
+			want: "https://abc.123/",
+		},
+		{
+			name: "Single Failure Result",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+			},
+			want: "https://abc.123/",
+		},
+		{
+			name: "Multiple Failure Results",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://def.456/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://ghi.789/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+			},
+			want: "https://ghi.789/",
+		},
+		{
+			name: "Multiple Results With Success",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://def.456/",
+					State:               v1alpha1.JobRunStateSuccess,
+				},
+				{
+					HumanProwResultsURL: "https://ghi.789/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+			},
+			want: "https://def.456/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getVerificationStatusUrl(tt.results)
+			if tt.want != got {
+				t.Errorf("%s: Expected %v, got %v", tt.name, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR switches the UI's data source, for the results of the release verification jobs, from the ImageStream Annotations over to the ReleasePayloads.

While testing this out, I ran into a Panic caused because I was not specifying the Jira endpoint parameters in my local sessions.  I've added a couple line to prevent the panic and pop an error to the screen.  This really shouldn't even happen, but just in case!