### PR TITLE
cmd: create release-reimport-controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,12 @@
 /release-controller
 /release-controller-api
 /release-payload-controller
+/release-reimport-controller
 /_output
 
 .dccache
+python-env
+
 .scannerwork/
 coverage.out
 golangci-lint.out

--- a/cmd/release-reimport-controller/main.go
+++ b/cmd/release-reimport-controller/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+
+	releasereimportcontroller "github.com/openshift/release-controller/pkg/cmd/release-reimport-controller"
+	"github.com/spf13/cobra"
+	"k8s.io/component-base/cli"
+)
+
+func main() {
+	command := NewReleaseReimportControllerCommand()
+	code := cli.Run(command)
+	os.Exit(code)
+}
+
+func NewReleaseReimportControllerCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "release-reimport-controller",
+		Short: "OpenShift Release Reimport Controller",
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	cmd.AddCommand(releasereimportcontroller.NewReleaseReimportControllerCommand("start"))
+	return cmd
+}

--- a/images/release-reimport-controller/Dockerfile
+++ b/images/release-reimport-controller/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.ci.openshift.org/ocp/4.13.9:cli
+LABEL maintainer="apavel@redhat.com"
+
+ADD release-reimport-controller /usr/bin/release-reimport-controller
+ENTRYPOINT ["/usr/bin/release-reimport-controller"]

--- a/images/release-reimport-controller/Dockerfile
+++ b/images/release-reimport-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.13.9:cli
+FROM registry.ci.openshift.org/ocp/4.13.18:cli
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-reimport-controller /usr/bin/release-reimport-controller

--- a/pkg/cmd/release-reimport-controller/cmd.go
+++ b/pkg/cmd/release-reimport-controller/cmd.go
@@ -1,0 +1,78 @@
+package release_reimport_controller
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/release-controller/pkg/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+type Options struct {
+	controllerContext *controllercmd.ControllerContext
+	namespaces        []string
+	dryRun            bool
+}
+
+func NewReleaseReimportControllerCommand(name string) *cobra.Command {
+	o := &Options{}
+
+	ccc := controllercmd.NewControllerCommandConfig("release-reimport-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+		o.controllerContext = controllerContext
+
+		err := o.Validate(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = o.Run(ctx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	cmd := ccc.NewCommandWithContext(context.Background())
+	cmd.Use = name
+	cmd.Short = "Start the release reimport controller"
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringArrayVar(&o.namespaces, "namespaces", []string{}, "Namespaces to watch for automatic reimporting")
+	fs.BoolVar(&o.dryRun, "dry-run", false, "Run 'oc import-image' commands in dry-run mode")
+}
+
+func (o *Options) Validate(ctx context.Context) error {
+	if len(o.namespaces) == 0 {
+		return errors.New("--namespaces flag must be set")
+	}
+	return nil
+}
+
+func (o *Options) Run(ctx context.Context) error {
+	inClusterConfig := o.controllerContext.KubeConfig
+
+	// ImageStream Informers
+	imageStreamClient, err := imageclientset.NewForConfig(inClusterConfig)
+	if err != nil {
+		klog.Fatalf("Error building imagestream clientset: %s", err.Error())
+	}
+
+	imageReimportController := NewImageReimportController(imageStreamClient, o.namespaces, o.dryRun)
+
+	go imageReimportController.Run(ctx, 10*time.Minute)
+
+	<-ctx.Done()
+
+	return nil
+}

--- a/pkg/cmd/release-reimport-controller/controller.go
+++ b/pkg/cmd/release-reimport-controller/controller.go
@@ -1,0 +1,78 @@
+package release_reimport_controller
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned"
+	imageinformers "github.com/openshift/client-go/image/informers/externalversions"
+	imagelisters "github.com/openshift/client-go/image/listers/image/v1"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+type ImageReimportController struct {
+	releaseLister *releasecontroller.MultiImageStreamLister
+	dryRun        bool
+}
+
+func NewImageReimportController(imageClient *imageclientset.Clientset, namespaces []string, dryRun bool) *ImageReimportController {
+	c := &ImageReimportController{
+		releaseLister: &releasecontroller.MultiImageStreamLister{Listers: make(map[string]imagelisters.ImageStreamNamespaceLister)},
+		dryRun:        dryRun,
+	}
+	var hasSynced []cache.InformerSynced
+	stopCh := wait.NeverStop
+	for _, ns := range namespaces {
+		klog.Infof("Adding %s namespace to reimport controller", ns)
+		factory := imageinformers.NewSharedInformerFactoryWithOptions(imageClient, 10*time.Minute, imageinformers.WithNamespace(ns))
+		streams := factory.Image().V1().ImageStreams()
+		c.releaseLister.Listers[ns] = streams.Lister().ImageStreams(ns)
+		hasSynced = append(hasSynced, streams.Informer().HasSynced)
+		factory.Start(stopCh)
+	}
+	cache.WaitForCacheSync(stopCh, hasSynced...)
+
+	return c
+}
+
+func (c *ImageReimportController) Run(ctx context.Context, interval time.Duration) {
+	wait.Until(c.sync, interval, ctx.Done())
+}
+
+func (c *ImageReimportController) sync() {
+	streams, err := c.releaseLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list releases: %s", err)
+	}
+	for _, stream := range streams {
+		// only handle release imagestreams
+		if stream.Annotations["release.openshift.io/config"] == "" {
+			continue
+		}
+		for _, tag := range stream.Status.Tags {
+			for _, condition := range tag.Conditions {
+				if condition.Type == "ImportSuccess" && condition.Status == "False" {
+					klog.Infof("Reimporting %s:%s", stream.Name, tag.Tag)
+					commandSlice := []string{"import-image"}
+					if c.dryRun {
+						commandSlice = append(commandSlice, "--dry-run")
+					}
+					commandSlice = append(commandSlice, fmt.Sprintf("%s:%s", stream.Name, tag.Tag))
+					cmd := exec.Command("oc", commandSlice...)
+					out, err := cmd.Output()
+					if err != nil {
+						klog.Errorf("Failed to run `%s`: %v", cmd.String(), err)
+						continue
+					}
+					klog.Infof("Output of `%s`: %s", cmd.String(), out)
+				}
+			}
+		}
+	}
+}

--- a/pkg/cmd/release-reimport-controller/controller.go
+++ b/pkg/cmd/release-reimport-controller/controller.go
@@ -52,7 +52,7 @@ func (c *ImageReimportController) sync() {
 	}
 	for _, stream := range streams {
 		// only handle release imagestreams
-		if stream.Annotations["release.openshift.io/config"] == "" {
+		if _, ok := stream.Annotations[releasecontroller.ReleaseAnnotationConfig]; !ok {
 			continue
 		}
 		for _, tag := range stream.Status.Tags {


### PR DESCRIPTION
This PR creates the `release-reimport-controller` which checks whether images from a release need to be reimported every 10 minutes. It takes a list of namespaces as an input and uses the `MultiImageStreamLister` to keep track of imagestreams, which should be more efficient as it receives events on changes, preventing the `release-reimport-controller` from needing to get every imagestream every 10 minutes.