### PR TITLE
increase the git-cache PVC size

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -813,7 +813,7 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							"storage": resource.MustParse("128Gi"),
+							"storage": resource.MustParse("200Gi"),
 						},
 					},
 				},


### PR DESCRIPTION
The git-cache is full, causing failures in loading change logs. Increasing the size to 200Gi, from 128Gi. 