### PR TITLE
Allow changelogs with missing commits

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -253,12 +253,16 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string, isJson bool) (string, error
 		Stdin:  nil,
 		Stderr: errOut,
 	}); err != nil {
-		klog.V(4).Infof("Failed to generate changelog: %v\n$ %s\n%s\n%s", err, strings.Join(cmd, " "), errOut.String(), out.String())
 		msg := errOut.String()
 		if len(msg) == 0 {
 			msg = err.Error()
 		}
-		return "", fmt.Errorf("could not generate a changelog: %v", msg)
+		if strings.Contains(msg, "Could not load commits for") {
+			klog.Warningf("Generated changelog with missing commits:\n$ %s\n%s", strings.Join(cmd, " "), errOut.String())
+		} else {
+			klog.V(4).Infof("Failed to generate changelog: %v\n$ %s\n%s\n%s", err, strings.Join(cmd, " "), errOut.String(), out.String())
+			return "", fmt.Errorf("could not generate a changelog: %v", msg)
+		}
 	}
 	if isJson {
 		var changeLog ChangeLog


### PR DESCRIPTION
When generating the Changelog between releases, we make a call down into the `git-cache` pod like:
```bash
$ oc adm release info --changelog=/tmp/git/ quay.io/openshift-release-dev/ocp-release@sha256:a346fc0c84644e64c726013a98bef0f75e58f246fce1faa83fb6bbbc6d4050aa quay.io/openshift-release-dev/ocp-release@sha256:073a4e46289be25e2a05f5264c8f1d697410db66b960c9ceeddebd1c61e58717
```
When `oc` encounters an error while running the command, it:
1. Returns an error code `1`
2. Outputs the error into `stdErr`
3. Prints the truncated ouput to `stdOut`

This fix specifically checks `stdErr` for the string: ` Could not load commits for`
If it finds the string, it will log a `Warning` message with the details, swallow the error, and display the truncated output.