### PR TITLE
Removing unused types and refactoring validation logic

### DIFF
--- a/pkg/releasequalifiers/notifications/jira/jira.go
+++ b/pkg/releasequalifiers/notifications/jira/jira.go
@@ -1,0 +1,7 @@
+package jira
+
+func (j Notification) Send() {
+	//TODO implement me
+	panic("implement me")
+}
+

--- a/pkg/releasequalifiers/notifications/jira/types.go
+++ b/pkg/releasequalifiers/notifications/jira/types.go
@@ -53,8 +53,3 @@ func (in ByJiraEscalationName) Len() int {
 func (in ByJiraEscalationName) Swap(i, j int) {
 	in[i], in[j] = in[j], in[i]
 }
-
-func (j Notification) Send() {
-	//TODO implement me
-	panic("implement me")
-}

--- a/pkg/releasequalifiers/notifications/slack/slack.go
+++ b/pkg/releasequalifiers/notifications/slack/slack.go
@@ -1,0 +1,7 @@
+package slack
+
+func (s Notification) Send() {
+	//TODO implement me
+	panic("implement me")
+}
+

--- a/pkg/releasequalifiers/notifications/slack/types.go
+++ b/pkg/releasequalifiers/notifications/slack/types.go
@@ -41,8 +41,3 @@ func (in BySlackEscalationName) Len() int {
 func (in BySlackEscalationName) Swap(i, j int) {
 	in[i], in[j] = in[j], in[i]
 }
-
-func (s Notification) Send() {
-	//TODO implement me
-	panic("implement me")
-}

--- a/pkg/releasequalifiers/types.go
+++ b/pkg/releasequalifiers/types.go
@@ -47,55 +47,8 @@ type ReleaseQualifier struct {
 	Notifications *notifications.Notifications `json:"notifications,omitempty" yaml:"notifications,omitempty"`
 }
 
-// Validate enforces any rules that all ReleaseQualifier objects must adhere to
-func (rq ReleaseQualifier) Validate() error {
-	return nil
-}
-
 // BoolPtr returns a pointer to the given bool value
 // This is a utility function for creating pointers to bool values
 func BoolPtr(b bool) *bool {
 	return &b
-}
-
-// SortableQualifier represents a qualifier with its ID for sorting purposes
-type SortableQualifier struct {
-	ID        QualifierId
-	Qualifier ReleaseQualifier
-}
-
-// SortableQualifiers is a slice of SortableQualifier for sorting
-type SortableQualifiers []SortableQualifier
-
-func (sq SortableQualifiers) Len() int {
-	return len(sq)
-}
-
-func (sq SortableQualifiers) Less(i, j int) bool {
-	return string(sq[i].ID) < string(sq[j].ID)
-}
-
-func (sq SortableQualifiers) Swap(i, j int) {
-	sq[i], sq[j] = sq[j], sq[i]
-}
-
-// ToSortableSlice converts ReleaseQualifiers map to a sortable slice
-func (rqs ReleaseQualifiers) ToSortableSlice() SortableQualifiers {
-	slice := make(SortableQualifiers, 0, len(rqs))
-	for id, qualifier := range rqs {
-		slice = append(slice, SortableQualifier{
-			ID:        id,
-			Qualifier: qualifier,
-		})
-	}
-	return slice
-}
-
-// ToMap converts a sorted slice back to a ReleaseQualifiers map
-func (sq SortableQualifiers) ToMap() ReleaseQualifiers {
-	result := make(ReleaseQualifiers)
-	for _, item := range sq {
-		result[item.ID] = item.Qualifier
-	}
-	return result
 }

--- a/pkg/releasequalifiers/validation.go
+++ b/pkg/releasequalifiers/validation.go
@@ -1,0 +1,6 @@
+package releasequalifiers
+
+// Validate enforces any rules that all ReleaseQualifier objects must adhere to
+func (rq ReleaseQualifier) Validate() error {
+	return nil
+}


### PR DESCRIPTION
Quick PR to remove some unused functions that were orphaned during changes from the last code review.
I've also moved the validation logic into it's own file for future implementation and testing.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED