### PR TITLE
Use `ImportModePreserveOriginal` when publishing versioned tags

### DIFF
--- a/cmd/release-controller/sync_publish.go
+++ b/cmd/release-controller/sync_publish.go
@@ -42,7 +42,7 @@ func (c *Controller) ensureTagPointsToRelease(release *releasecontroller.Release
 		toTag = &target.Spec.Tags[len(target.Spec.Tags)-1]
 	}
 	toTag.From = &corev1.ObjectReference{Kind: "ImageStreamTag", Name: from}
-	toTag.ImportPolicy = imagev1.TagImportPolicy{}
+	toTag.ImportPolicy = imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal}
 
 	is, err := c.imageClient.ImageStreams(target.Namespace).Update(context.TODO(), target, metav1.UpdateOptions{})
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
It has come to our attention that when the release-controller publishes its versioned tags, like: https://github.com/openshift/release/blob/1ee59359367cb870fcf8e55ef5a4f186b905ce53/core-services/release-controller/_releases/release-ocp-4.18.json#L18-L25
it does not specify `ImportModePreserveOriginal` as the import mode.  This PR corrects that.