### PR TITLE
Exclude `MultiJobAnalysis` jobs from stable release verification jobs

### DIFF
--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -566,7 +566,7 @@ func GetVerificationJobs(rcCache *lru.Cache, eventRecorder record.EventRecorder,
 		return nil, fmt.Errorf("failed to get release definition from stream %s/%s", release.Target.Namespace, isName)
 	}
 	for name, verify := range versionedRelease.Config.Verify {
-		if _, ok := jobs[name]; !ok && !verify.Optional && verify.AggregatedProwJob == nil {
+		if _, ok := jobs[name]; !ok && !verify.Optional && verify.AggregatedProwJob == nil && !verify.MultiJobAnalysis {
 			verify.Optional = true
 			jobs[name] = verify
 		}


### PR DESCRIPTION
When verifying `Stable` releases, the release-controller reaches down into the respective release's "nightly" release configuration and runs its `Blocking` jobs as `Informing` jobs.  Due to how the `MultiJobAnalysis` jobs are performed, they are guaranteed to always fail whenever the get run against a `Stable` releases.  

This PR excludes all the `MultiJobAnalysis` from being added to the `Stable` release verification all together.