### PR TITLE
mirror-cleanup-controller: add interval flag

### DIFF
--- a/pkg/cmd/release-mirror-cleanup-controller/cmd.go
+++ b/pkg/cmd/release-mirror-cleanup-controller/cmd.go
@@ -22,6 +22,7 @@ type Options struct {
 	credentialsNamespace string
 	credentialsName      string
 	minimumAge           time.Duration
+	interval             time.Duration
 	dryRun               bool
 }
 
@@ -61,6 +62,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.credentialsName, "credentials-secret", "release-controller-quay-mirror-secret", "Namespace where repo credentials secret is located")
 	// default to 30 days minimum age
 	fs.DurationVar(&o.minimumAge, "minimum-age", 720*time.Hour, "Only delete tags older than this duration")
+	fs.DurationVar(&o.interval, "interval", 24*time.Hour, "How often to run the cleaner")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Print tags to be deleted without actually committing the changes.")
 }
 
@@ -99,7 +101,7 @@ func (o *Options) Run(ctx context.Context) error {
 
 	mirrorCleanupController := NewMirrorCleanupController(imageStreamClient, "/tmp/config.json", o.namespaces, o.dryRun, o.minimumAge)
 
-	go mirrorCleanupController.Run(ctx, 6*time.Hour)
+	go mirrorCleanupController.Run(ctx, o.interval)
 
 	<-ctx.Done()
 


### PR DESCRIPTION
Make cleanup interval configurable via a flag and change default interval to 24 hours.