### PR TITLE
release-controller: opt-in ProwJob scheduling

### DIFF
--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -173,7 +173,9 @@ func (c *Controller) createProwJobFromPeriodicWithRelease(periodicWithRelease Pe
 	if err != nil || !ok {
 		return fmt.Errorf("failed to add release env to periodic %s: %v", periodicWithRelease.Periodic.Name, err)
 	}
-	prowJob := pjutil.NewProwJob(spec, periodicWithRelease.Periodic.Labels, periodicWithRelease.Periodic.Annotations)
+
+	schedulingEnabled := c.prowConfigLoader.Config().Scheduler.Enabled
+	prowJob := pjutil.NewProwJob(spec, periodicWithRelease.Periodic.Labels, periodicWithRelease.Periodic.Annotations, pjutil.RequireScheduling(schedulingEnabled))
 	prowJob.Labels[releasecontroller.ReleaseAnnotationVerify] = "true"
 	prowJob.Annotations[releasecontroller.ReleaseAnnotationSource] = fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name)
 	prowJob.Annotations[releasecontroller.ReleaseAnnotationToTag] = latestTag.Name

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -109,9 +109,10 @@ func (c *Controller) ensureProwJobForReleaseTag(release *releasecontroller.Relea
 		}
 		ok = ok && status
 	}
+	schedulingEnabled := c.prowConfigLoader.Config().Scheduler.Enabled
 	pj := prowutil.NewProwJob(spec, extraLabels, map[string]string{
 		releasecontroller.ReleaseAnnotationSource: fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name),
-	})
+	}, prowutil.RequireScheduling(schedulingEnabled))
 	// Override default UUID naming of prowjob
 	pj.Name = prowJobName
 	if !ok {


### PR DESCRIPTION
This PR is part of the effort of introducing a scheduler in Prow: https://github.com/kubernetes/test-infra/issues/32039.
It is a follow up of:
- https://github.com/kubernetes/test-infra/pull/32173
- https://github.com/kubernetes/test-infra/pull/32361
- https://github.com/openshift/ci-tools/pull/4044

TL;DR: we have introduced a simple scheduler in Prow, disabled by default. Once enabled via:
```yaml
scheduler:
  enabled: true
```
every agent capable of creating a ProwJob should honor the configuration, hence spawing in `.status.state = scheduling`. Those are going to be picked up by the scheduler, that will assign a cluster to them and make the transition from `.status.state = scheduling` to `.status.state = trigged`. From this moment on the workflow is the same as it used to. We hope the scheduler will reduce the maintenance cost of the TestPlatform infrastructure; in particular during outages.
