### PR TITLE
pin release-tool.py requirements to openshift-client 1.0.16

### DIFF
--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,1 +1,1 @@
-openshift-client
+openshift-client==1.0.16


### PR DESCRIPTION
If you don't pin, you get latest stable version:

```bash
$ pip install -r requirements.txt 
Collecting openshift-client (from -r requirements.txt (line 1))
  Obtaining dependency information for openshift-client from https://files.pythonhosted.org/packages/34/ee/68341c51f15a106990a2799fc6403fb46fe97dabf5c48a82d5e87b314a12/openshift_client-2.0.1-py3-none-any.whl.metadata
  Downloading openshift_client-2.0.1-py3-none-any.whl.metadata (37 kB)
Requirement already satisfied: pyyaml in /Users/dperique/anaconda3/lib/python3.11/site-packages (from openshift-client->-r requirements.txt (line 1)) (6.0)
Requirement already satisfied: six in /Users/dperique/anaconda3/lib/python3.11/site-packages (from openshift-client->-r requirements.txt (line 1)) (1.16.0)
Downloading openshift_client-2.0.1-py3-none-any.whl (78 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.9/78.9 kB 1.6 MB/s eta 0:00:00
Installing collected packages: openshift-client
Successfully installed openshift-client-2.0.1
```

But `release-tool.py` doesn't run on latest stable:

```bash
(base) schubert:hack dperique$ ./release-tool.py -h
Traceback (most recent call last):
  File "/Volumes/EnvoyProSX/mygit/dperique/NG/Dennis/Redhat/release-controller/hack/./release-tool.py", line 12, in <module>
    import openshift as oc
ModuleNotFoundError: No module named 'openshift'
```

Even with more pip installs for `openshift`, you still get:

```bash
$ ./release-tool.py 
Traceback (most recent call last):
  File "/Volumes/EnvoyProSX/mygit/dperique/NG/Dennis/Redhat/release-controller/hack/./release-tool.py", line 13, in <module>
    from openshift import OpenShiftPythonException, Missing
ImportError: cannot import name 'OpenShiftPythonException' from 'openshift' (/Users/dperique/anaconda3/envs/test-accept-reject/lib/python3.10/site-packages/openshift/__init__.py)
```

With my pin:

```bash
$ pip install openshift-client==1.0.16
Collecting openshift-client==1.0.16
  Using cached openshift_client-1.0.16-py2.py3-none-any.whl (74 kB)
Collecting six (from openshift-client==1.0.16)
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting pyyaml (from openshift-client==1.0.16)
  Using cached PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl.metadata (2.1 kB)
Collecting paramiko (from openshift-client==1.0.16)
  Downloading paramiko-3.4.0-py3-none-any.whl.metadata (4.4 kB)
Collecting bcrypt>=3.2 (from paramiko->openshift-client==1.0.16)
  Using cached bcrypt-4.1.2-cp39-abi3-macosx_10_12_universal2.whl.metadata (9.5 kB)
Collecting cryptography>=3.3 (from paramiko->openshift-client==1.0.16)
  Downloading cryptography-42.0.3-cp39-abi3-macosx_10_12_universal2.whl.metadata (5.3 kB)
Collecting pynacl>=1.5 (from paramiko->openshift-client==1.0.16)
  Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl (349 kB)
Collecting cffi>=1.12 (from cryptography>=3.3->paramiko->openshift-client==1.0.16)
  Using cached cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl.metadata (1.5 kB)
Collecting pycparser (from cffi>=1.12->cryptography>=3.3->paramiko->openshift-client==1.0.16)
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Downloading paramiko-3.4.0-py3-none-any.whl (225 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 225.9/225.9 kB 2.1 MB/s eta 0:00:00
Using cached PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl (189 kB)
Using cached bcrypt-4.1.2-cp39-abi3-macosx_10_12_universal2.whl (528 kB)
Downloading cryptography-42.0.3-cp39-abi3-macosx_10_12_universal2.whl (5.9 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.9/5.9 MB 409.5 kB/s eta 0:00:00
Using cached cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl (182 kB)
Installing collected packages: six, pyyaml, pycparser, bcrypt, cffi, pynacl, cryptography, paramiko, openshift-client
Successfully installed bcrypt-4.1.2 cffi-1.16.0 cryptography-42.0.3 openshift-client-1.0.16 paramiko-3.4.0 pycparser-2.21 pynacl-1.5.0 pyyaml-6.0.1 six-1.16.0
```

You get a version that is known to work:

```bash
(test-accept-reject) schubert:hack dperique$ ./release-tool.py 
usage: release-tool.py [-h] [-m MESSAGE] [-r REASON] [-o OUTPUT] [--execute] [-v] [-c CONTEXT] [-k KUBECONFIG] [-n {ocp,okd}] [-i IMAGESTREAM] [-a {amd64,arm64,ppc64le,s390x,multi}] [-p]
                       {accept,reject,prune,archive,import,keep} ...
```