### PR TITLE
Drop verification results annotation

### DIFF
--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -265,7 +265,11 @@ func (c *Controller) transitionReleasePhaseFailure(release *releasecontroller.Re
 			}
 			tag.Annotations[releasecontroller.ReleaseAnnotationPhase] = phase
 			for k, v := range annotations {
-				tag.Annotations[k] = v
+				if len(v) == 0 {
+					delete(tag.Annotations, k)
+				} else {
+					tag.Annotations[k] = v
+				}
 			}
 			klog.V(2).Infof("Marking release %s failed: %v", name, annotations)
 			changed++


### PR DESCRIPTION
Currently, the release-controller's UI relies, solely, on the results stored in the respective release's ReleasePayload object and not on the verification results annotation of the ImageStreamTag.  Therefore, when a release reaches a terminal state of `Accepted` or `Rejected`, the necessity for carrying the verification results has little value any more.  This PR will cause the `release.openshift.io/verify` annotation to be deleted if/when the corresponding release reaches the `Accepted` or `Rejected` state.
As a result of this PR, and a manual cleanup effort (to purge the annotation from all Accepted/Rejected releases), it will be highly unlikely that we accumulate enough data that the size of the underlying imagestream ever reaches the maximum size of an etcd object (~1.5mb) again.