### PR TITLE
Fixing error when truncated prowjob name is invalid

### DIFF
--- a/cmd/release-controller/sync_verify_prow_test.go
+++ b/cmd/release-controller/sync_verify_prow_test.go
@@ -110,6 +110,12 @@ func TestGenerateSafeProwJobName(t *testing.T) {
 			suffix:   "aggregator-2",
 			expected: "4.16.0-0.nightly-2024-02-07-125310-aggrega-44j0w6k-aggregator-2",
 		},
+		{
+			name:     "TruncationResultsInInvalidJobName",
+			jobName:  "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.19-micro-fips",
+			suffix:   "1",
+			expected: "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4-mzdcpq2-1",
+		},
 	}
 
 	t.Parallel()

--- a/pkg/prow/utils.go
+++ b/pkg/prow/utils.go
@@ -38,6 +38,7 @@ func GenerateSafeProwJobName(name, suffix string) string {
 	if len(jobName) > MaxProwJobNameLength {
 		s := fmt.Sprintf("-%s%s", ProwjobSafeHash(name), suffix)
 		truncated := strings.TrimSuffix(name[0:MaxProwJobNameLength-len(s)], "-")
+		truncated = strings.TrimSuffix(truncated, ".")
 		jobName = fmt.Sprintf("%s%s", truncated, s)
 	}
 	return jobName


### PR DESCRIPTION
The prowjob truncation logic ran into a job name that, ultimately, truncated into an invalid name (although it really shouldn't be invalid, but that would take way longer to get properly addressed upstream)...

Original Job Name: 
`4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.19-micro-fips`

On a retry, the release-controller will append the number of the retry to the name, like:
`4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.19-micro-fips-1`

The resultant truncated name, which is invalid, is:
`4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.-mzdcpq2-1`

Which produces the following log message and prevents further processing of the release:
```
I0623 09:23:31.928864       1 controller.go:608] Unable to sync {ocp 4.19-art-latest}, no retry: ProwJob.prow.k8s.io "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.-mzdcpq2-1" is invalid: metadata.name: Invalid value: "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.-mzdcpq2-1": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

This fix specifically looks for periods at the end of the truncated name.