### PR TITLE
sync_release: fix mirror job name

### DIFF
--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -384,7 +384,7 @@ func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, 
 			cliImage = release.Config.OverrideCLIImage
 		}
 
-		job, prefix := newReleaseJobBase(name, cliImage, release.Config.AlternateImageRepositorySecretName)
+		job, prefix := newReleaseJobBase(releaseMirrorJobName(name), cliImage, release.Config.AlternateImageRepositorySecretName)
 
 		manifestListMode := "false"
 		if c.manifestListMode && !release.Config.DisableManifestListMode {


### PR DESCRIPTION
Use the correct name for the job base for release mirror jobs.