### PR TITLE
ensure the PreserveOriginal import mode policy image tag synchronization

### DIFF
--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -29,6 +29,7 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 			releasecontroller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
 			releasecontroller.ReleaseAnnotationPhase:             releasecontroller.ReleasePhasePending,
 		},
+		ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 	}
 	target.Spec.Tags = append(target.Spec.Tags, tag)
 


### PR DESCRIPTION
e.x
```yaml
    - name: 4.11.0-multi
      annotations:
        release.openshift.io/creationTimestamp: '2022-08-09T00:01:01Z'
        release.openshift.io/hash: 4.11.0-multi-102
        release.openshift.io/name: 4-stable-multi
        release.openshift.io/phase: Accepted
        release.openshift.io/rewrite: 'false'
        release.openshift.io/source: ocp-multi/release-multi
      from:
        kind: DockerImage
        name: 'quay.io/openshift-release-dev/ocp-release:4.11.0-multi'
      generation: 102
      importPolicy:
        importMode: Legacy
      referencePolicy:
        type: Source
```
The `quay.io/openshift-release-dev/ocp-release:4.11.0-multi` image holds a manifest list. After `4.13`, Openshift imagestreams are eligible to preserve the manifest list by using the `PreserveOriginal` import mode.

/cc @bear-redhat  

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
