### PR TITLE
Introducing the `disableManifestListMode` flag to the `ReleaseConfig`

### DIFF
--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -30,7 +30,7 @@ func (c *Controller) ensureReleaseJob(release *releasecontroller.Release, name s
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
 
 		manifestListMode := "false"
-		if c.manifestListMode {
+		if c.manifestListMode && !release.Config.DisableManifestListMode {
 			manifestListMode = "true"
 		}
 
@@ -69,7 +69,7 @@ func (c *Controller) ensureRewriteJob(release *releasecontroller.Release, name s
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
 
 		manifestListMode := "false"
-		if c.manifestListMode {
+		if c.manifestListMode && !release.Config.DisableManifestListMode {
 			manifestListMode = "true"
 		}
 
@@ -143,7 +143,7 @@ func (c *Controller) ensureImportJob(release *releasecontroller.Release, name st
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
 
 		manifestListMode := "false"
-		if c.manifestListMode {
+		if c.manifestListMode && !release.Config.DisableManifestListMode {
 			manifestListMode = "true"
 		}
 
@@ -387,7 +387,7 @@ func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, 
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
 
 		manifestListMode := "false"
-		if c.manifestListMode {
+		if c.manifestListMode && !release.Config.DisableManifestListMode {
 			manifestListMode = "true"
 		}
 

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -153,6 +153,12 @@ type ReleaseConfig struct {
 	// For example:
 	//   "alternateImageRepository": "quay.io/openshift-release-dev/dev-release"
 	AlternateImageRepository string `json:"alternateImageRepository"`
+
+	// DisableManifestListMode indicates this release stream should not utilize the --keep-manifest-list for release
+	// creation.  This flag should NOT be used unless absolutely necessary...
+	// Currently, it's being added to work around a limitation with `oc` and images from konflux:
+	// https://issues.redhat.com/browse/OCPBUGS-50660
+	DisableManifestListMode bool `json:"disableManifestListMode"`
 }
 
 type ReleaseCheck struct {


### PR DESCRIPTION
In an effort to work around an issue generating releases from konflux, we're introducing the `disableManifestListMode` override to allow for individual release streams to turn off creating manifest list based releases while the details of: https://issues.redhat.com/browse/OCPBUGS-50660 are being sorted out.