### PR TITLE
Fixing incorrect string replacement

### DIFF
--- a/pkg/rhcos/rhcos.go
+++ b/pkg/rhcos/rhcos.go
@@ -59,7 +59,7 @@ func TransformMarkDownOutput(markdown, fromTag, toTag, architecture, architectur
 	if m := reMdRHCoSVersion.FindStringSubmatch(markdown); m != nil {
 		markdown = transformCoreOSLinks(rhelCoreOs, architecture, architectureExtension, markdown, m)
 	} else if m = reMdCentOSCoSVersion.FindStringSubmatch(markdown); m != nil {
-		markdown = transformCoreOSLinks(rhelCoreOs, architecture, architectureExtension, markdown, m)
+		markdown = transformCoreOSLinks(centosStreamCoreOs, architecture, architectureExtension, markdown, m)
 	}
 	return markdown, nil
 }


### PR DESCRIPTION
Looks like a copy-n-paste error from when I first introduced this code.  This issue presents when any 2 versions of OKD-SCOS share the same version of CoreOS.  The replacement was incorrectly using RHCOS instead of CoreOS.