### PR TITLE
Drop to a single Jira Worker

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -445,9 +445,9 @@ func (c *Controller) run(workers int, stopCh <-chan struct{}) {
 		go wait.Until(c.auditWorker, time.Second, stopCh)
 	}
 
-	for range workers {
-		go wait.Until(c.jiraWorker, time.Second, stopCh)
-	}
+	//for range workers {
+	go wait.Until(c.jiraWorker, time.Second, stopCh)
+	//}
 
 	for range workers {
 		go wait.Until(c.legacyResultsWorker, time.Second, stopCh)


### PR DESCRIPTION
Taking a little more aggressive action against the release-controller's Jira limits.  This PR will reduce the number of Jira Workers from 3 down to 1.  This will absolutely slow down our jira validation process, but hopefully it's only temporary until we get out of Jira jail.