### PR TITLE
http_changelog: hold render for node image info

### DIFF
--- a/cmd/release-controller-api/http_changelog.go
+++ b/cmd/release-controller-api/http_changelog.go
@@ -181,18 +181,25 @@ func (c *Controller) renderChangeLog(w http.ResponseWriter, fromPull string, fro
 
 	fmt.Fprintf(w, "<h2 id=\"node-image-info\">Node Image Info</h2>")
 
-	// only render the RPM diff if it's cached; judged by it taking less than 500ms
 	select {
-	case <-time.After(500 * time.Millisecond):
-		fmt.Fprintf(w, `<p class="alert alert-danger">Node image info still loading; check again later...</p>`)
 	case render = <-chNodeInfo:
-		if render.err != nil {
-			fmt.Fprintf(w, `<p class="alert alert-danger">%s</p>`, fmt.Sprintf("Unable to show node image info: %s", render.err))
-		} else {
-			result := blackfriday.Run([]byte(render.out))
-			if _, err := w.Write(result); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
+	case <-time.After(1 * time.Second):
+		fmt.Fprintf(w, `<p id="node_loading" class="alert alert-danger">Loading node image info, this may take a while ...</p>`)
+		flusher.Flush()
+		select {
+		case render = <-chNodeInfo:
+		case <-time.After(15 * time.Second):
+			render.err = fmt.Errorf("node image info is still loading, check back later...")
+		}
+		fmt.Fprintf(w, `<style>#node_loading{display: none;}</style>`)
+		flusher.Flush()
+	}
+	if render.err != nil {
+		fmt.Fprintf(w, `<p class="alert alert-danger">%s</p>`, fmt.Sprintf("Unable to show node image info: %s", render.err))
+	} else {
+		result := blackfriday.Run([]byte(render.out))
+		if _, err := w.Write(result); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
 }


### PR DESCRIPTION
Use the same trick for the node image info section that that main changelog section uses to first display a "loading..." box, flush, then hide the box once the render is complete.

This change avoids users having to refresh the page for the node image info section when accessing a release page that isn't yet cached, without sacrificing how long it takes to have the main changelog section rendered.

We still put a hard timeout of 15 seconds to render it. Even on a cold startup, it should normally be much faster than the changelog case which requires massive git cloning.