### PR TITLE
Updating multi-arch jobs with RELEASE_IMAGE_ env variable

### DIFF
--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -207,6 +207,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			case "ppc64le":
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 			case "multi":
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 			default:
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
@@ -224,6 +225,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			case "ppc64le":
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 			case "multi":
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
 			default:
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
@@ -240,6 +242,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			case "ppc64le":
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_INITIAL", Value: previousReleasePullSpec})
 			case "multi":
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: previousReleasePullSpec})
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_INITIAL", Value: previousReleasePullSpec})
 			default:
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: previousReleasePullSpec})


### PR DESCRIPTION
In reference to a discussion had here: https://redhat-internal.slack.com/archives/CNHC2DK2M/p1768185606830309

Adding `RELEASE_IMAGE_LATEST` and `RELEASE_IMAGE_INITIAL` to all multi-arch release-controller jobs.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Enhanced multi-architecture release configurations with improved environment variable coverage. Generic release image variables are now available alongside architecture-specific ones, ensuring consistent access to latest and initial release image references across different architecture scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->