### PR TITLE
Echo repo name while performing git repo maintenance

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -874,7 +874,7 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 							  echo "Performing git maintenance..."
 							  for repo in $(find /tmp/git -type d -a -name .git | xargs dirname)
 							  do
-								(cd $repo && git gc && git pull)
+								(echo $repo && cd $repo && git gc && git pull)
 							  done
 							else
 							  FROM=$(curl -s https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/accepted | jq -r '.["4-stable"][0] // empty')


### PR DESCRIPTION
Ran into an issue where the git maintenance was failing and I couldn't tell which repo was being processed.  Printing out the repo name to assist in debugging init issues.