### PR TITLE
Hard coding 5.0's previous release as 4.23

### DIFF
--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -99,6 +99,10 @@ func (c *Controller) calculatePreviousReleaseTagForNightly(currentVersion semver
 		targetMajor = 5
 		targetMinor = 55
 		klog.V(4).Infof("jira: special case for version 6.0, using hardcoded previous version 5.55 (test case)")
+	} else if currentVersion.Major == 5 && currentVersion.Minor == 0 {
+		targetMajor = 4
+		targetMinor = 23
+		klog.V(4).Infof("jira: special case for version 5.0, using hardcoded previous version 4.23")
 	} else if currentVersion.Minor == 0 {
 		return nil, fmt.Errorf("cannot calculate previous minor version for %d.%d", currentVersion.Major, currentVersion.Minor)
 	} else {


### PR DESCRIPTION
For `5.0-nightly` releases, their auto-calculated previous release versions should reach back to `4.23` releases.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release version tracking for nightly builds to ensure version 5.0 releases correctly reference the associated previous release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->