### PR TITLE
Adding retry support to the Aggregator job

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/openshift/release-controller/pkg/prow"
@@ -38,8 +39,13 @@ func (c *Controller) ensureProwJobForReleaseTag(release *releasecontroller.Relea
 		} else {
 			jobName = defaultAggregateProwJobName
 		}
+		aggregatorSuffix := "aggregator"
+		if retry, err := strconv.Atoi(verifySuffix); err == nil {
+			klog.V(6).Infof("Aggregator job has failed.  Retry count: %d", retry)
+			aggregatorSuffix = aggregatorSuffix + fmt.Sprintf("-%s", verifySuffix)
+		}
 		// Postfix the name to differentiate it from the analysis jobs
-		prowJobName = prow.GenerateSafeProwJobName(fullProwJobName, "aggregator")
+		prowJobName = prow.GenerateSafeProwJobName(fullProwJobName, aggregatorSuffix)
 	}
 	obj, exists, err := c.prowLister.GetByKey(fmt.Sprintf("%s/%s", c.prowNamespace, prowJobName))
 	if err != nil {

--- a/cmd/release-controller/sync_verify_prow_test.go
+++ b/cmd/release-controller/sync_verify_prow_test.go
@@ -97,6 +97,18 @@ func TestGenerateSafeProwJobName(t *testing.T) {
 			suffix:   "analysis-1",
 			expected: "4.9.0-0.ci-2021-08-30-133010-this-is-a-reall-gmlwrnb-analysis-1",
 		},
+		{
+			name:     "AggregatorJob",
+			jobName:  "4.16.0-0.nightly-2024-02-07-125310-aggregated-hypershift-ovn-conformance-4.16",
+			suffix:   "aggregator",
+			expected: "4.16.0-0.nightly-2024-02-07-125310-aggregate-44j0w6k-aggregator",
+		},
+		{
+			name:     "AggregatorJobWithRetry",
+			jobName:  "4.16.0-0.nightly-2024-02-07-125310-aggregated-hypershift-ovn-conformance-4.16",
+			suffix:   "aggregator-2",
+			expected: "4.16.0-0.nightly-2024-02-07-125310-aggrega-44j0w6k-aggregator-2",
+		},
 	}
 
 	t.Parallel()


### PR DESCRIPTION
There have been reports of the "aggregator" job being randomly deleted in the middle of release verification.  Unfortunately, the original implementation didn't allow for the job to be retried.  This PR adds the necessary logic to allow for the aggregator job to be retried.  To enable the logic, you can update an aggregated job as follows:
```json
    "aggregated-hypershift-ovn-conformance-4.16": {
      "maxRetries": 3,
      "prowJob": {
        "name": "periodic-ci-openshift-hypershift-release-4.16-periodics-e2e-aws-ovn-conformance"
      },
      "aggregatedProwJob": {
        "analysisJobCount": 10
      }
    },
```