### PR TITLE
http: add collapse support for all imagestreams

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1711,7 +1711,6 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 		}
 	}
 	if requestedStream == nil {
-		klog.V(2).Infof("COULDN'T FIND RELEASE")
 		return
 	}
 
@@ -1865,7 +1864,16 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 	if r.Config.As != releasecontroller.ReleaseConfigModeStable {
 		s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph, false)
 	}
+	page.TargetStream = s
 	page.Streams = append(page.Streams, s)
+	for _, check := range r.Config.Check {
+		if check.ConsistentImages != nil {
+			parent := findReleaseStream(page, check.ConsistentImages.Parent)
+			if parent != nil {
+				page.Streams = append(page.Streams, s)
+			}
+		}
+	}
 	sort.Sort(preferredReleases(page.Streams))
 	checkReleasePage(page)
 	pruneEndOfLifeTags(page, endOfLifePrefixes)

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -25,9 +25,10 @@ import (
 )
 
 type ReleasePage struct {
-	BaseURL    string
-	Streams    []ReleaseStream
-	Dashboards []Dashboard
+	BaseURL      string
+	Streams      []ReleaseStream
+	Dashboards   []Dashboard
+	TargetStream ReleaseStream
 }
 
 type ReleaseStream struct {

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -3,16 +3,17 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
-	"github.com/openshift/release-controller/pkg/releasepayload"
 	"io"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 	"net/url"
 	"sort"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	"github.com/openshift/release-controller/pkg/releasepayload"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 

--- a/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
+++ b/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
@@ -1,14 +1,14 @@
 <p class="small">Source code for this page located on <a href="https://github.com/openshift/release-controller">github</a></p>
 </div>
-<script src="static/js/jquery-1.11.3.min.js"></script>
-<script src="static/js/jquery.dataTables.js"></script>
-<script src="static/js/dataTables.rowGroup.min.js"></script>
-{{ $stableList := stableStream .Streams }}
-{{ range  $i, $stream := $stableList }}
+<script src="/static/js/jquery-1.11.3.min.js"></script>
+<script src="/static/js/jquery.dataTables.js"></script>
+<script src="/static/js/dataTables.rowGroup.min.js"></script>
+{{ $streamNameList := streamNames .Streams }}
+{{ range  $i, $stream := $streamNameList }}
 <script>
     $(document).ready(function() {
         var collapsedGroups = {};
-        var table = $('#{{ $stream  }}_table').DataTable({
+        var table = $('#{{ removeSpecialCharacters $stream  }}_table').DataTable({
             columnDefs: [
                 {
                     "targets": [ 4 ],
@@ -23,6 +23,9 @@
             rowGroup: {
                 dataSrc: 4,
                 startRender: function (rows, group) {
+                    if (group == "delayedMessage") {
+                        return $('<tr/>')
+                    }
                     var collapsed = !!collapsedGroups[group];
                     var i = 0;
                     j = 0;
@@ -54,7 +57,7 @@
                 }
             }
         });
-        $('#{{ $stream  }}_table tbody').on('click', 'tr.group-start',  function () {
+        $('#{{ removeSpecialCharacters $stream  }}_table tbody').on('click', 'tr.group-start',  function () {
             var name = $(this).data('name');
             collapsedGroups[name] = !collapsedGroups[name];
             table.draw(false);
@@ -88,6 +91,6 @@
     }
 </script>
 {{ end }}
-<link href="static/css/custom.css" rel="stylesheet" type="text/css" />
+<link href="/static/css/custom.css" rel="stylesheet" type="text/css" />
 </body>
 </html>

--- a/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
+++ b/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
@@ -69,7 +69,7 @@
         var input, filter, table, tr, td, i, txtValue;
         input = document.getElementById(element);
         filter = input.value.toUpperCase();
-        table = document.getElementById("{{ $stream  }}_table");
+        table = document.getElementById("{{ removeSpecialCharacters $stream  }}_table");
         tr = table.getElementsByTagName("tr");
         for (i = 0; i < tr.length; i++) {
             td = tr[i].getElementsByTagName("td")[0];

--- a/cmd/release-controller-api/static/releaseStreamPageHtml.tmpl
+++ b/cmd/release-controller-api/static/releaseStreamPageHtml.tmpl
@@ -1,13 +1,12 @@
 <a href="/">Back home</a>
 <div class="row">
     <div class="col">
-        {{ range .Streams }}
-        {{ $isStable := .Release.Config.As }}
-        <h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}"><a id="{{ .Release.Config.Name }}" href="#{{ .Release.Config.Name }}" class="text-dark">{{ .Release.Config.Name }}</a></h2>
-        {{ publishDescription . }}
-        {{ alerts . }}
-        {{ $upgrades := .Upgrades }}
-        <table id="{{.Release.Config.Name}}_table" class="table text-nowrap">
+        {{ $isStable := .TargetStream.Release.Config.As }}
+        <h2 title="From image stream {{ .TargetStream.Release.Source.Namespace }}/{{ .TargetStream.Release.Source.Name }}"><a id="{{ .TargetStream.Release.Config.Name }}" href="#{{ .TargetStream.Release.Config.Name }}" class="text-dark">{{ .TargetStream.Release.Config.Name }}</a></h2>
+        {{ publishDescription .TargetStream }}
+        {{ alerts .TargetStream }}
+        {{ $upgrades := .TargetStream.Upgrades }}
+        <table id="{{.TargetStream.Release.Config.Name}}_table" class="table text-nowrap">
             <thead>
             <tr>
                 <th title="The name and version of the release image (as well as the tag it is published under)">Name</th>
@@ -18,14 +17,14 @@
             </tr>
             </thead>
             <tbody>
-            {{ $release := .Release }}
-            {{ if .Delayed }}
+            {{ $release := .TargetStream.Release }}
+            {{ if .TargetStream.Delayed }}
             <tr>
-                <td colspan="4"><em>{{ .Delayed.Message }}</em></td>
+                <td colspan="4"><em>{{ .TargetStream.Delayed.Message }}</em></td>
                 {{ if $upgrades }}<td colspan="{{ inc $upgrades.Width }}"></td>{{ end }}
             </tr>
             {{ end }}
-            {{ range $index, $tag := .Tags }}
+            {{ range $index, $tag := .TargetStream.Tags }}
             {{ $created := index .Annotations "release.openshift.io/creationTimestamp" }}
             <tr>
                 {{ tableLink $release.Config $tag }}
@@ -37,6 +36,5 @@
             {{ end }}
             </tbody>
         </table>
-        {{ end }}
     </div>
 </div>

--- a/cmd/release-controller-api/static/releaseStreamPageHtml.tmpl
+++ b/cmd/release-controller-api/static/releaseStreamPageHtml.tmpl
@@ -1,45 +1,28 @@
-<h1>Release Status</h1>
-<p class="small mb-3">
-    Quick links: {{ dashboardsJoin .Dashboards }}
-</p>
-<p>Visualize upgrades in <a href="/graph">Cincinnati</a> | <a href="/graph?format=dot">dot</a> | <a href="/graph?format=svg">SVG</a> | <a href="/graph?format=png">PNG</a> format. Run the following command to make this your update server:</p>
-<pre class="ml-4">
-oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}graph"}}' --type=merge
-</pre>
-<div class="alert alert-primary">This site is part of OpenShift's continuous delivery pipeline. Neither the builds linked here nor the upgrade paths tested here are officially supported. For information about the available builds, please reference the <a href="https://mirror.openshift.com/pub/openshift-v4/OpenShift_Release_Types.pdf" target="_blank">OpenShift Release Types documentation</a>.</br>Please visit the Red Hat Customer Portal for the latest supported product details.</div>
-{{ displayAuthMessage }}
-
-<p class="small mb-3">
-    Jump to: {{ releaseJoin .Streams true }}
-</p>
-
+<a href="/">Back home</a>
 <div class="row">
     <div class="col">
         {{ range .Streams }}
+        {{ $isStable := .Release.Config.As }}
         <h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}"><a id="{{ .Release.Config.Name }}" href="#{{ .Release.Config.Name }}" class="text-dark">{{ .Release.Config.Name }}</a></h2>
         {{ publishDescription . }}
         {{ alerts . }}
-        <a href="/releasestream/{{ .Release.Config.Name }}">Full list with upgrade graph</a>
         {{ $upgrades := .Upgrades }}
-        <table id="{{removeSpecialCharacters .Release.Config.Name}}_table" class="table text-nowrap">
+        <table id="{{.Release.Config.Name}}_table" class="table text-nowrap">
             <thead>
             <tr>
                 <th title="The name and version of the release image (as well as the tag it is published under)">Name</th>
                 <th title="The release moves through these stages:&#10;&#10;Pending - still creating release image&#10;Ready - release image created&#10;Accepted - all tests pass&#10;Rejected - some tests failed&#10;Failed - Could not create release image">Phase</th>
                 <th>Started</th>
                 <th title="Tests that failed or are still pending on releases. See release page for more.">Failures</th>
-                <th>Version Grouping</th>
+                {{ if $upgrades }}<th colspan="{{ inc $upgrades.Width }}">Upgrades</th>{{ end }}
             </tr>
             </thead>
             <tbody>
             {{ $release := .Release }}
             {{ if .Delayed }}
             <tr>
-                <td><em>{{ .Delayed.Message }}</em></td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>delayedMessage</td>
+                <td colspan="4"><em>{{ .Delayed.Message }}</em></td>
+                {{ if $upgrades }}<td colspan="{{ inc $upgrades.Width }}"></td>{{ end }}
             </tr>
             {{ end }}
             {{ range $index, $tag := .Tags }}
@@ -49,7 +32,7 @@ oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}grap
                 {{ phaseCell . }}
                 <td title="{{ $created }}">{{ since $created }}</td>
                 <td>{{ links . $release }}</td>
-                <td>{{ versionGrouping $tag.Name }}</td>
+                {{ upgradeCells $upgrades $index }}
             </tr>
             {{ end }}
             </tbody>


### PR DESCRIPTION
This PR adds support for collapsable rows for all imagestreams on the homepage of the `release-controller-api` and adds new pages for each individual imagestream at `/releasestream/releaseConfigName` for users who wish to see the upgrade graph. Due to the massive size of the `4-stable` upgrade graph, the upgrade graph is omitted for `/releasestream/4-stable`.