### PR TITLE
Makefile: disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ version=v${build_date}-${git_commit}
 SOURCE_GIT_TAG=v1.0.0+$(shell git rev-parse --short=7 HEAD)
 
 GO_LD_EXTRAFLAGS=-X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitCommit=$(shell git rev-parse HEAD) -X github.com/openshift/release-controller/vendor/k8s.io/client-go/pkg/version.gitVersion=${SOURCE_GIT_TAG} -X k8s.io/test-infra/prow/version.Name=release-controller -X k8s.io/test-infra/prow/version.Version=${version}
-GO_TEST_FLAGS=
-export CGO_ENABLED := 0
 
 # Codegen configuration
 CODEGEN_PKG=./vendor/k8s.io/code-generator


### PR DESCRIPTION
This PR reenables CGO and the `-race` test flag once the RHEL9 migration
for OCP is complete.