### PR TITLE
Introduce an approvals API

### DIFF
--- a/pkg/release-controller/release_payload.go
+++ b/pkg/release-controller/release_payload.go
@@ -1,0 +1,55 @@
+package releasecontroller
+
+import (
+	"fmt"
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
+	v1alpha2 "github.com/openshift/release-controller/pkg/client/listers/release/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"strings"
+)
+
+func ApprovedReleasesByTeam(lister v1alpha2.ReleasePayloadLister, team string) ([]*v1alpha1.ReleasePayload, error) {
+	payloads, err := lister.List(labels.SelectorFromSet(labels.Set{fmt.Sprintf("release.openshift.io/%s_state", strings.ToLower(team)): "Accepted"}))
+	if err != nil {
+		return nil, err
+	}
+	return payloads, nil
+}
+
+func ApprovedReleases(lister v1alpha2.ReleasePayloadLister) ([]*v1alpha1.ReleasePayload, error) {
+	payloads, err := lister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	var approved []*v1alpha1.ReleasePayload
+	for _, payload := range payloads {
+		for label, value := range payload.Labels {
+			if strings.HasPrefix(label, "release.openshift.io/") && strings.HasSuffix(label, "_state") && value == "Accepted" {
+				approved = append(approved, payload)
+				break
+			}
+		}
+	}
+	return approved, nil
+}
+
+func GetReleasePhase(payload *v1alpha1.ReleasePayload) string {
+	for _, condition := range payload.Status.Conditions {
+		switch condition.Type {
+		case v1alpha1.ConditionPayloadAccepted:
+			if condition.Status == v1.ConditionTrue {
+				return ReleasePhaseAccepted
+			}
+		case v1alpha1.ConditionPayloadRejected:
+			if condition.Status == v1.ConditionTrue {
+				return ReleasePhaseRejected
+			}
+		case v1alpha1.ConditionPayloadFailed:
+			if condition.Status == v1.ConditionTrue {
+				return ReleasePhaseFailed
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -741,3 +741,26 @@ type CommitInfo struct {
 	CommitID  string            `json:"commitID,omitempty"`
 	CommitURL string            `json:"commitURL,omitempty"`
 }
+
+type APITagsBySemVerName []APITag
+
+func (t APITagsBySemVerName) Less(i, j int) bool {
+	iVer, err := SemverParseTolerant(t[i].Name)
+	if err != nil {
+		return t[i].Name > t[j].Name
+	}
+	jVer, err := SemverParseTolerant(t[j].Name)
+	if err != nil {
+		return t[i].Name > t[j].Name
+	}
+	if iVer.GT(jVer) {
+		return true
+	}
+	if iVer.LT(jVer) {
+		return false
+	}
+	return t[i].Name > t[j].Name
+}
+
+func (t APITagsBySemVerName) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t APITagsBySemVerName) Len() int      { return len(t) }


### PR DESCRIPTION
Adding an API that provides a way to get releases that have been marked as `Approved` by teams.  This PR introduces the `/api/v1/releasestreams/approvals` to the `release-controller-api`.  The API behaves as follows:

When called directly, like:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals`
The API will return a JSON array of all releases that have been flagged as `Approved`, in descending order (from the most recent to the oldest release versions (by SemVer comparison)

These results can be filtered down by specifying any combination of the following query parameters:

- `team` - releases that have been `Approved` by the specified team
Examples:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?team=trt`
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?team=qe`

- `prefix` - `Approved` releases that match the specified prefix
Examples:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?prefix=4.17`
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?prefix=4.17.0-0.nightly`
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?prefix=4.17.0-0.ci`

- `index` - the relative index, zero based, of the singular result to return 
Examples:
To get the "latest" `Approved` release:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?index=0`
To get the "second-most recent" `Approved` release:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?index=1`

These parameters can be used in combination to perform more complex filtering, like:

- To get the latest `4.17` release, `Approved` by `QE`:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?team=qe&prefix=4.17&index=0`

- To get the latest `4.17`, `Nightly` release, `Approved` by `QE`:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?team=qe&prefix=4.17.0-0.nightly&index=0`

- To get the latest `4.17`, `CI` release, `Approved` by `QE`:
`https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestreams/approvals?team=qe&prefix=4.17.0-0.ci&index=0`
