### PR TITLE
Remove cluster assignment for specific jobs

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -89,12 +88,6 @@ func (c *Controller) ensureProwJobForReleaseTag(release *releasecontroller.Relea
 		if buildClusterDistribution.Contains(periodicConfig.Cluster) {
 			spec.Cluster = buildClusterDistribution.Get()
 		}
-	}
-
-	// Currently, there is a set of jobs that must be run on the `build05` cluster
-	r := regexp.MustCompile(`\b(e2e-agent|metal|telco5g)\b`)
-	if r.FindString(jobName) != "" {
-		spec.Cluster = "build05"
 	}
 
 	mirror, _ := releasecontroller.GetMirror(release, releaseTag.Name, c.releaseLister)


### PR DESCRIPTION
Removed the condition that sets the cluster to 'build05' for specific jobs.

/hold until Tuesday, follow up release PR will be merged at the same time

/cc @bradmwilliams 

