### PR TITLE
Specifying `OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY=false` for all verification jobs

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -252,6 +252,12 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: previousReleasePullSpec})
 			}
 		}
+		// This environment variable is being added, to all release-controller jobs, to override the default value
+		// of "true", specified in the Step definition.  Why? The variable is being added as a cost saving mechanism
+		// that forces everyone to utilize Public worker nodes and bypassing any NAT Gateway expenses on their
+		// clusters.  The release-controller must run its verification tests against "real" clusters and therefore,
+		// we're overriding this value.
+		c.Env = append(c.Env, corev1.EnvVar{Name: "OPENSHIFT_INSTALL_AWS_PUBLIC_ONLY", Value: "false"})
 	}
 	return true, nil
 }


### PR DESCRIPTION
This environment variable is being added, to all release-controller jobs, to override the default value of "true", specified in the Step definition.  Why? The variable is being added as a cost saving mechanism that forces everyone to utilize Public worker nodes and bypassing any NAT Gateway expenses on their clusters.  The release-controller must run its verification tests against "real" clusters and therefore, we're overriding this value.