### PR TITLE
Adding support for OpenShift version 5

### DIFF
--- a/cmd/release-controller-api/http_compare.go
+++ b/cmd/release-controller-api/http_compare.go
@@ -91,7 +91,7 @@ func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Reque
 		if err != nil || !ok {
 			continue
 		}
-		if r.Config.Name == "4-stable" {
+		if r.Config.Name == "4-stable" || r.Config.Name == "5-stable" {
 			s := ReleaseStream{
 				Release: r,
 				Tags:    releasecontroller.SortedReleaseTags(r),

--- a/cmd/release-controller-api/static/releaseDashboardPage.tmpl
+++ b/cmd/release-controller-api/static/releaseDashboardPage.tmpl
@@ -9,7 +9,7 @@
 <div class="row">
     <div class="col">
         {{ range .Streams }}
-        {{ if and (ne .Release.Config.Name "4-stable") (ne .Release.Config.Name "4-dev-preview") }}
+        {{ if and (ne .Release.Config.Name "4-stable") (ne .Release.Config.Name "5-stable") (ne .Release.Config.Name "4-dev-preview") (ne .Release.Config.Name "5-dev-preview") }}
         <h2 title="From image stream {{ .Release.Source.Namespace }}/{{ .Release.Source.Name }}"><a id="{{ .Release.Config.Name }}" href="#{{ .Release.Config.Name }}" class="text-dark">{{ .Release.Config.Name }}</a></h2>
         {{ publishDescription . }}
         {{ $upgrades := .Upgrades }}

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -78,11 +78,11 @@ func getNonVerifiedTagsJira(acceptedTags []*v1.TagReference) (current, previous 
 // from the previous minor version to use as the previousReleaseTag for nightly releases.
 // For example, for "4.20.0-0.nightly", it would look for "4.19.0-rc.0" or "4.19.0-fc.0"
 //
-// Special test case: The 5.0 -> 4.22 mapping serves as a test case for hardcoding a previous release
+// Special test case: The 6.0 -> 5.55 mapping serves as a test case for hardcoding a previous release
 // when the normal calculation logic would not work. Used 5.0 as it is not a planned OpenShift release.
 // If a major version transition requires a specific previous release mapping, follow this pattern.
 func (c *Controller) calculatePreviousReleaseTagForNightly(currentVersion semver.Version) (*releasecontroller.VerifyIssuesTagInfo, error) {
-	// Get all stable releases (includes both 4-stable and 4-dev-preview streams)
+	// Get all stable releases (includes 4-stable, 4-dev-preview, 5-stable, and 5-dev-preview streams)
 	stableReleases, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get stable releases: %w", err)
@@ -91,14 +91,14 @@ func (c *Controller) calculatePreviousReleaseTagForNightly(currentVersion semver
 	// Calculate the target minor version (previous minor)
 	var targetMajor, targetMinor uint64
 
-	// Special case: 5.0 uses 4.22 as a test case for hardcoded previous release logic.
+	// Special case: 6.0 uses 5.55 as a test case for hardcoded previous release logic.
 	// This demonstrates how to handle major version transitions that require a specific
-	// previous release rather than calculated previous minor. Using 5.0 as this is not
-	// a planned release.
-	if currentVersion.Major == 5 && currentVersion.Minor == 0 {
-		targetMajor = 4
-		targetMinor = 22
-		klog.V(4).Infof("jira: special case for version 5.0, using hardcoded previous version 4.22 (test case)")
+	// previous release rather than calculated previous minor. Using 6.0 as this is not
+	// a planned release at this time.
+	if currentVersion.Major == 6 && currentVersion.Minor == 0 {
+		targetMajor = 5
+		targetMinor = 55
+		klog.V(4).Infof("jira: special case for version 6.0, using hardcoded previous version 5.55 (test case)")
 	} else if currentVersion.Minor == 0 {
 		return nil, fmt.Errorf("cannot calculate previous minor version for %d.%d", currentVersion.Major, currentVersion.Minor)
 	} else {

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -209,6 +209,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 		if err != nil {
 			return "", "", fmt.Errorf("invalid semver range `%s`: %w", upgradeRelease.Prerelease.VersionBounds.Query(), err)
 		}
+		//TODO: Right now, nothing relies on the "prerelease" stanza that would trigger this logic.  If it is ever used, we are going to need to handle "4-stable" and "5-stable"...
 		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, "4-stable", semverRange, 0, "")
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get latest tag in 4-stable stream: %w", err)

--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -1406,8 +1406,15 @@ class FileServer(handler):
             release_cache_dir = os.path.join(CACHE_DIR, release)
 
             release_imagestream_name = 'release'
+            major = int(parts[0])
+            if major > 4:
+                release_imagestream_name = f'release-{major}'
+
             if '-ec.' in release:
-                release_imagestream_name = '4-dev-preview'
+                if major > 4:
+                    release_imagestream_name = f'{major}-dev-preview'
+                else:
+                    release_imagestream_name = '4-dev-preview'
 
             if os.path.isfile(os.path.join(release_cache_dir, "sha256sum.txt")) or os.path.isfile(os.path.join(release_cache_dir, "FAILED.md")):
                 handler.do_GET(self)


### PR DESCRIPTION
This is my initial pass at getting the release-controller to handle OpenShift version 5.  Everything checked out with whatever testing I could do locally with the 5.0 resources that are currently available.  There is still one remaining TODO in this PR but it's protected by a setting that is not actively being used anywhere.  This should hopefully buy us some time to improve that particular logic to properly handle multiple "prerelease" streams (`4-stable` and `5-stable`) in play at once.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED