### PR TITLE
[OCPCRT-169] Do not show i icon if no inconsistency exist

### DIFF
--- a/cmd/release-controller-api/controller.go
+++ b/cmd/release-controller-api/controller.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	imagev1 "github.com/openshift/api/image/v1"
 	releasepayloadlister "github.com/openshift/release-controller/pkg/client/listers/release/v1alpha1"
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 
@@ -64,6 +65,9 @@ type Controller struct {
 
 	releasePayloadNamespace string
 	releasePayloadLister    releasepayloadlister.ReleasePayloadLister
+
+	// All image streams from app.ci cluster
+	imageStreams []*imagev1.ImageStream
 }
 
 // NewController instantiates a Controller to manage release objects.

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1477,6 +1477,37 @@ func (c *Controller) httpReleaseLatestDownload(w http.ResponseWriter, req *http.
 	http.Redirect(w, req, u, http.StatusFound)
 }
 
+// Find the stream from app.ci and check whether it has the
+// inconsistency annotation
+func (c *Controller) doesInconsistencyExist(tag string) bool {
+	releaseStream, err := c.getStreamFromTag(tag)
+	if err == nil {
+		if inconsistencyMessage, ok := releaseStream.Annotations[releasecontroller.ReleaseAnnotationInconsistency]; ok {
+			_, nil := jsonArrayToString(inconsistencyMessage)
+			if nil == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Controller) tableLink(config *releasecontroller.ReleaseConfig, tag imagev1.TagReference) string {
+	if canLink(tag) {
+		if value, ok := tag.Annotations[releasecontroller.ReleaseAnnotationKeep]; ok {
+			return fmt.Sprintf(`<td class="text-monospace"><a title="%s" class="%s" href="/releasestream/%s/release/%s">%s <span>*</span></a></td>`, template.HTMLEscapeString(value), phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
+		}
+		if strings.Contains(tag.Name, "nightly") && c.doesInconsistencyExist(tag.Name) {
+			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a> <a href="/releasestream/%s/inconsistency/%s"><i title="Inconsistency detected! Click for more details" class="bi bi-exclamation-circle"></i></a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name))
+		} else if config.As == releasecontroller.ReleaseConfigModeStable {
+			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" style="padding-left:15px" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
+		} else {
+			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
+		}
+	}
+	return fmt.Sprintf(`<td class="text-monospace %s">%s</td>`, phaseAlert(tag), template.HTMLEscapeString(tag.Name))
+}
+
 func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { klog.V(4).Infof("rendered in %s", time.Now().Sub(start)) }()
@@ -1570,7 +1601,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 				}
 				return ""
 			},
-			"tableLink":       tableLink,
+			"tableLink":       c.tableLink,
 			"versionGrouping": versionGrouping,
 			"stableStream":    stableStream,
 			"phaseCell":       phaseCell,
@@ -1735,7 +1766,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 				}
 				return ""
 			},
-			"tableLink":      tableLink,
+			"tableLink":      c.tableLink,
 			"phaseCell":      phaseCell,
 			"phaseAlert":     phaseAlert,
 			"inc":            func(i int) int { return i + 1 },

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -55,14 +55,8 @@ var statusComplete = sets.NewString(strings.ToLower(jira.StatusOnQA), strings.To
 // Find the stream from releaseTag.
 // Eg if we have release.openshift.io/releaseTag, we find the corresponding stream metadata
 func (c *Controller) getStreamFromTag(tag string) (*imagev1.ImageStream, error) {
-	// Get all imagestreams from app.ci
-	imageStreams, err := c.releaseLister.List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-
 	// Go through each image stream
-	for _, stream := range imageStreams {
+	for _, stream := range c.imageStreams {
 		// Get the field release.openshift.io/releaseTag from Annotations
 		releaseTag, ok := stream.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]
 		if !ok {
@@ -1509,6 +1503,10 @@ func (c *Controller) tableLink(config *releasecontroller.ReleaseConfig, tag imag
 }
 
 func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
+	// Get the data just once per run
+	imageStreams, _ := c.releaseLister.List(labels.Everything())
+	c.imageStreams = imageStreams
+
 	start := time.Now()
 	defer func() { klog.V(4).Infof("rendered in %s", time.Now().Sub(start)) }()
 

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -243,22 +243,6 @@ func canLink(tag imagev1.TagReference) bool {
 	}
 }
 
-func tableLink(config *releasecontroller.ReleaseConfig, tag imagev1.TagReference, inconsistencies bool) string {
-	if canLink(tag) {
-		if value, ok := tag.Annotations[releasecontroller.ReleaseAnnotationKeep]; ok {
-			return fmt.Sprintf(`<td class="text-monospace"><a title="%s" class="%s" href="/releasestream/%s/release/%s">%s <span>*</span></a></td>`, template.HTMLEscapeString(value), phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
-		}
-		if strings.Contains(tag.Name, "nightly") && inconsistencies {
-			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a> <a href="/releasestream/%s/inconsistency/%s"><i title="Inconsistency detected! Click for more details" class="bi bi-exclamation-circle"></i></a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name))
-		} else if config.As == releasecontroller.ReleaseConfigModeStable {
-			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" style="padding-left:15px" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
-		} else {
-			return fmt.Sprintf(`<td class="text-monospace"><a class="%s" href="/releasestream/%s/release/%s">%s</a></td>`, phaseAlert(tag), template.HTMLEscapeString(config.Name), template.HTMLEscapeString(tag.Name), template.HTMLEscapeString(tag.Name))
-		}
-	}
-	return fmt.Sprintf(`<td class="text-monospace %s">%s</td>`, phaseAlert(tag), template.HTMLEscapeString(tag.Name))
-}
-
 func (c *Controller) GetReleasePayload(name string) *v1alpha1.ReleasePayload {
 	payload, err := c.releasePayloadLister.ReleasePayloads(c.releasePayloadNamespace).Get(name)
 	if err != nil {

--- a/cmd/release-controller-api/static/releaseDashboardPage.tmpl
+++ b/cmd/release-controller-api/static/releaseDashboardPage.tmpl
@@ -39,7 +39,7 @@
             {{ if lt $index 10 }}
             {{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
             <tr>
-                {{ tableLink $release.Config $tag $release.HasInconsistencies }}
+                {{ tableLink $release.Config $tag }}
                 {{ phaseCell . }}
                 <td title="{{ $created }}">{{ since $created }}</td>
                 {{ if $upgrades }}{{ upgradeJobs $upgrades $index $created }}{{ end }}

--- a/cmd/release-controller-api/static/releasePageHtml.tmpl
+++ b/cmd/release-controller-api/static/releasePageHtml.tmpl
@@ -43,7 +43,7 @@ oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}grap
             {{ range $index, $tag := .Tags }}
             {{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
             <tr>
-                {{ tableLink $release.Config $tag $release.HasInconsistencies }}
+                {{ tableLink $release.Config $tag }}
                 {{ phaseCell . }}
                 <td title="{{ $created }}">{{ since $created }}</td>
                 <td>{{ links . $release }}</td>


### PR DESCRIPTION
Follows https://github.com/openshift/release-controller/pull/575

Currently, we display the `i` icon next to all nightlies if the latest one has inconsistency. With this update, it will not display that icon.