### PR TITLE
Update the RHCOS Release Browser URL

### DIFF
--- a/pkg/rhcos/rhcos.go
+++ b/pkg/rhcos/rhcos.go
@@ -20,7 +20,7 @@ var (
 	changeoverTimestamp = 202212000000
 
 	serviceScheme = "https"
-	serviceUrl    = "releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com"
+	serviceUrl    = "releases-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com"
 
 	reMdPromotedFrom = regexp.MustCompile("Promoted from (.*):(.*)")
 


### PR DESCRIPTION
The RHCOS release browser has been moved from the ocp virt cluster to the ITUP.stable cluster.

See: https://issues.redhat.com/browse/COS-2767