### PR TITLE
Fixing release mirror job naming problem

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -490,7 +490,7 @@ func (c *Controller) syncReady(release *releasecontroller.Release) error {
 		mirror, err := releasecontroller.GetMirror(release, releaseTag.Name, c.releaseLister)
 		if err != nil {
 			klog.Errorf("Failed to identify `from` mirror for creation of release mirror job: %v", err)
-		} else if _, err := c.ensureReleaseMirrorJob(release, releaseMirrorJobName(releaseTag.Name), mirror); err != nil {
+		} else if _, err := c.ensureReleaseMirrorJob(release, releaseTag.Name, mirror); err != nil {
 			klog.Errorf("Failed to create release mirror job: %v", err)
 		}
 

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -375,7 +375,7 @@ func jobIsComplete(job *batchv1.Job) (succeeded bool, complete bool) {
 // Command should be like:
 // $ oc image mirror --keep-manifest-list=true registry.ci.openshift.org/ocp/release:4.17.0-0.ci-2024-08-30-110931 quay.io/openshift-release-dev/dev-release:4.17.0-0.ci-2024-08-30-110931
 func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) { //nolint:unused
-	return c.ensureJob(name, nil, func() (*batchv1.Job, error) {
+	return c.ensureJob(releaseMirrorJobName(name), nil, func() (*batchv1.Job, error) {
 		fromImage := fmt.Sprintf("%s:%s", release.Target.Status.PublicDockerImageRepository, name)
 		toImage := fmt.Sprintf("%s:%s", release.Config.AlternateImageRepository, name)
 


### PR DESCRIPTION
The current logic creates a job named like: `4.19.0-0.ci-2025-04-02-113804-alternate-mirror`, but also uses that same name for both the `fromImage` and `toImage`, which does not exist.  This PR updates the logic to only set the "alternate-mirror" name for the Job itself.