### PR TITLE
CNF-10171: Update port for kpi results host

### DIFF
--- a/cmd/release-controller-api/controller.go
+++ b/cmd/release-controller-api/controller.go
@@ -117,7 +117,7 @@ func NewController(
 		{"Index", "/"},
 		{"Overview", "/dashboards/overview"},
 		{"Compare", "/dashboards/compare"},
-		{"Telco KPI Results (VPN Required)", "http://ocp-far-edge-vran-deployment-kpi.hosts.prod.psi.rdu2.redhat.com:8080/"},
+		{"Telco KPI Results (VPN Required)", "http://ocp-far-edge-vran-deployment-kpi.hosts.prod.psi.rdu2.redhat.com/"},
 	}
 
 	return c


### PR DESCRIPTION
- [CNF-10171](https://issues.redhat.com//browse/CNF-10171) will be moving the internal kpi results host to be using port 80 instead of 8080
- This will align the link on the page to the new port
- The server will be temporarily listening on both ports for an interim time until all alignment work (this pr and some others in other components) are completed, at which point the server will stop listening on 8080
