### PR TITLE
remove github errors from Jira comments

### DIFF
--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -120,7 +120,17 @@ func (c *Verifier) verifyExtPRs(issue *jiraBaseClient.Issue, extPRs []pr, errs *
 			var newErr error
 			unlabeledPRs, newErr = c.ghUnlabeledPRs(extPR)
 			if newErr != nil {
-				*errs = append(*errs, newErr)
+				exists := false
+				for _, tmpErr := range *errs {
+					if tmpErr.Error() == "Internal Error on Automation" {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					*errs = append(*errs, fmt.Errorf("Internal Error on Automation"))
+				}
+				klog.Warning(newErr)
 				return "", false
 			}
 			// Comment on the PR saying that this PR is included in the release

--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -352,7 +352,7 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  []error{errors.New("unable to get labels for github pull openshift/vmware-vsphere-csi-driver-operator#105: injected error")},
+				errors:  []error{errors.New("Internal Error on Automation")},
 				status:  "ON_QA",
 				message: "",
 			},


### PR DESCRIPTION
Remove GitHub errors from the Jira comment. Include only the generic `Internal Error on Automation`, as with the other internal errors, and only log the actual error. 