### PR TITLE
release-reimport-controller: improve logging

### DIFF
--- a/pkg/cmd/release-reimport-controller/cmd.go
+++ b/pkg/cmd/release-reimport-controller/cmd.go
@@ -37,6 +37,7 @@ func NewReleaseReimportControllerCommand(name string) *cobra.Command {
 
 		return nil
 	})
+	ccc.DisableLeaderElection = true
 
 	cmd := ccc.NewCommandWithContext(context.Background())
 	cmd.Use = name


### PR DESCRIPTION
This PR improves logging in the release-reimport-controller and disables the controller leader election.