### PR TITLE
Always display the latest prowjob result

### DIFF
--- a/pkg/releasepayload/jobrunresult/helpers.go
+++ b/pkg/releasepayload/jobrunresult/helpers.go
@@ -18,3 +18,31 @@ func (in ByCoordinatesName) Len() int {
 func (in ByCoordinatesName) Swap(i, j int) {
 	in[i], in[j] = in[j], in[i]
 }
+
+type ByCompletionTime []v1alpha1.JobRunResult
+
+func (in ByCompletionTime) Less(i, j int) bool {
+	return in[i].CompletionTime.Before(in[j].CompletionTime)
+}
+
+func (in ByCompletionTime) Len() int {
+	return len(in)
+}
+
+func (in ByCompletionTime) Swap(i, j int) {
+	in[i], in[j] = in[j], in[i]
+}
+
+type ByStartTime []v1alpha1.JobRunResult
+
+func (in ByStartTime) Less(i, j int) bool {
+	return in[i].StartTime.Before(&in[j].StartTime)
+}
+
+func (in ByStartTime) Len() int {
+	return len(in)
+}
+
+func (in ByStartTime) Swap(i, j int) {
+	in[i], in[j] = in[j], in[i]
+}

--- a/pkg/releasepayload/utils.go
+++ b/pkg/releasepayload/utils.go
@@ -3,6 +3,8 @@ package releasepayload
 import (
 	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+	"github.com/openshift/release-controller/pkg/releasepayload/jobrunresult"
+	"sort"
 )
 
 func GenerateVerificationStatusMap(payload *v1alpha1.ReleasePayload, status *releasecontroller.VerificationStatusMap) bool {
@@ -89,6 +91,7 @@ func getVerificationStatusUrl(jobRunResults []v1alpha1.JobRunResult) string {
 	}
 	// Otherwise, return the URL of the "last" attempt
 	if len(jobRunResults) >= 1 {
+		sort.Sort(jobrunresult.ByStartTime(jobRunResults))
 		return jobRunResults[len(jobRunResults)-1].HumanProwResultsURL
 	}
 	return ""


### PR DESCRIPTION
It was reported that the release-controller was not displaying the latest/greatest results for a verification job.  After investigating, it turns out that there is a bug in the display logic...
Basically, the `release-payload-controller` sorts all the `JobRunResults`, for a given validation job, by their respective `Coordinate.Name` value (for generating a canonical version of the resource).  Unfortunately, in some occasions, this results in the list not being in the order that the `release-controller-api` was expecting.
This PR adds logic to sort all `JobRunResults`, of a given job, by its `StartTime`, and then chooses the "latest" results to display. 