### PR TITLE
Process multi-arch releases

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -303,6 +303,16 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 				if err != nil {
 					return err
 				}
+				// Handle manifest list based releases...
+				for _, m := range isi.Image.DockerImageManifests {
+					if m.Architecture == "amd64" {
+						isi, err = c.imageClient.ImageStreamImages(release.Source.Namespace).Get(context.TODO(), fmt.Sprintf("%s@%s", release.Source.Name, m.Digest), metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+						break
+					}
+				}
 				metadata := &docker10.DockerImage{}
 				if len(isi.Image.DockerImageMetadata.Raw) == 0 {
 					return fmt.Errorf("could not fetch Docker image metadata for release %s", tag.Name)


### PR DESCRIPTION
After the changes, introduced with: https://github.com/openshift/release-controller/pull/617, went live, we started performing "rewrite" jobs for any manifest-list based releases because the label we key off of (`io.openshift.release` is never present inside of the manifest-list of "adopted" releases (i.e. .Z releases published directly into a Stable stream).  This PR checks for multiple manifests and looks for the `amd64` release to then process the label accordingly.