### PR TITLE
Adding a nil check for AlternateImageRepository

### DIFF
--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -375,6 +375,10 @@ func jobIsComplete(job *batchv1.Job) (succeeded bool, complete bool) {
 // Command should be like:
 // $ oc image mirror --keep-manifest-list=true registry.ci.openshift.org/ocp/release:4.17.0-0.ci-2024-08-30-110931 quay.io/openshift-release-dev/dev-release:4.17.0-0.ci-2024-08-30-110931
 func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) { //nolint:unused
+	if len(release.Config.AlternateImageRepository) == 0 {
+		klog.Warningf("Unable to create release mirror job for %s: no alternateImageRepository defined", name)
+		return nil, nil
+	}
 	return c.ensureJob(releaseMirrorJobName(name), nil, func() (*batchv1.Job, error) {
 		fromImage := fmt.Sprintf("%s:%s", release.Target.Status.PublicDockerImageRepository, name)
 		toImage := fmt.Sprintf("%s:%s", release.Config.AlternateImageRepository, name)


### PR DESCRIPTION
The `ensureReleaseMirrorJob()` method relies on `release.Config.AlternateImageRepository` being set.  This PR performs a check to ensure that there is a value before creating a job that will never succeed:

```
Command:
  /bin/bash
  -c
      
        set -eu
        mkdir -p "${XDG_RUNTIME_DIR}"
        oc registry login
            
        oc image mirror --keep-manifest-list=$1 $2 $3
            
      
  true
  registry.ci.openshift.org/ocp/release:4.20.0-0.ci-2025-04-02-143700
  :4.20.0-0.ci-2025-04-02-143700
State:      Terminated
  Reason:   Error
  Message:  info: Using registry public hostname registry.ci.openshift.org
Saved credentials for registry.ci.openshift.org into /tmp/run/containers/auth.json
error: ":4.20.0-0.ci-2025-04-02-143700" is not a valid image reference: invalid reference format

  Exit Code:    1
```