### PR TITLE
.golangci.yaml: migrate config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,26 @@
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - fmt.Fprint
-      - fmt.Fprintf
-      - fmt.Fprintln
+version: "2"
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/release-controller-api/http_changelog.go
+++ b/cmd/release-controller-api/http_changelog.go
@@ -186,7 +186,7 @@ func (c *Controller) renderChangeLog(w http.ResponseWriter, fromPull string, fro
 	select {
 	case render = <-chNodeInfo:
 	case <-time.After(15 * time.Second):
-		render.err = fmt.Errorf("node image info is still loading, check back later...")
+		render.err = fmt.Errorf("node image info is still loading, check back later")
 	}
 	fmt.Fprintf(w, `<style>#node_loading{display: none;}</style>`)
 	if render.err != nil {


### PR DESCRIPTION
Update `.golangci.yaml` to v2 format by running `golangci-lint migrate`. The new config is required with `v2.6.0` of `golangci-lint`. This PR also fixes one lint issue detected by `v2.6.0` of `golangci-lint`.

Requires https://github.com/openshift/release/pull/71167