### PR TITLE
remove conflicted repositories on `git-init`

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -1008,7 +1008,20 @@ func (r *ExecReleaseInfo) specHash(image string) appsv1.StatefulSetSpec {
 							  echo "Performing git maintenance..."
 							  for repo in $(find /tmp/git -type d -a -name .git | xargs dirname)
 							  do
-								(echo $repo && cd $repo && git gc && git pull)
+								(
+								  echo $repo
+								  cd $repo
+							
+								  # Check for unmerged files
+								  if git status | grep -q "Unmerged paths"; then
+									echo "Repository has unmerged files. Removing the directory and moving to the next repository..."
+									git reset --hard HEAD  # discards all changes 
+								  else
+									# No conflicts, perform maintenance
+									git gc
+									git pull
+								  fi
+								)
 							  done
 							else
 							  FROM=$(curl -s https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/accepted | jq -r '.["4-stable"][0] // empty')


### PR DESCRIPTION
To avoid issues such as: 
```
/tmp/git/github.com/openshift/cloud-provider-openstack
error: Pulling is not possible because you have unmerged files.
hint: Fix them up in the work tree, and then use 'git add/rm <file>'
hint: as appropriate to mark resolution and make a commit.
fatal: Exiting because of an unresolved conflict.
```
With this PR, the conflicted repositories will be removed while consolidating. 