### PR TITLE
release-controller-api: print team acceptance status

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1287,7 +1287,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	fmt.Fprintf(w, "Team Approvals: ")
-	teamApprovedList := c.renderTeamApprovals(tagInfo.Tag)
+	teamApprovedList := c.renderTeamApprovals(tagInfo.Tag, true)
 	if teamApprovedList == "" {
 		fmt.Fprintf(w, "None<br>")
 	} else {
@@ -1707,12 +1707,11 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (c *Controller) renderTeamApprovals(tag string) string {
+func (c *Controller) renderTeamApprovals(tag string, asList bool) string {
 	payload := c.GetReleasePayload(tag)
 	if payload == nil {
 		return ""
 	}
-	approvals := ""
 	acceptedLabels := []string{}
 	rejectedLabels := []string{}
 	for label, value := range payload.Labels {
@@ -1728,18 +1727,37 @@ func (c *Controller) renderTeamApprovals(tag string) string {
 	teamName := func(fullLabel string) string {
 		return strings.ToUpper(strings.Split(strings.TrimSuffix(fullLabel, "_state"), "/")[1])
 	}
+	var approvals string
+	if asList {
+		approvals += "<ul>"
+	}
 	if len(acceptedLabels) > 0 {
+		if asList {
+			approvals += "<li>"
+		}
 		approvals += "<span class=\"text-success\">Accepted</span><ul>"
 		for _, anno := range acceptedLabels {
 			approvals += "<li>" + teamName(anno) + "</li>"
 		}
 		approvals += "</ul>"
+		if asList {
+			approvals += "</li>"
+		}
 	}
 	if len(rejectedLabels) > 0 {
+		if asList {
+			approvals += "<li>"
+		}
 		approvals += "<span class=\"text-danger\">Rejected</span><ul>"
 		for _, anno := range rejectedLabels {
 			approvals += "<li>" + teamName(anno) + "</li>"
 		}
+		approvals += "</ul>"
+		if asList {
+			approvals += "</li>"
+		}
+	}
+	if asList {
 		approvals += "</ul>"
 	}
 	return approvals

--- a/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
+++ b/cmd/release-controller-api/static/htmlPageEndScripts.tmpl
@@ -11,7 +11,7 @@
         var table = $('#{{ removeSpecialCharacters $stream  }}_table').DataTable({
             columnDefs: [
                 {
-                    "targets": [ 4 ],
+                    "targets": [ 5 ],
                     "visible": false,
                     "searchable": false
                 }
@@ -21,7 +21,7 @@
             paging: false,
             searching: false,
             rowGroup: {
-                dataSrc: 4,
+                dataSrc: 5,
                 startRender: function (rows, group) {
                     if (group == "delayedMessage") {
                         return $('<tr/>')

--- a/cmd/release-controller-api/static/releasePageHtml.tmpl
+++ b/cmd/release-controller-api/static/releasePageHtml.tmpl
@@ -28,6 +28,7 @@ oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}grap
                 <th title="The release moves through these stages:&#10;&#10;Pending - still creating release image&#10;Ready - release image created&#10;Accepted - all tests pass&#10;Rejected - some tests failed&#10;Failed - Could not create release image">Phase</th>
                 <th>Started</th>
                 <th title="Tests that failed or are still pending on releases. See release page for more.">Failures</th>
+                <th title="Explicit approvals for teams such as QE and TRT">Team Approvals</th>
                 <th>Version Grouping</th>
             </tr>
             </thead>
@@ -36,6 +37,7 @@ oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}grap
             {{ if .Delayed }}
             <tr>
                 <td><em>{{ .Delayed.Message }}</em></td>
+                <td></td>
                 <td></td>
                 <td></td>
                 <td></td>
@@ -49,6 +51,7 @@ oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}grap
                 {{ phaseCell . }}
                 <td title="{{ $created }}">{{ since $created }}</td>
                 <td>{{ links . $release }}</td>
+                <td>{{ teamApprovals $tag.Name }}</td>
                 <td>{{ versionGrouping $tag.Name }}</td>
             </tr>
             {{ end }}

--- a/cmd/release-controller-api/static/releasePageHtml.tmpl
+++ b/cmd/release-controller-api/static/releasePageHtml.tmpl
@@ -51,7 +51,7 @@ oc patch clusterversion/version --patch '{"spec":{"upstream":"{{ .BaseURL }}grap
                 {{ phaseCell . }}
                 <td title="{{ $created }}">{{ since $created }}</td>
                 <td>{{ links . $release }}</td>
-                <td>{{ teamApprovals $tag.Name }}</td>
+                <td>{{ teamApprovals $tag.Name false }}</td>
                 <td>{{ versionGrouping $tag.Name }}</td>
             </tr>
             {{ end }}


### PR DESCRIPTION
This adds a new column to the release streams called "Team Approvals" which list all teams that have accepted or rejected a release payload via a label with a key in the format of "...teamName_state" which can have a value of "Accepted" or "Rejected". This also prints the list of the tag's page above the test results.