### PR TITLE
Adding support for prowjobs in a `Scheduling` state

### DIFF
--- a/pkg/apis/release/v1alpha1/types.go
+++ b/pkg/apis/release/v1alpha1/types.go
@@ -378,6 +378,9 @@ const (
 	// JobRunStateTriggered job has been created but not scheduled
 	JobRunStateTriggered JobRunState = "Triggered"
 
+	// JobRunStateScheduling job has been created and is waiting to be scheduled
+	JobRunStateScheduling JobRunState = "Scheduling"
+
 	// JobRunStatePending job is running and awaiting completion
 	JobRunStatePending JobRunState = "Pending"
 

--- a/pkg/cmd/release-payload-controller/job_state_controller.go
+++ b/pkg/cmd/release-payload-controller/job_state_controller.go
@@ -145,7 +145,7 @@ func computeJobState(job v1alpha1.JobStatus) v1alpha1.JobState {
 func interrogateJobResults(results []v1alpha1.JobRunResult) (pendingJobs, successfulJobs, failedJobs, unknownJobs []v1alpha1.JobRunResult) {
 	for _, result := range results {
 		switch result.State {
-		case v1alpha1.JobRunStatePending, v1alpha1.JobRunStateTriggered:
+		case v1alpha1.JobRunStatePending, v1alpha1.JobRunStateTriggered, v1alpha1.JobRunStateScheduling:
 			pendingJobs = append(pendingJobs, result)
 		case v1alpha1.JobRunStateSuccess:
 			successfulJobs = append(successfulJobs, result)

--- a/pkg/cmd/release-payload-controller/job_state_controller_test.go
+++ b/pkg/cmd/release-payload-controller/job_state_controller_test.go
@@ -678,6 +678,9 @@ func TestInterrogateJobResults(t *testing.T) {
 					State: v1alpha1.JobRunStateSuccess,
 				},
 				{
+					State: v1alpha1.JobRunStateScheduling,
+				},
+				{
 					State: v1alpha1.JobRunStateTriggered,
 				},
 				{
@@ -697,6 +700,9 @@ func TestInterrogateJobResults(t *testing.T) {
 				},
 			},
 			expectedPendingJobs: []v1alpha1.JobRunResult{
+				{
+					State: v1alpha1.JobRunStateScheduling,
+				},
 				{
 					State: v1alpha1.JobRunStateTriggered,
 				},
@@ -760,6 +766,9 @@ func TestProcessJobResults(t *testing.T) {
 					State: v1alpha1.JobRunStateSuccess,
 				},
 				{
+					State: v1alpha1.JobRunStateScheduling,
+				},
+				{
 					State: v1alpha1.JobRunStateTriggered,
 				},
 				{
@@ -783,6 +792,9 @@ func TestProcessJobResults(t *testing.T) {
 		{
 			name: "PendingJobState",
 			results: []v1alpha1.JobRunResult{
+				{
+					State: v1alpha1.JobRunStateScheduling,
+				},
 				{
 					State: v1alpha1.JobRunStateTriggered,
 				},

--- a/pkg/cmd/release-payload-controller/prowjob_controller.go
+++ b/pkg/cmd/release-payload-controller/prowjob_controller.go
@@ -270,6 +270,8 @@ func getJobRunState(prowState v1.ProwJobState) v1alpha1.JobRunState {
 		return v1alpha1.JobRunStateSuccess
 	case v1.TriggeredState:
 		return v1alpha1.JobRunStateTriggered
+	case v1.SchedulingState:
+		return v1alpha1.JobRunStateScheduling
 	default:
 		return v1alpha1.JobRunStateUnknown
 	}

--- a/pkg/release-controller/prowjob.go
+++ b/pkg/release-controller/prowjob.go
@@ -28,7 +28,7 @@ func ProwJobVerificationStatus(obj *unstructured.Unstructured) (*VerificationSta
 	case prowjobsv1.FailureState, prowjobsv1.ErrorState, prowjobsv1.AbortedState:
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "completionTime")
 		status = &VerificationStatus{State: ReleaseVerificationStateFailed, URL: truncateProwJobResultsURL(url)}
-	case prowjobsv1.TriggeredState, prowjobsv1.PendingState, prowjobsv1.ProwJobState(""):
+	case prowjobsv1.TriggeredState, prowjobsv1.PendingState, prowjobsv1.SchedulingState, prowjobsv1.ProwJobState(""):
 		transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "pendingTime")
 		if transitionTime == "" {
 			transitionTime, _, _ = unstructured.NestedString(obj.Object, "status", "startTime")


### PR DESCRIPTION
Prow recently introduced the `Scheduling` state for Prowjobs.  The release-controller controller does not handle this state very well and emits the following log messages every time it encounters it:
```
E0819 21:05:12.870109       1 prowjob.go:38] Unrecognized prow job state "scheduling" on job 4.15.0-0.ci-2024-08-19-205542-gcp-sdn
I0819 21:05:12.870178       1 controller.go:606] Error syncing {ocp 4.15}: unexpected error accessing prow job definition
I0819 21:05:12.870295       1 event.go:377] Event(v1.ObjectReference{Kind:"ImageStream", Namespace:"ocp", Name:"4.15", UID:"329ee0e8-7670-4fdd-9f29-6e4248c3e2f8", APIVersion:"image.openshift.io/v1", ResourceVersion:"4393617790", FieldPath:""}): type: 'Warning' reason: 'UnableToVerifyRelease' unexpected error accessing prow job definition
```

The release-payload-controller classifies these jobs as "Unknown", but will eventually update them accordingly once they transition into `Triggered` or `Pending`.  This PR updates the logic to automatically move these jobs into the `Pending` State instead of `Unknown`.