### PR TITLE
Fixing logic that determines the aggregate state of JobRunResults

### DIFF
--- a/pkg/cmd/release-payload-controller/job_state_controller_test.go
+++ b/pkg/cmd/release-payload-controller/job_state_controller_test.go
@@ -477,6 +477,9 @@ func TestComputeJobState(t *testing.T) {
 					{
 						State: v1alpha1.JobRunStateFailure,
 					},
+					{
+						State: v1alpha1.JobRunStateFailure,
+					},
 				},
 			},
 			expected: v1alpha1.JobStateFailure,
@@ -971,6 +974,9 @@ func TestProcessRetryJobResults(t *testing.T) {
 		{
 			name: "FailureJobRunResults",
 			results: []v1alpha1.JobRunResult{
+				{
+					State: v1alpha1.JobRunStateFailure,
+				},
 				{
 					State: v1alpha1.JobRunStateFailure,
 				},


### PR DESCRIPTION
For any individual job, there should always be at least a single JobRunResult.  Retries are consecutive attempts of the initial job that ended in a failure state.  Therefore, the maximum number of JobRunResults should amount to 1 + job.MaxRetries.