### PR TITLE
Bumping tools to 4.23

### DIFF
--- a/images/release-controller-api/Dockerfile
+++ b/images/release-controller-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.21:tools
+FROM registry.ci.openshift.org/ocp/4.23:tools
 LABEL maintainer="apavel@redhat.com"
 
 RUN yum install -y graphviz

--- a/images/release-controller/Dockerfile
+++ b/images/release-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.21:tools
+FROM registry.ci.openshift.org/ocp/4.23:tools
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-controller /usr/bin/release-controller

--- a/images/release-mirror-cleanup-controller/Dockerfile
+++ b/images/release-mirror-cleanup-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.21:cli
+FROM registry.ci.openshift.org/ocp/4.23:cli
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-mirror-cleanup-controller /usr/bin/release-mirror-cleanup-controller

--- a/images/release-reimport-controller/Dockerfile
+++ b/images/release-reimport-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.21:cli
+FROM registry.ci.openshift.org/ocp/4.23:cli
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-reimport-controller /usr/bin/release-reimport-controller


### PR DESCRIPTION
A request has come in that we bump to `4.23` to pick up the latest/greatest `oc` command.
This PR just syncs things up with: https://github.com/openshift/release/pull/75672

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base images for release controller services.
  * Added explicit entry points to release controller applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->