### PR TITLE
Changing the way synthetic jobs are displayed in the UI

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -490,13 +490,19 @@ func (c *Controller) renderVerificationJobsList(jobs releasecontroller.Verificat
 			}
 			continue
 		}
-		switch value.State {
-		case releasecontroller.ReleaseVerificationStateFailed:
-			buf.WriteString("<li><span class=\"text-danger\">")
-		case releasecontroller.ReleaseVerificationStateSucceeded:
-			buf.WriteString("<li><span class=\"text-success\">")
-		default:
-			buf.WriteString("<li><span class=\"\">")
+		// Synthetic upgrade jobs are always successful and never have a URL.  This can cause confusion, so we're going
+		// to render them in a different color...
+		if verificationJobs[key].Upgrade && len(value.URL) == 0 && value.State == releasecontroller.ReleaseVerificationStateSucceeded {
+			buf.WriteString("<li><span class=\"text-muted\">")
+		} else {
+			switch value.State {
+			case releasecontroller.ReleaseVerificationStateFailed:
+				buf.WriteString("<li><span class=\"text-danger\">")
+			case releasecontroller.ReleaseVerificationStateSucceeded:
+				buf.WriteString("<li><span class=\"text-success\">")
+			default:
+				buf.WriteString("<li><span class=\"\">")
+			}
 		}
 		buf.WriteString(template.HTMLEscapeString(key))
 		switch value.State {


### PR DESCRIPTION
If the release-controller is unable to deter determine how to fulfill an upgrade job (i.e. there isn't an excepted payload to upgrade from), it creates a synthetic prowjob, that's successful, to not block the payload.
Unfortunately, this means it doesn't have a URL to point to and ultimately the job is not clickable in the UI.

This PR will change the color of these particular jobs to be a light grey color to distinguish them from the other jobs.