### PR TITLE
Makefile: disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ version=v${build_date}-${git_commit}
 SOURCE_GIT_TAG=v1.0.0+$(shell git rev-parse --short=7 HEAD)
 
 GO_LD_EXTRAFLAGS=-X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitCommit=$(shell git rev-parse HEAD) -X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitVersion=${SOURCE_GIT_TAG} -X k8s.io/test-infra/prow/version.Name=release-controller -X k8s.io/test-infra/prow/version.Version=${version}
+GO_TEST_FLAGS=
+export CGO_ENABLED := 0
 
 # Codegen configuration
 CODEGEN_PKG=./vendor/k8s.io/code-generator


### PR DESCRIPTION
We're getting GLIBC errors for the reimport controller as the `cli` image is currently based on RHEL8 while the golang builder is on RHEL9. Disabling CGO will fix this mismatch.