### PR TITLE
reimport-controller: use klog/v2

### DIFF
--- a/pkg/cmd/release-reimport-controller/controller.go
+++ b/pkg/cmd/release-reimport-controller/controller.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type ImageReimportController struct {


### PR DESCRIPTION
Klog-v2 and the original klog appear to be incompatible, causing klog-v1 logs with verbosity set to not be logged.