### PR TITLE
[OCPCRT-169] Clean up inconsistency page

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -2067,6 +2067,12 @@ func (c *Controller) httpInconsistencyInfo(w http.ResponseWriter, req *http.Requ
 	start := time.Now()
 	defer func() { klog.V(4).Infof("rendered in %s", time.Now().Sub(start)) }()
 
+	// If someone directly goes to this page, then sync images streams if empty
+	if c.imageStreams == nil {
+		imageStreams, _ := c.releaseLister.List(labels.Everything())
+		c.imageStreams = imageStreams
+	}
+
 	vars := mux.Vars(req)
 	imageStreamInconsistencies := Inconsistencies{}
 	type1Inconsistency := PayloadInconsistencyDetails{}

--- a/cmd/release-controller-api/static/imageStreamInconsistency.tmpl
+++ b/cmd/release-controller-api/static/imageStreamInconsistency.tmpl
@@ -67,6 +67,8 @@
     </section>
 </div>
 {{end}}
+
+{{if .PayloadInconsistencies}}
 <div class="mt-4 content-wrapper">
     <section class="content">
         <div class="container-fluid">
@@ -106,5 +108,6 @@
         </div>
     </section>
 </div>
+{{end}}
 </body>
 </html>


### PR DESCRIPTION
Follows https://github.com/openshift/release-controller/pull/577

Changes in this PR:
- Do not display payload inconsistency if it doesn't exist
- If a user directly goes to the inconsistency page, load the streams from cluster if the variable is empty 