### PR TITLE
Add EndOfSupport flag

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1716,16 +1716,18 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 			Tags:    releasecontroller.SortedReleaseTags(r),
 		}
 		var delays []string
-		if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
+		if r.Config.EndOfSupport {
+			s.Delayed = &ReleaseDelay{Message: "Release has reached end of support"}
+		} else if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
 			if ok, _, queueAfter := releasecontroller.IsReleaseDelayedForInterval(r, s.Tags[0]); ok {
 				delays = append(delays, fmt.Sprintf("waiting for %s", queueAfter.Truncate(time.Second)))
 			}
 			if r.Config.MaxUnreadyReleases > 0 && releasecontroller.CountUnreadyReleases(r, s.Tags) >= r.Config.MaxUnreadyReleases {
 				delays = append(delays, fmt.Sprintf("no more than %d pending", r.Config.MaxUnreadyReleases))
 			}
-		}
-		if len(delays) > 0 {
-			s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
+			if len(delays) > 0 {
+				s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
+			}
 		}
 		if r.Config.As != releasecontroller.ReleaseConfigModeStable {
 			s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph, false)
@@ -1966,16 +1968,18 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 		Tags:    releasecontroller.SortedReleaseTags(r),
 	}
 	var delays []string
-	if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
+	if r.Config.EndOfSupport {
+		s.Delayed = &ReleaseDelay{Message: "Release has reached end of support"}
+	} else if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
 		if ok, _, queueAfter := releasecontroller.IsReleaseDelayedForInterval(r, s.Tags[0]); ok {
 			delays = append(delays, fmt.Sprintf("waiting for %s", queueAfter.Truncate(time.Second)))
 		}
 		if r.Config.MaxUnreadyReleases > 0 && releasecontroller.CountUnreadyReleases(r, s.Tags) >= r.Config.MaxUnreadyReleases {
 			delays = append(delays, fmt.Sprintf("no more than %d pending", r.Config.MaxUnreadyReleases))
 		}
-	}
-	if len(delays) > 0 {
-		s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
+		if len(delays) > 0 {
+			s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
+		}
 	}
 	if r.Config.As != releasecontroller.ReleaseConfigModeStable {
 		s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph, false)
@@ -2123,20 +2127,21 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 			Tags:    releasecontroller.SortedReleaseTags(r),
 		}
 		var delays []string
-		if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
+		if r.Config.EndOfSupport {
+			s.Delayed = &ReleaseDelay{Message: "Release has reached end of support"}
+		} else if r.Config.As != releasecontroller.ReleaseConfigModeStable && len(s.Tags) > 0 {
 			if ok, _, queueAfter := releasecontroller.IsReleaseDelayedForInterval(r, s.Tags[0]); ok {
 				delays = append(delays, fmt.Sprintf("waiting for %s", queueAfter.Truncate(time.Second)))
 			}
 			if r.Config.MaxUnreadyReleases > 0 && releasecontroller.CountUnreadyReleases(r, s.Tags) >= r.Config.MaxUnreadyReleases {
 				delays = append(delays, fmt.Sprintf("no more than %d pending", r.Config.MaxUnreadyReleases))
 			}
+			if len(delays) > 0 {
+				s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
+			}
 		}
 		if isReleaseFailing(s.Tags, r.Config.MaxUnreadyReleases) {
 			s.Failing = true
-		}
-
-		if len(delays) > 0 {
-			s.Delayed = &ReleaseDelay{Message: fmt.Sprintf("Next release may not start: %s", strings.Join(delays, ", "))}
 		}
 		if r.Config.As != releasecontroller.ReleaseConfigModeStable {
 			s.Upgrades = calculateReleaseUpgrades(r, s.Tags, c.graph, true)

--- a/cmd/release-controller/periodic.go
+++ b/cmd/release-controller/periodic.go
@@ -61,6 +61,10 @@ func (c *Controller) syncPeriodicJobs(prowInformers cache.SharedIndexInformer, s
 				klog.V(6).Infof("release %s has reached the end of life", r.Config.Name)
 				continue
 			}
+			if r.Config.EndOfSupport {
+				klog.V(6).Infof("release %s has reached end of support, skipping periodic jobs", r.Config.Name)
+				continue
+			}
 			for name, releasePeriodic := range r.Config.Periodic {
 				periodicConfig, ok := hasProwJob(cfg, releasePeriodic.ProwJob.Name)
 				if !ok {

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -240,7 +240,11 @@ func calculateSyncActions(release *releasecontroller.Release, now time.Time) (ad
 		inputImageHash = ""
 		removeTags = nil
 	default:
-		// gate creating new releases when we already are at max unready or in the cooldown interval
+		// gate creating new releases when end of support, at max unready, or in the cooldown interval
+		if release.Config.EndOfSupport {
+			klog.V(2).Infof("Release %s has reached end of support, will not launch new tags", release.Config.Name)
+			hasNewImages = false
+		}
 		if release.Config.MaxUnreadyReleases > 0 && unreadyTagCount >= release.Config.MaxUnreadyReleases {
 			klog.V(2).Infof("Release %s at max %d unready releases, will not launch new tags", release.Config.Name, release.Config.MaxUnreadyReleases)
 			hasNewImages = false

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -87,6 +87,11 @@ type ReleaseConfig struct {
 	// displayed by the release-controller
 	EndOfLife bool `json:"endOfLife"`
 
+	// EndOfSupport indicates this release stream is no longer supported and should
+	// stop creating new releases, but remain visible on the status pages without
+	// showing a countdown timer.
+	EndOfSupport bool `json:"endOfSupport"`
+
 	// As defines what this image stream provides. The default value is "Integration"
 	// and the images in the image stream will be used to build payloads. An optional
 	// mode is "Stable" and tags are assumed to be release payloads that should be promoted


### PR DESCRIPTION
Currently, the release controller has an EndOfLife flag that completely hides releases from the UI. 
As a trick, minCreationIntervalSeconds is increased to a big number.
However, there's a need for an intermediate state where a release stream:

- Should stop creating new releases
- Should remain visible on the status pages (unlike EndOfLife)
- Should not display countdown timers or pending release messages

This is useful for release streams that are no longer actively maintained but should still be accessible.


**Usage**
Set "endOfSupport": true in the release configuration to enable this behavior:
```
{
 "name": "4.19.0-0.okd-scos",
 "endOfSupport": true,
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EndOfSupport status capability for releases. Releases marked as EndOfSupport will display "Release has reached end of support" messaging on status pages and will no longer create new periodic jobs or image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->