### PR TITLE
bugfix on PR commenting

### DIFF
--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -97,7 +97,7 @@ func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {
 	// Check to see if the same message has already been posted.
 	for _, comment := range comments {
 		if strings.Contains(comment.Body, message) {
-			return nil, false
+			return nil, true
 		}
 	}
 	// If the message hasn't already been posted, post it.
@@ -105,7 +105,7 @@ func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {
 	if err != nil {
 		return err, false
 	}
-	return err, true
+	return nil, true
 }
 
 func (c *Verifier) verifyExtPRs(issue *jiraBaseClient.Issue, extPRs []pr, errs *[]error, tagName string) (ticketMessage string, isSuccess bool) {

--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -52,8 +52,8 @@ func TestCommentOnPR(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if created {
-		t.Errorf("Expected comment not to be created, but it was")
+	if !created {
+		t.Errorf("Unexpected result while checking an already commented PR")
 	}
 }
 


### PR DESCRIPTION
If the PR already has the comment, `return nil, true`. Returning `false` will log an error.