### PR TITLE
Truncate ProwJob URLs

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -324,7 +324,7 @@ func (c *Controller) links(tag imagev1.TagReference, release *releasecontroller.
 				default:
 					buf.WriteString(" <a title=\"Pending\" class=\"\" href=\"")
 				}
-				buf.WriteString(template.HTMLEscapeString(s.URL))
+				buf.WriteString(template.HTMLEscapeString(releasecontroller.GenerateProwJobResultsURL(s.URL)))
 				buf.WriteString("\">")
 				buf.WriteString(template.HTMLEscapeString(key))
 				buf.WriteString("</a>")
@@ -469,7 +469,7 @@ func (c *Controller) renderVerificationJobsList(jobs releasecontroller.Verificat
 			default:
 				buf.WriteString("<li><a class=\"\" href=\"")
 			}
-			buf.WriteString(template.HTMLEscapeString(value.URL))
+			buf.WriteString(template.HTMLEscapeString(releasecontroller.GenerateProwJobResultsURL(value.URL)))
 			buf.WriteString("\">")
 			buf.WriteString(template.HTMLEscapeString(key))
 			switch value.State {

--- a/cmd/release-controller-api/main.go
+++ b/cmd/release-controller-api/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/test-infra/prow/jira"
 	releasepayloadclient "github.com/openshift/release-controller/pkg/client/clientset/versioned"
 	releasepayloadinformers "github.com/openshift/release-controller/pkg/client/informers/externalversions"
+	"k8s.io/test-infra/prow/jira"
 	"net/http"
 	"os"
 	goruntime "runtime"
@@ -289,7 +289,7 @@ func (o *options) Run() error {
 				}
 				graph.Add(from, to, releasecontroller.UpgradeResult{
 					State: status.State,
-					URL:   status.URL,
+					URL:   releasecontroller.GenerateProwJobResultsURL(status.URL),
 				})
 			}
 		}, 2*time.Minute, stopCh)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -529,7 +529,7 @@ func (o *options) Run() error {
 					}
 					graph.Add(from, to, releasecontroller.UpgradeResult{
 						State: status.State,
-						URL:   status.URL,
+						URL:   releasecontroller.GenerateProwJobResultsURL(status.URL),
 					})
 				}
 			}, 2*time.Minute, stopCh)

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -104,7 +104,7 @@ func (c *Controller) ensureVerificationJobs(release *releasecontroller.Release, 
 				return nil, fmt.Errorf("unexpected error accessing prow job definition")
 			}
 			if status.State == releasecontroller.ReleaseVerificationStateSucceeded {
-				klog.V(2).Infof("Prow job %s for release %s succeeded, logs at %s", name, releaseTag.Name, status.URL)
+				klog.V(2).Infof("Prow job %s for release %s succeeded, logs at %s", name, releaseTag.Name, releasecontroller.GenerateProwJobResultsURL(status.URL))
 			}
 			if verifyStatus == nil {
 				verifyStatus = make(releasecontroller.VerificationStatusMap)

--- a/pkg/cmd/release-payload-controller/legacy_job_status_controller.go
+++ b/pkg/cmd/release-payload-controller/legacy_job_status_controller.go
@@ -130,7 +130,7 @@ func (c *LegacyJobStatusController) sync(ctx context.Context, key string) error 
 		klog.V(4).Infof("Processing legacy result for: %q", ciConfigurationName)
 		current := &v1alpha1.JobRunResult{
 			State:               getLegacyJobRunState(status.State),
-			HumanProwResultsURL: status.URL,
+			HumanProwResultsURL: releasecontroller.GenerateProwJobResultsURL(status.URL),
 		}
 
 		jobStatus, err := findLegacyJobStatus(originalReleasePayload.Name, &originalReleasePayload.Status, ciConfigurationName)

--- a/pkg/release-controller/prowjob.go
+++ b/pkg/release-controller/prowjob.go
@@ -1,6 +1,8 @@
 package releasecontroller
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -22,16 +24,16 @@ func ProwJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationSta
 	switch prowjobsv1.ProwJobState(s) {
 	case prowjobsv1.SuccessState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &VerificationStatus{State: ReleaseVerificationStateSucceeded, URL: url}
+		status = &VerificationStatus{State: ReleaseVerificationStateSucceeded, URL: truncateProwJobResultsURL(url)}
 	case prowjobsv1.FailureState, prowjobsv1.ErrorState, prowjobsv1.AbortedState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
-		status = &VerificationStatus{State: ReleaseVerificationStateFailed, URL: url}
+		status = &VerificationStatus{State: ReleaseVerificationStateFailed, URL: truncateProwJobResultsURL(url)}
 	case prowjobsv1.TriggeredState, prowjobsv1.PendingState, prowjobsv1.ProwJobState(""):
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "pendingTime")
 		if transitionTime == "" {
 			transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "startTime")
 		}
-		status = &VerificationStatus{State: ReleaseVerificationStatePending, URL: url}
+		status = &VerificationStatus{State: ReleaseVerificationStatePending, URL: truncateProwJobResultsURL(url)}
 	default:
 		klog.Errorf("Unrecognized prow job state %q on job %s", s, obj.GetName())
 		return nil, false
@@ -41,4 +43,19 @@ func ProwJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationSta
 		status.TransitionTime = &trTime
 	}
 	return status, true
+}
+
+func truncateProwJobResultsURL(url string) string {
+	if strings.HasPrefix(url, ProwJobResultsURLPrefix) {
+		return strings.TrimPrefix(url, ProwJobResultsURLPrefix)
+	}
+	klog.Warningf("Unknown prowjob result URL prefix: %s", url)
+	return url
+}
+
+func GenerateProwJobResultsURL(suffix string) string {
+	if strings.HasPrefix(suffix, "/") {
+		return fmt.Sprintf("%s%s", ProwJobResultsURLPrefix, suffix)
+	}
+	return suffix
 }

--- a/pkg/release-controller/prowjob_test.go
+++ b/pkg/release-controller/prowjob_test.go
@@ -1,0 +1,70 @@
+package releasecontroller
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestTruncateProwJobResultsURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Matching Prefix",
+			url:      "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+			expected: "/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+		},
+		{
+			name:     "Non-Matching Prefix",
+			url:      "https://prow.ci.openshift.org/view/gs/origin-ci-test2/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+			expected: "https://prow.ci.openshift.org/view/gs/origin-ci-test2/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+		},
+		{
+			name:     "Garbage",
+			url:      "garbage in...garbage out",
+			expected: "garbage in...garbage out",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := truncateProwJobResultsURL(testCase.url)
+			if !cmp.Equal(result, testCase.expected) {
+				t.Errorf("%s: Expected %v, got %v", testCase.name, testCase.expected, result)
+			}
+		})
+	}
+}
+
+func TestGenerateProwJobResultsURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Truncated URL",
+			url:      "/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+			expected: "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+		},
+		{
+			name:     "Full URL",
+			url:      "https://prow.ci.openshift.org/view/gs/origin-ci-test2/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+			expected: "https://prow.ci.openshift.org/view/gs/origin-ci-test2/logs/periodic-ci-openshift-release-master-nightly-4.8-e2e-aws/1577585519322206208",
+		},
+		{
+			name:     "Garbage",
+			url:      "garbage in...garbage out",
+			expected: "garbage in...garbage out",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := GenerateProwJobResultsURL(testCase.url)
+			if !cmp.Equal(result, testCase.expected) {
+				t.Errorf("%s: Expected %v, got %v", testCase.name, testCase.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -554,6 +554,9 @@ const (
 
 	// ReleaseLabelPayload indicates the ReleasePayload of the release
 	ReleaseLabelPayload = "release.openshift.io/payload"
+
+	// ProwJobResultsURLPrefix the URL prefix for ProwJob Results
+	ProwJobResultsURLPrefix = "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs"
 )
 
 type Duration time.Duration


### PR DESCRIPTION
To free up a little space in the release imagestreams (about 20%) we are going to truncate the ProwJob URLs down to just their unique paths.  This PR adds support for writing the truncated URLs to the imagestream annotations as well as re-hydrating whenever they are referenced in the UI.