### PR TITLE
release_info: use local `oc`

### DIFF
--- a/images/release-controller-api/Dockerfile
+++ b/images/release-controller-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/centos:stream9
+FROM registry.ci.openshift.org/ocp/4.16:tools
 LABEL maintainer="apavel@redhat.com"
 
 RUN yum install -y graphviz

--- a/images/release-controller/Dockerfile
+++ b/images/release-controller/Dockerfile
@@ -1,6 +1,5 @@
-FROM registry.ci.openshift.org/openshift/centos:stream9
+FROM registry.ci.openshift.org/ocp/4.16:tools
 LABEL maintainer="apavel@redhat.com"
 
-RUN yum install -y graphviz
 ADD release-controller /usr/bin/release-controller
 ENTRYPOINT ["/usr/bin/release-controller"]


### PR DESCRIPTION
With https://github.com/openshift/oc/pull/1708, `oc` now requires much less disk space and can be run locally without depending on an external git-cache pod. This improves availability and speed of changelog generation.