### PR TITLE
rhcos: add info box with RPM diff command if necessary

### DIFF
--- a/cmd/release-controller-api/http_changelog.go
+++ b/cmd/release-controller-api/http_changelog.go
@@ -72,7 +72,7 @@ func (c *Controller) getChangeLog(ch chan renderResult, fromPull string, fromTag
 		ch <- renderResult{out: out}
 	}
 
-	out, err = rhcos.TransformMarkDownOutput(out, fromTag, toTag, architecture, archExtension)
+	out, err = rhcos.TransformMarkDownOutput(out, fromPull, fromTag, toPull, toTag, architecture, archExtension)
 	if err != nil {
 		ch <- renderResult{err: err}
 		return

--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -248,6 +248,7 @@ func (r *ExecReleaseInfo) ChangeLog(from, to string, isJson bool) (string, error
 			return "", fmt.Errorf("could not generate a changelog: %v", msg)
 		}
 	}
+	klog.V(4).Infof("Finished running changelog command: %s", cmd.String())
 	if isJson {
 		var changeLog ChangeLog
 		if err := json.Unmarshal(out.Bytes(), &changeLog); err != nil {

--- a/pkg/rhcos/rhcos.go
+++ b/pkg/rhcos/rhcos.go
@@ -17,6 +17,7 @@ const (
 )
 
 var (
+	// when CoreOS switched to a new bucket prefix
 	changeoverTimestamp = 202212000000
 
 	serviceScheme = "https"


### PR DESCRIPTION
As part of https://github.com/openshift/enhancements/pull/1637, the CoreOS pipeline now only builds a RHEL-only RHCOS base image and later on, a node image is built on top of this base image to add all the OCP-specific packages.

As a result, the RHCOS release browser will only display the diff of the _base_ image content, and will not have any OCP content.

Often, that's sufficient. E.g. if you're just interested in kernel or systemd changes, the RHCOS release browser is enough. However, users can be confused by the lack of OCP packages in the list.

Let's add an info box to the changelog page with instructions to generate a full diff. But only display it if one of the RHCOS versions is of the new RHEL-only kind.

As a bonus, these instructions also conveniently serve as a way to get any diff at all without VPN access.

Of course, being able to generate this diff ourselves and rendering it would be useful. And such a mechanism need not be specific to the CoreOS image; any of the many OCP images we ship which contain RPMs would benefit from being able to view package diffs.

The most likely candidate for implementing this would be in `oc adm release info`, but downloading images to generate diffs is a much more expensive operation than the git changelog-based one. So a caching service might be better instead.

(That said, it's possible with Konflux that we'll end up storing RPM lockfiles in git, in which case an RPM diff _is_ a git diff which matches nicely the existing semantics.)

---

For a sample of what this looks like (forcing it on even though it wouldn't normally show in this case):

![image](https://github.com/user-attachments/assets/4b38ef1f-faae-4c9c-939c-da2e818b8a0c)