### PR TITLE
Adding support for a version prefix to the latest API

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -498,8 +498,12 @@ func (c *Controller) locateLatest(w http.ResponseWriter, req *http.Request) (*re
 		}
 		relativeIndex = i
 	}
+	var releasePrefix string
+	if inString := req.URL.Query().Get("prefix"); len(inString) > 0 {
+		releasePrefix = inString
+	}
 
-	r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, streamName, constraint, relativeIndex)
+	r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, streamName, constraint, relativeIndex, releasePrefix)
 	if err != nil {
 		code := http.StatusInternalServerError
 		if err == releasecontroller.ErrStreamNotFound || err == releasecontroller.ErrStreamTagNotFound {

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -208,7 +208,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 		if err != nil {
 			return "", "", fmt.Errorf("invalid semver range `%s`: %w", upgradeRelease.Prerelease.VersionBounds.Query(), err)
 		}
-		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, "4-stable", semverRange, 0)
+		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, "4-stable", semverRange, 0, "")
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get latest tag in 4-stable stream: %w", err)
 		}
@@ -219,7 +219,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 		// create blank semver.Range
 		var constraint semver.Range
 		stream := fmt.Sprintf("%s.0-0.%s%s", upgradeRelease.Candidate.Version, upgradeRelease.Candidate.Stream, strings.TrimPrefix(release.Config.To, "release"))
-		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, stream, constraint, upgradeRelease.Candidate.Relative)
+		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, stream, constraint, upgradeRelease.Candidate.Relative, "")
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get latest tag for stream %s: %w", stream, err)
 		}

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -490,7 +490,7 @@ func GetStableReleases(rcCache *lru.Cache, eventRecorder record.EventRecorder, l
 	return stable, nil
 }
 
-func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, streamName string, constraint semver.Range, relativeIndex int) (*Release, *imagev1.TagReference, error) {
+func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, streamName string, constraint semver.Range, relativeIndex int, versionPrefix string) (*Release, *imagev1.TagReference, error) {
 	imageStreams, err := lister.List(labels.Everything())
 	if err != nil {
 		return nil, nil, err
@@ -507,6 +507,9 @@ func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lis
 		tags := UnsortedSemanticReleaseTags(r, ReleasePhaseAccepted)
 		sort.Sort(tags)
 		for _, ver := range tags {
+			if len(versionPrefix) > 0 && !strings.HasPrefix(ver.Tag.Name, versionPrefix) {
+				continue
+			}
 			if constraint != nil && (ver.Version == nil || !constraint(*ver.Version)) {
 				continue
 			}


### PR DESCRIPTION
This will allow users the ability to filter the results down the only the versions that match the specified prefix:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest?prefix=4.14`