### PR TITLE
Adding Manifest List based release support

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -145,6 +145,8 @@ type Controller struct {
 
 	releasePayloadClient releasepayloadclient.ReleasePayloadsGetter
 	releasePayloadLister *releasecontroller.MultiReleasePayloadLister
+
+	manifestListMode bool
 }
 
 // NewController instantiates a Controller to manage release objects.
@@ -165,6 +167,7 @@ func NewController(
 	architecture string,
 	artSuffix string,
 	releasePayloadClient releasepayloadclient.ReleasePayloadsGetter,
+	manifestListMode bool,
 ) *Controller {
 
 	// log events at v2 and send them to the server
@@ -227,6 +230,8 @@ func NewController(
 		releasePayloadLister: &releasecontroller.MultiReleasePayloadLister{Listers: make(map[string]v1alpha1.ReleasePayloadNamespaceLister)},
 
 		legacyResultsQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "legacyResults"),
+
+		manifestListMode: manifestListMode,
 	}
 
 	c.auditTracker = NewAuditTracker(c.auditQueue)

--- a/cmd/release-controller/main.go
+++ b/cmd/release-controller/main.go
@@ -108,6 +108,7 @@ type options struct {
 	ConfirmPruneGraph bool
 
 	ProcessLegacyResults bool
+	ManifestListMode     bool
 }
 
 // Add metrics for jira verifier errors
@@ -211,6 +212,7 @@ func main() {
 	flagset.BoolVar(&opt.ConfirmPruneGraph, "confirm-prune-graph", opt.ConfirmPruneGraph, "Persist the pruned graph")
 
 	flagset.BoolVar(&opt.ProcessLegacyResults, "process-legacy-results", opt.ProcessLegacyResults, "enable the migration of imagestream based results to ReleasePayloads")
+	flagset.BoolVar(&opt.ManifestListMode, "manifest-list-mode", opt.ManifestListMode, "enable manifest list support for oc operations")
 
 	goFlagSet := flag.NewFlagSet("prowflags", flag.ContinueOnError)
 	opt.github.AddFlags(goFlagSet)
@@ -395,6 +397,7 @@ func (o *options) Run() error {
 		architecture,
 		o.ARTSuffix,
 		releasePayloadClient.ReleaseV1alpha1(),
+		o.ManifestListMode,
 	)
 
 	if o.VerifyJira {


### PR DESCRIPTION
This PR adds a `--manifest-list-mode` flag to the commandline that enables executing `oc` commands with the `--keep-manifest-list` options specified.