### PR TITLE
Quiet noisy warning about empty prowjob URLs

### DIFF
--- a/pkg/release-controller/prowjob.go
+++ b/pkg/release-controller/prowjob.go
@@ -46,6 +46,9 @@ func ProwJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationSta
 }
 
 func truncateProwJobResultsURL(url string) string {
+	if len(url) == 0 {
+		return url
+	}
 	if strings.HasPrefix(url, ProwJobResultsURLPrefix) {
 		return strings.TrimPrefix(url, ProwJobResultsURLPrefix)
 	}


### PR DESCRIPTION
There are a ton of logs that look like now:
`W1025 18:13:26.237275       1 prowjob.go:52] Unknown prowjob result URL prefix:`
Why?  My best guess is that prowjobs are being created and then getting triggered, which causes an update that triggers the release-controller.  I'm guessing that update is probably too early for the URL to have been populated and therefore we get this message...

These messages are useless, so this PR adds a check for an empty URL.