### PR TITLE
Add 9.6 version map to fix RHCOS browser link

### DIFF
--- a/pkg/rhcos/rhcos.go
+++ b/pkg/rhcos/rhcos.go
@@ -154,6 +154,7 @@ func getRHCoSReleaseStream(version, architectureExtension string) (string, bool)
 			versionMap := map[string]string{
 				"92": "9.2",
 				"94": "9.4",
+				"96": "9.6",
 			}
 			if version, ok := versionMap[m[4]]; ok {
 				return fmt.Sprintf("prod/streams/%s.%s-%s", m[2], m[3], version), true


### PR DESCRIPTION
Update the version map to include `9.6` to fix the broken link between the ocp release browser and the rhcos release browser when viewing `4.19` builds.