### PR TITLE
Excluding `OCPSTRAT-` project from FixVersion updates

### DIFF
--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -197,7 +197,7 @@ func (c *Controller) syncJira(key queueKey) error {
 
 	parentFeatures := []string{}
 	for key, details := range mapIssueDetails {
-		if strings.HasPrefix(key, "OSDOCS-") || strings.HasPrefix(key, "PLMCORE-") {
+		if strings.HasPrefix(key, "OSDOCS-") || strings.HasPrefix(key, "PLMCORE-") || strings.HasPrefix(key, "OCPSTRAT-") {
 			continue
 		}
 		if details.IssueType == releasecontroller.JiraTypeFeature {
@@ -221,18 +221,18 @@ func (c *Controller) syncJira(key queueKey) error {
 
 	fixVersionUpdateList := sets.New[string]()
 	for _, issue := range issueList {
-		if strings.HasPrefix(issue, "OSDOCS-") || strings.HasPrefix(issue, "PLMCORE-") {
+		if strings.HasPrefix(issue, "OSDOCS-") || strings.HasPrefix(issue, "PLMCORE-") || strings.HasPrefix(issue, "OCPSTRAT-") {
 			continue
 		}
 		fixVersionUpdateList = fixVersionUpdateList.Insert(issue)
-		if mapIssueDetails[issue].Epic != "" && !(strings.HasPrefix(mapIssueDetails[issue].Epic, "OSDOCS-") || strings.HasPrefix(mapIssueDetails[issue].Epic, "PLMCORE-")) {
+		if mapIssueDetails[issue].Epic != "" && !(strings.HasPrefix(mapIssueDetails[issue].Epic, "OSDOCS-") || strings.HasPrefix(mapIssueDetails[issue].Epic, "PLMCORE-") || strings.HasPrefix(mapIssueDetails[issue].Epic, "OCPSTRAT-")) {
 			fixVersionUpdateList = fixVersionUpdateList.Insert(mapIssueDetails[issue].Epic)
 		}
 	}
 	for _, feature := range parentFeatures {
 		unsetEpic := false
 		for _, epic := range featureChildren[feature] {
-			if strings.HasPrefix(epic.Key, "OSDOCS-") || strings.HasPrefix(epic.Key, "PLMCORE-") ||
+			if strings.HasPrefix(epic.Key, "OSDOCS-") || strings.HasPrefix(epic.Key, "PLMCORE-") || strings.HasPrefix(epic.Key, "OCPSTRAT-") ||
 				fixVersionUpdateList.Has(epic.Key) || (epic.Fields != nil && epic.Fields.FixVersions != nil && len(epic.Fields.FixVersions) > 0) {
 				continue
 			}


### PR DESCRIPTION
While we wait for a resolution to the inconsistencies found with the `Fix Version` field in the `OCPSTRAT` project, we're going to skip its updates all together (for now). 