### PR TITLE
Adjust logic to overwrite `ImportPolicy.ImportMode`

### DIFF
--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -158,10 +158,8 @@ func calculateMirrorImageStream(release *releasecontroller.Release, is *imagev1.
 				Name: source,
 			}
 		}
-		ref.ImportPolicy = imagev1.TagImportPolicy{
-			ImportMode: imagev1.ImportModePreserveOriginal,
-			Scheduled:  false,
-		}
+		ref.ImportPolicy.Scheduled = false
+		ref.ImportPolicy.ImportMode = imagev1.ImportModePreserveOriginal
 		is.Spec.Tags = append(is.Spec.Tags, *ref)
 	}
 	return nil


### PR DESCRIPTION
The original logic here only overwrote the settings that it needed to for the mirrored tags.  So, instead of overwriting the whole `ImportPolicy` all together, I'm going to revert back to the original style and just overwrite the `ImportMode` as well. 