### PR TITLE
Release qualifiers refactor 4

### DIFF
--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -413,10 +413,10 @@ func TestValidateQualifiersConfiguration(t *testing.T) {
 						},
 						Qualifiers: releasequalifiers.ReleaseQualifiers{
 							"test": {
-								Enabled:     releasequalifiers.BoolPtr(false),
-								Name:        "TEST",
-								Description: "An updated description when displaying badge details",
-								Badge:       releasequalifiers.BadgeStatusNo,
+								Enabled:            releasequalifiers.BoolPtr(false),
+								BadgeName:          "TEST",
+								Description:        "An updated description when displaying badge details",
+								PayloadBadgeStatus: releasequalifiers.BadgeStatusNo,
 							},
 						},
 					},

--- a/pkg/releasequalifiers/merge.go
+++ b/pkg/releasequalifiers/merge.go
@@ -33,8 +33,8 @@ func mergeQualifier(base, override ReleaseQualifier) ReleaseQualifier {
 	result := base
 
 	// Override simple fields if they are set in override
-	if override.Name != "" {
-		result.Name = override.Name
+	if override.BadgeName != "" {
+		result.BadgeName = override.BadgeName
 	}
 	if override.Summary != "" {
 		result.Summary = override.Summary
@@ -42,8 +42,8 @@ func mergeQualifier(base, override ReleaseQualifier) ReleaseQualifier {
 	if override.Description != "" {
 		result.Description = override.Description
 	}
-	if override.Badge != "" {
-		result.Badge = override.Badge
+	if override.PayloadBadgeStatus != "" {
+		result.PayloadBadgeStatus = override.PayloadBadgeStatus
 	}
 
 	// Override Enabled field if it's explicitly set in override

--- a/pkg/releasequalifiers/merge_test.go
+++ b/pkg/releasequalifiers/merge_test.go
@@ -32,8 +32,8 @@ func TestReleaseQualifiers_Merge(t *testing.T) {
 			base: ReleaseQualifiers{},
 			override: ReleaseQualifiers{
 				"test": {
-					Enabled: TRUE,
-					Name:    "TEST",
+					Enabled:   TRUE,
+					BadgeName: "TEST",
 				},
 			},
 			expected: ReleaseQualifiers{},
@@ -42,8 +42,8 @@ func TestReleaseQualifiers_Merge(t *testing.T) {
 			name: "base with empty override",
 			base: ReleaseQualifiers{
 				"test": {
-					Enabled: TRUE,
-					Name:    "TEST",
+					Enabled:   TRUE,
+					BadgeName: "TEST",
 				},
 			},
 			override: ReleaseQualifiers{},
@@ -53,22 +53,22 @@ func TestReleaseQualifiers_Merge(t *testing.T) {
 			name: "simple field override",
 			base: ReleaseQualifiers{
 				"test": {
-					Enabled: FALSE,
-					Name:    "OLD",
-					Summary: "Old Summary",
+					Enabled:   FALSE,
+					BadgeName: "OLD",
+					Summary:   "Old Summary",
 				},
 			},
 			override: ReleaseQualifiers{
 				"test": {
 					Enabled:     TRUE,
-					Name:        "NEW",
+					BadgeName:   "NEW",
 					Description: "New Description",
 				},
 			},
 			expected: ReleaseQualifiers{
 				"test": {
 					Enabled:     TRUE,
-					Name:        "NEW",
+					BadgeName:   "NEW",
 					Summary:     "Old Summary", // Not overridden
 					Description: "New Description",
 				},
@@ -78,14 +78,14 @@ func TestReleaseQualifiers_Merge(t *testing.T) {
 			name: "add new qualifier",
 			base: ReleaseQualifiers{
 				"existing": {
-					Enabled: TRUE,
-					Name:    "EXIST",
+					Enabled:   TRUE,
+					BadgeName: "EXIST",
 				},
 			},
 			override: ReleaseQualifiers{
 				"new": {
-					Enabled: TRUE,
-					Name:    "NEW",
+					Enabled:   TRUE,
+					BadgeName: "NEW",
 				},
 			},
 			expected: ReleaseQualifiers{},
@@ -342,17 +342,17 @@ func TestReleaseQualifiers_Merge(t *testing.T) {
 			name: "string field override with empty string",
 			base: ReleaseQualifiers{
 				"test": {
-					Name: "ORIGINAL",
+					BadgeName: "ORIGINAL",
 				},
 			},
 			override: ReleaseQualifiers{
 				"test": {
-					Name: "", // Empty string should not override
+					BadgeName: "", // Empty string should not override
 				},
 			},
 			expected: ReleaseQualifiers{
 				"test": {
-					Name: "ORIGINAL", // Should keep original
+					BadgeName: "ORIGINAL", // Should keep original
 				},
 			},
 		},
@@ -360,17 +360,17 @@ func TestReleaseQualifiers_Merge(t *testing.T) {
 			name: "string field override with non-empty string",
 			base: ReleaseQualifiers{
 				"test": {
-					Name: "ORIGINAL",
+					BadgeName: "ORIGINAL",
 				},
 			},
 			override: ReleaseQualifiers{
 				"test": {
-					Name: "NEW",
+					BadgeName: "NEW",
 				},
 			},
 			expected: ReleaseQualifiers{
 				"test": {
-					Name: "NEW",
+					BadgeName: "NEW",
 				},
 			},
 		},
@@ -405,8 +405,8 @@ func TestReleaseQualifiers_Merge_EdgeCases(t *testing.T) {
 			name: "complex nested merge",
 			base: ReleaseQualifiers{
 				"complex": {
-					Enabled: FALSE,
-					Name:    "COMPLEX",
+					Enabled:   FALSE,
+					BadgeName: "COMPLEX",
 					Notifications: &notifications.Notifications{
 						Slack: &slack.Notification{
 							Escalations: []slack.Escalation{
@@ -448,8 +448,8 @@ func TestReleaseQualifiers_Merge_EdgeCases(t *testing.T) {
 			},
 			expected: ReleaseQualifiers{
 				"complex": {
-					Enabled: TRUE,
-					Name:    "COMPLEX",
+					Enabled:   TRUE,
+					BadgeName: "COMPLEX",
 					Notifications: &notifications.Notifications{
 						Slack: &slack.Notification{
 							Escalations: []slack.Escalation{
@@ -557,21 +557,21 @@ func TestReleaseQualifiers_Merge_EmptyStringHandling(t *testing.T) {
 			name: "empty strings should not override existing values",
 			base: ReleaseQualifiers{
 				"test": {
-					Name:        "ORIGINAL",
+					BadgeName:   "ORIGINAL",
 					Summary:     "Original Summary",
 					Description: "Original Description",
 				},
 			},
 			override: ReleaseQualifiers{
 				"test": {
-					Name:        "", // Empty string should not override
+					BadgeName:   "", // Empty string should not override
 					Summary:     "New Summary",
 					Description: "", // Empty string should not override
 				},
 			},
 			expected: ReleaseQualifiers{
 				"test": {
-					Name:        "ORIGINAL",             // Empty string should not override
+					BadgeName:   "ORIGINAL",             // Empty string should not override
 					Summary:     "New Summary",          // Non-empty string should override
 					Description: "Original Description", // Empty string should not override
 				},
@@ -601,8 +601,8 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			base: nil,
 			override: ReleaseQualifiers{
 				"test": {
-					Enabled: TRUE,
-					Name:    "TEST",
+					Enabled:   TRUE,
+					BadgeName: "TEST",
 				},
 			},
 			expected: ReleaseQualifiers{},
@@ -611,8 +611,8 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			name: "non-nil base with nil override",
 			base: ReleaseQualifiers{
 				"test": {
-					Enabled: TRUE,
-					Name:    "TEST",
+					Enabled:   TRUE,
+					BadgeName: "TEST",
 				},
 			},
 			override: nil,
@@ -622,7 +622,7 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			name: "override enabled from nil to false",
 			base: ReleaseQualifiers{
 				"test": {
-					Name: "TEST",
+					BadgeName: "TEST",
 				},
 			},
 			override: ReleaseQualifiers{
@@ -632,8 +632,8 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			},
 			expected: ReleaseQualifiers{
 				"test": {
-					Enabled: FALSE,
-					Name:    "TEST",
+					Enabled:   FALSE,
+					BadgeName: "TEST",
 				},
 			},
 		},
@@ -641,8 +641,8 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			name: "override enabled from false to true",
 			base: ReleaseQualifiers{
 				"test": {
-					Enabled: FALSE,
-					Name:    "TEST",
+					Enabled:   FALSE,
+					BadgeName: "TEST",
 				},
 			},
 			override: ReleaseQualifiers{
@@ -652,8 +652,8 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			},
 			expected: ReleaseQualifiers{
 				"test": {
-					Enabled: TRUE,
-					Name:    "TEST",
+					Enabled:   TRUE,
+					BadgeName: "TEST",
 				},
 			},
 		},
@@ -697,26 +697,26 @@ func TestReleaseQualifiers_Merge_ComprehensiveEdgeCases(t *testing.T) {
 			name: "all payload badge status combinations",
 			base: ReleaseQualifiers{
 				"test1": {
-					Badge: BadgeStatusYes,
+					PayloadBadgeStatus: BadgeStatusYes,
 				},
 				"test2": {
-					Badge: BadgeStatusNo,
+					PayloadBadgeStatus: BadgeStatusNo,
 				},
 			},
 			override: ReleaseQualifiers{
 				"test1": {
-					Badge: BadgeStatusOnSuccess,
+					PayloadBadgeStatus: BadgeStatusOnSuccess,
 				},
 				"test2": {
-					Badge: BadgeStatusOnFailure,
+					PayloadBadgeStatus: BadgeStatusOnFailure,
 				},
 			},
 			expected: ReleaseQualifiers{
 				"test1": {
-					Badge: BadgeStatusOnSuccess,
+					PayloadBadgeStatus: BadgeStatusOnSuccess,
 				},
 				"test2": {
-					Badge: BadgeStatusOnFailure,
+					PayloadBadgeStatus: BadgeStatusOnFailure,
 				},
 			},
 		},
@@ -796,85 +796,85 @@ func TestReleaseQualifier_Merge(t *testing.T) {
 			name: "empty base with override",
 			base: ReleaseQualifier{},
 			override: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "TEST",
+				Enabled:   TRUE,
+				BadgeName: "TEST",
 			},
 			expected: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "TEST",
+				Enabled:   TRUE,
+				BadgeName: "TEST",
 			},
 		},
 		{
 			name: "base with empty override",
 			base: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "TEST",
+				Enabled:   TRUE,
+				BadgeName: "TEST",
 			},
 			override: ReleaseQualifier{},
 			expected: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "TEST",
+				Enabled:   TRUE,
+				BadgeName: "TEST",
 			},
 		},
 		{
 			name: "override all simple fields",
 			base: ReleaseQualifier{
-				Enabled:     FALSE,
-				Name:        "OLD_BADGE",
-				Summary:     "Old Summary",
-				Description: "Old Description",
-				Badge:       BadgeStatusNo,
+				Enabled:            FALSE,
+				BadgeName:          "OLD_BADGE",
+				Summary:            "Old Summary",
+				Description:        "Old Description",
+				PayloadBadgeStatus: BadgeStatusNo,
 			},
 			override: ReleaseQualifier{
-				Enabled:     TRUE,
-				Name:        "NEW_BADGE",
-				Summary:     "New Summary",
-				Description: "New Description",
-				Badge:       BadgeStatusYes,
+				Enabled:            TRUE,
+				BadgeName:          "NEW_BADGE",
+				Summary:            "New Summary",
+				Description:        "New Description",
+				PayloadBadgeStatus: BadgeStatusYes,
 			},
 			expected: ReleaseQualifier{
-				Enabled:     TRUE,
-				Name:        "NEW_BADGE",
-				Summary:     "New Summary",
-				Description: "New Description",
-				Badge:       BadgeStatusYes,
+				Enabled:            TRUE,
+				BadgeName:          "NEW_BADGE",
+				Summary:            "New Summary",
+				Description:        "New Description",
+				PayloadBadgeStatus: BadgeStatusYes,
 			},
 		},
 		{
 			name: "partial override - only some fields",
 			base: ReleaseQualifier{
-				Enabled:     FALSE,
-				Name:        "BASE_BADGE",
-				Summary:     "Base Summary",
-				Description: "Base Description",
-				Badge:       BadgeStatusNo,
+				Enabled:            FALSE,
+				BadgeName:          "BASE_BADGE",
+				Summary:            "Base Summary",
+				Description:        "Base Description",
+				PayloadBadgeStatus: BadgeStatusNo,
 			},
 			override: ReleaseQualifier{
-				Name:    "OVERRIDE_BADGE",
-				Summary: "Override Summary",
+				BadgeName: "OVERRIDE_BADGE",
+				Summary:   "Override Summary",
 			},
 			expected: ReleaseQualifier{
-				Enabled:     FALSE,
-				Name:        "OVERRIDE_BADGE",
-				Summary:     "Override Summary",
-				Description: "Base Description",
-				Badge:       BadgeStatusNo,
+				Enabled:            FALSE,
+				BadgeName:          "OVERRIDE_BADGE",
+				Summary:            "Override Summary",
+				Description:        "Base Description",
+				PayloadBadgeStatus: BadgeStatusNo,
 			},
 		},
 		{
 			name: "empty strings don't override",
 			base: ReleaseQualifier{
-				Name:        "ORIGINAL",
+				BadgeName:   "ORIGINAL",
 				Summary:     "Original Summary",
 				Description: "Original Description",
 			},
 			override: ReleaseQualifier{
-				Name:        "",
+				BadgeName:   "",
 				Summary:     "New Summary",
 				Description: "",
 			},
 			expected: ReleaseQualifier{
-				Name:        "ORIGINAL",
+				BadgeName:   "ORIGINAL",
 				Summary:     "New Summary",
 				Description: "Original Description",
 			},
@@ -882,28 +882,28 @@ func TestReleaseQualifier_Merge(t *testing.T) {
 		{
 			name: "override enabled from nil to false",
 			base: ReleaseQualifier{
-				Name: "TEST",
+				BadgeName: "TEST",
 			},
 			override: ReleaseQualifier{
 				Enabled: FALSE,
 			},
 			expected: ReleaseQualifier{
-				Enabled: FALSE,
-				Name:    "TEST",
+				Enabled:   FALSE,
+				BadgeName: "TEST",
 			},
 		},
 		{
 			name: "override enabled from false to true",
 			base: ReleaseQualifier{
-				Enabled: FALSE,
-				Name:    "TEST",
+				Enabled:   FALSE,
+				BadgeName: "TEST",
 			},
 			override: ReleaseQualifier{
 				Enabled: TRUE,
 			},
 			expected: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "TEST",
+				Enabled:   TRUE,
+				BadgeName: "TEST",
 			},
 		},
 		{
@@ -933,13 +933,13 @@ func TestReleaseQualifier_Merge(t *testing.T) {
 		{
 			name: "override Badge variants",
 			base: ReleaseQualifier{
-				Badge: BadgeStatusYes,
+				PayloadBadgeStatus: BadgeStatusYes,
 			},
 			override: ReleaseQualifier{
-				Badge: BadgeStatusOnSuccess,
+				PayloadBadgeStatus: BadgeStatusOnSuccess,
 			},
 			expected: ReleaseQualifier{
-				Badge: BadgeStatusOnSuccess,
+				PayloadBadgeStatus: BadgeStatusOnSuccess,
 			},
 		},
 		{
@@ -1199,12 +1199,12 @@ func TestReleaseQualifier_Merge(t *testing.T) {
 		{
 			name: "complex merge - all fields",
 			base: ReleaseQualifier{
-				Enabled:     FALSE,
-				Name:        "BASE",
-				Summary:     "Base Summary",
-				Description: "Base Description",
-				Badge:       BadgeStatusNo,
-				Labels:      []string{"base-label"},
+				Enabled:            FALSE,
+				BadgeName:          "BASE",
+				Summary:            "Base Summary",
+				Description:        "Base Description",
+				PayloadBadgeStatus: BadgeStatusNo,
+				Labels:             []string{"base-label"},
 				Notifications: &notifications.Notifications{
 					Slack: &slack.Notification{
 						Escalations: []slack.Escalation{
@@ -1220,11 +1220,11 @@ func TestReleaseQualifier_Merge(t *testing.T) {
 				},
 			},
 			override: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "OVERRIDE",
-				Summary: "Override Summary",
-				Badge:   BadgeStatusOnSuccess,
-				Labels:  []string{"override-label1", "override-label2"},
+				Enabled:            TRUE,
+				BadgeName:          "OVERRIDE",
+				Summary:            "Override Summary",
+				PayloadBadgeStatus: BadgeStatusOnSuccess,
+				Labels:             []string{"override-label1", "override-label2"},
 				Notifications: &notifications.Notifications{
 					Slack: &slack.Notification{
 						Escalations: []slack.Escalation{
@@ -1240,12 +1240,12 @@ func TestReleaseQualifier_Merge(t *testing.T) {
 				},
 			},
 			expected: ReleaseQualifier{
-				Enabled:     TRUE,
-				Name:        "OVERRIDE",
-				Summary:     "Override Summary",
-				Description: "Base Description",
-				Badge:       BadgeStatusOnSuccess,
-				Labels:      []string{"override-label1", "override-label2"},
+				Enabled:            TRUE,
+				BadgeName:          "OVERRIDE",
+				Summary:            "Override Summary",
+				Description:        "Base Description",
+				PayloadBadgeStatus: BadgeStatusOnSuccess,
+				Labels:             []string{"override-label1", "override-label2"},
 				Notifications: &notifications.Notifications{
 					Slack: &slack.Notification{
 						Escalations: []slack.Escalation{
@@ -1307,30 +1307,30 @@ func TestReleaseQualifier_Merge_PointerReceiver(t *testing.T) {
 		{
 			name: "pointer receiver with basic override",
 			base: &ReleaseQualifier{
-				Enabled: FALSE,
-				Name:    "BASE",
+				Enabled:   FALSE,
+				BadgeName: "BASE",
 			},
 			override: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "OVERRIDE",
+				Enabled:   TRUE,
+				BadgeName: "OVERRIDE",
 			},
 			expected: ReleaseQualifier{
-				Enabled: TRUE,
-				Name:    "OVERRIDE",
+				Enabled:   TRUE,
+				BadgeName: "OVERRIDE",
 			},
 		},
 		{
 			name: "pointer receiver preserves base when override is empty",
 			base: &ReleaseQualifier{
 				Enabled:     TRUE,
-				Name:        "BASE",
+				BadgeName:   "BASE",
 				Summary:     "Base Summary",
 				Description: "Base Description",
 			},
 			override: ReleaseQualifier{},
 			expected: ReleaseQualifier{
 				Enabled:     TRUE,
-				Name:        "BASE",
+				BadgeName:   "BASE",
 				Summary:     "Base Summary",
 				Description: "Base Description",
 			},

--- a/pkg/releasequalifiers/prettyprint_test.go
+++ b/pkg/releasequalifiers/prettyprint_test.go
@@ -20,15 +20,15 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 			name: "pretty print with sorted keys and escalations",
 			qualifiers: ReleaseQualifiers{
 				"zebra": {
-					Enabled:     BoolPtr(true),
-					Name:        "ZEB",
-					Summary:     "Zebra Component",
-					Description: "Detailed zebra description",
-					Badge:       BadgeStatusOnSuccess,
+					Enabled:            BoolPtr(true),
+					BadgeName:          "ZEB",
+					Summary:            "Zebra Component",
+					Description:        "Detailed zebra description",
+					PayloadBadgeStatus: BadgeStatusOnSuccess,
 				},
 				"alpha": {
 					Enabled:     BoolPtr(false),
-					Name:        "ALP",
+					BadgeName:   "ALP",
 					Summary:     "Alpha Component",
 					Description: "Detailed alpha description",
 					Notifications: &notifications.Notifications{
@@ -52,9 +52,9 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 					},
 				},
 				"beta": {
-					Enabled: BoolPtr(true),
-					Name:    "BET",
-					Summary: "Beta Component",
+					Enabled:   BoolPtr(true),
+					BadgeName: "BET",
+					Summary:   "Beta Component",
 				},
 			},
 			expectedKeys: []string{"alpha", "beta", "zebra"},
@@ -68,12 +68,12 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 			name: "single qualifier with all fields",
 			qualifiers: ReleaseQualifiers{
 				"comprehensive": {
-					Enabled:     BoolPtr(true),
-					Name:        "COMP",
-					Summary:     "Comprehensive test",
-					Description: "Full description",
-					Badge:       BadgeStatusNo,
-					Labels:      []string{"label1", "label2"},
+					Enabled:            BoolPtr(true),
+					BadgeName:          "COMP",
+					Summary:            "Comprehensive test",
+					Description:        "Full description",
+					PayloadBadgeStatus: BadgeStatusNo,
+					Labels:             []string{"label1", "label2"},
 					Notifications: &notifications.Notifications{
 						Jira: &jira.Notification{
 							Project:     "PROJ",
@@ -101,18 +101,18 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 			name: "multiple qualifiers with varying complexity",
 			qualifiers: ReleaseQualifiers{
 				"simple": {
-					Enabled: BoolPtr(false),
-					Name:    "SIM",
+					Enabled:   BoolPtr(false),
+					BadgeName: "SIM",
 				},
 				"with-labels": {
-					Enabled: BoolPtr(true),
-					Name:    "LAB",
-					Labels:  []string{"critical", "urgent"},
+					Enabled:   BoolPtr(true),
+					BadgeName: "LAB",
+					Labels:    []string{"critical", "urgent"},
 				},
 				"with-payload": {
-					Enabled: BoolPtr(true),
-					Name:    "PAY",
-					Badge:   BadgeStatusOnFailure,
+					Enabled:            BoolPtr(true),
+					BadgeName:          "PAY",
+					PayloadBadgeStatus: BadgeStatusOnFailure,
 				},
 			},
 			expectedKeys: []string{"simple", "with-labels", "with-payload"},
@@ -263,8 +263,8 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 					t.Error("Expected zebra qualifier to be a map")
 					return
 				}
-				if badge, ok := zebraQualifier["badge"].(string); !ok || badge != string(BadgeStatusOnSuccess) {
-					t.Error("Expected zebra to have badge field")
+				if badge, ok := zebraQualifier["payloadBadgeStatus"].(string); !ok || badge != string(BadgeStatusOnSuccess) {
+					t.Error("Expected zebra to have payloadBadgeStatus field")
 				}
 				if desc, ok := zebraQualifier["description"].(string); !ok || desc == "" {
 					t.Error("Expected zebra to have description field")
@@ -280,8 +280,8 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 				if _, ok := comp["enabled"]; !ok {
 					t.Error("Expected enabled field")
 				}
-				if _, ok := comp["name"]; !ok {
-					t.Error("Expected name field")
+				if _, ok := comp["badgeName"]; !ok {
+					t.Error("Expected badgeName field")
 				}
 				if _, ok := comp["summary"]; !ok {
 					t.Error("Expected summary field")
@@ -289,8 +289,8 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 				if _, ok := comp["description"]; !ok {
 					t.Error("Expected description field")
 				}
-				if badge, ok := comp["badge"].(string); !ok || badge != string(BadgeStatusNo) {
-					t.Error("Expected badge field with 'No' value")
+				if badge, ok := comp["payloadBadgeStatus"].(string); !ok || badge != string(BadgeStatusNo) {
+					t.Error("Expected payloadBadgeStatus field with 'No' value")
 				}
 				// Note: labels field is not included in formatQualifierForJSON output
 
@@ -322,8 +322,8 @@ func TestReleaseQualifiers_PrettyPrint(t *testing.T) {
 
 				// Verify with-payload qualifier has badge
 				if withPayload, ok := parsed["with-payload"].(map[string]interface{}); ok {
-					if badge, ok := withPayload["badge"].(string); !ok || badge != string(BadgeStatusOnFailure) {
-						t.Error("Expected with-payload qualifier to have badge=OnFailure")
+					if badge, ok := withPayload["payloadBadgeStatus"].(string); !ok || badge != string(BadgeStatusOnFailure) {
+						t.Error("Expected with-payload qualifier to have payloadBadgeStatus=OnFailure")
 					}
 				}
 
@@ -398,11 +398,11 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "full qualifier with all fields",
 			qualifier: ReleaseQualifier{
-				Enabled:     BoolPtr(true),
-				Name:        "TEST",
-				Summary:     "Test Summary",
-				Description: "Test Description",
-				Badge:       "payload-test",
+				Enabled:            BoolPtr(true),
+				BadgeName:          "TEST",
+				Summary:            "Test Summary",
+				Description:        "Test Description",
+				PayloadBadgeStatus: "payload-test",
 				Notifications: &notifications.Notifications{
 					Jira: &jira.Notification{
 						Project:     "PROJ",
@@ -443,8 +443,8 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 				if _, ok := parsed["enabled"]; !ok {
 					t.Error("Expected enabled field")
 				}
-				if _, ok := parsed["name"]; !ok {
-					t.Error("Expected name field")
+				if _, ok := parsed["badgeName"]; !ok {
+					t.Error("Expected badgeName field")
 				}
 				if _, ok := parsed["summary"]; !ok {
 					t.Error("Expected summary field")
@@ -452,8 +452,8 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 				if _, ok := parsed["description"]; !ok {
 					t.Error("Expected description field")
 				}
-				if _, ok := parsed["badge"]; !ok {
-					t.Error("Expected badge field")
+				if _, ok := parsed["payloadBadgeStatus"]; !ok {
+					t.Error("Expected payloadBadgeStatus field")
 				}
 				if _, ok := parsed["notifications"]; !ok {
 					t.Error("Expected notifications field")
@@ -468,9 +468,9 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "qualifier with jira notifications only",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(false),
-				Name:    "JIRA-ONLY",
-				Summary: "Jira Only Test",
+				Enabled:   BoolPtr(false),
+				BadgeName: "JIRA-ONLY",
+				Summary:   "Jira Only Test",
 				Notifications: &notifications.Notifications{
 					Jira: &jira.Notification{
 						Project:   "TEST",
@@ -506,9 +506,9 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "qualifier with slack notifications only",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(true),
-				Name:    "SLACK-ONLY",
-				Summary: "Slack Only Test",
+				Enabled:   BoolPtr(true),
+				BadgeName: "SLACK-ONLY",
+				Summary:   "Slack Only Test",
 				Notifications: &notifications.Notifications{
 					Slack: &slack.Notification{
 						Escalations: []slack.Escalation{
@@ -542,7 +542,7 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 			name: "qualifier with empty notifications",
 			qualifier: ReleaseQualifier{
 				Enabled:       BoolPtr(true),
-				Name:          "EMPTY",
+				BadgeName:     "EMPTY",
 				Notifications: &notifications.Notifications{},
 			},
 			wantErr: false,
@@ -561,8 +561,8 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "qualifier with escalations with mentions",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(true),
-				Name:    "MENTIONS",
+				Enabled:   BoolPtr(true),
+				BadgeName: "MENTIONS",
 				Notifications: &notifications.Notifications{
 					Jira: &jira.Notification{
 						Project: "TEST",
@@ -625,7 +625,7 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 			name: "qualifier with description field",
 			qualifier: ReleaseQualifier{
 				Enabled:     BoolPtr(true),
-				Name:        "DESC-TEST",
+				BadgeName:   "DESC-TEST",
 				Summary:     "Summary text",
 				Description: "This is a detailed description for the qualifier",
 			},
@@ -644,9 +644,9 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "qualifier with payload badge",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(true),
-				Name:    "BADGE-TEST",
-				Badge:   BadgeStatusYes,
+				Enabled:            BoolPtr(true),
+				BadgeName:          "BADGE-TEST",
+				PayloadBadgeStatus: BadgeStatusYes,
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result string) {
@@ -655,16 +655,16 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 					t.Errorf("Failed to parse JSON: %v", err)
 				}
 
-				if badge, ok := parsed["badge"].(string); !ok || badge != string(BadgeStatusYes) {
-					t.Errorf("Expected badge field with value 'Yes', got: %v", parsed["badge"])
+				if badge, ok := parsed["payloadBadgeStatus"].(string); !ok || badge != string(BadgeStatusYes) {
+					t.Errorf("Expected payloadBadgeStatus field with value 'Yes', got: %v", parsed["payloadBadgeStatus"])
 				}
 			},
 		},
 		{
 			name: "qualifier with all jira fields",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(true),
-				Name:    "FULL-JIRA",
+				Enabled:   BoolPtr(true),
+				BadgeName: "FULL-JIRA",
 				Notifications: &notifications.Notifications{
 					Jira: &jira.Notification{
 						Project:     "MYPROJ",
@@ -731,9 +731,9 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "qualifier with labels",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(true),
-				Name:    "LABELS-TEST",
-				Labels:  []string{"bug", "priority-high", "team-a"},
+				Enabled:   BoolPtr(true),
+				BadgeName: "LABELS-TEST",
+				Labels:    []string{"bug", "priority-high", "team-a"},
 			},
 			wantErr: false,
 			validate: func(t *testing.T, result string) {
@@ -750,8 +750,8 @@ func TestReleaseQualifier_PrettyPrint(t *testing.T) {
 		{
 			name: "qualifier with slack escalations without mentions",
 			qualifier: ReleaseQualifier{
-				Enabled: BoolPtr(true),
-				Name:    "SLACK-NO-MENTIONS",
+				Enabled:   BoolPtr(true),
+				BadgeName: "SLACK-NO-MENTIONS",
 				Notifications: &notifications.Notifications{
 					Slack: &slack.Notification{
 						Escalations: []slack.Escalation{

--- a/pkg/releasequalifiers/types.go
+++ b/pkg/releasequalifiers/types.go
@@ -10,16 +10,6 @@ import (
 // QualifierId is a unique name that corresponds to a specific ReleaseQualifier definition
 type QualifierId string
 
-// BadgeStatus badge status
-type BadgeStatus string
-
-const (
-	BadgeStatusYes       BadgeStatus = "Yes"
-	BadgeStatusNo        BadgeStatus = "No"
-	BadgeStatusOnSuccess BadgeStatus = "OnSuccess"
-	BadgeStatusOnFailure BadgeStatus = "OnFailure"
-)
-
 // ReleaseQualifiers represents a collection of release qualifiers indexed by their unique names
 // Each qualifier defines configuration for a specific component or feature
 type ReleaseQualifiers map[QualifierId]ReleaseQualifier
@@ -32,8 +22,8 @@ type ReleaseQualifier struct {
 	// Using a pointer to distinguish between "not set" and "set to false"
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// Name is the short display name used for this qualifier in UI badges
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// BadgeName short name displayed, as UI badges, in job level summaries
+	BadgeName string `json:"badgeName,omitempty" yaml:"badgeName,omitempty"`
 
 	// Summary provides a brief description of what this qualifier represents
 	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -41,8 +31,8 @@ type ReleaseQualifier struct {
 	// Description contains detailed information about the qualifier for display in tooltips or detailed views
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
-	// Badge indicates if/when the qualifier's badge should be displayed
-	Badge BadgeStatus `json:"badge,omitempty" yaml:"badge,omitempty"`
+	// PayloadBadgeStatus indicates if/when the qualifier's BadgeName should be displayed at the ReleasePayload level
+	PayloadBadgeStatus BadgeStatus `json:"payloadBadgeStatus,omitempty" yaml:"payloadBadgeStatus,omitempty"`
 
 	// Labels the labels to apply when qualifying jobs fail
 	Labels []string `json:"labels,omitempty" yaml:"labels,omitempty"`
@@ -50,6 +40,16 @@ type ReleaseQualifier struct {
 	// Notifications contains configuration for notification channels
 	Notifications *notifications.Notifications `json:"notifications,omitempty" yaml:"notifications,omitempty"`
 }
+
+// BadgeStatus badge status used to indicate if/when a ReleaseQualifier badge should be displayed
+type BadgeStatus string
+
+const (
+	BadgeStatusYes       BadgeStatus = "Yes"
+	BadgeStatusNo        BadgeStatus = "No"
+	BadgeStatusOnSuccess BadgeStatus = "OnSuccess"
+	BadgeStatusOnFailure BadgeStatus = "OnFailure"
+)
 
 // BoolPtr returns a pointer to the given bool value
 // This is a utility function for creating pointers to bool values


### PR DESCRIPTION
Working through the release-payload integration, I missed a nuance, about badging, that's important.  This PR updates a couple, badge specific, fields and descriptions of said fields. 

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED