### PR TITLE
TELCOV10N-447: Remove link to Telco CI results

### DIFF
--- a/cmd/release-controller-api/controller.go
+++ b/cmd/release-controller-api/controller.go
@@ -121,7 +121,6 @@ func NewController(
 		{"Index", "/"},
 		{"Overview", "/dashboards/overview"},
 		{"Compare", "/dashboards/compare"},
-		{"Telco KPI Results (VPN Required)", "https://kpi-reports.telco5g.corp.redhat.com"},
 	}
 
 	return c


### PR DESCRIPTION
- This results page has been deprecated and replaced with a new reporting portal
- See details in https://issues.redhat.com/browse/TELCOV10N-445