### PR TITLE
Updating to the latest/greatest `openshift-client-python`

### DIFF
--- a/hack/release-tool.py
+++ b/hack/release-tool.py
@@ -9,8 +9,8 @@ import tempfile
 
 import time
 
-import openshift as oc
-from openshift import OpenShiftPythonException, Missing
+import openshift_client as oc
+from openshift_client import OpenShiftPythonException, Missing
 
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(message)s')
 logger = logging.getLogger('releaseTool')

--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,1 +1,1 @@
-openshift-client
+openshift-client~=2.0


### PR DESCRIPTION
This PR supersedes #603 in that it bumps the dependency up to the `2.*` version of the `openshift-client-python` library.  Unfortunately, this will be a breaking change for anyone who attempts to run the `release-tool.py` against the older version of the library as the package name has changed from `openshift` to `openshift_client`.  This was a necessary change on the `openshift-client-python` side because there were 2 RedHat libraries attempting to use the `openshift` namespace and therefore they couldn't co-exist (https://github.com/openshift/openshift-client-python/issues/75)