### PR TITLE
OCPCRT-24: Add expandable links to all retry attempts

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -471,6 +471,38 @@ func (c *Controller) renderVerificationJobsList(jobs releasecontroller.Verificat
 			continue
 		}
 		if len(value.URL) > 0 {
+			if value.Retries > 0 && len(value.PreviousAttemptURLs) > 0 {
+				// Expandable row showing all attempts
+				buf.WriteString("<li><details><summary style=\"cursor:pointer\">")
+				stateClass := ""
+				stateText := " Pending"
+				switch value.State {
+				case releasecontroller.ReleaseVerificationStateFailed:
+					stateClass = "text-danger"
+					stateText = " Failed"
+				case releasecontroller.ReleaseVerificationStateSucceeded:
+					stateClass = "text-success"
+					stateText = " Succeeded"
+				}
+				fmt.Fprintf(buf, "<span class=\"%s\">%s%s</span>", stateClass, template.HTMLEscapeString(key), stateText)
+				retryWord := "retries"
+				if value.Retries == 1 {
+					retryWord = "retry"
+				}
+				fmt.Fprintf(buf, " <span class=\"text-warning\">(%d %s)</span>", value.Retries, retryWord)
+				if pj := verificationJobs[key].ProwJob; pj != nil {
+					buf.WriteString(" ")
+					buf.WriteString(pj.Name)
+				}
+				buf.WriteString("</summary><ul>")
+				for i, retryURL := range value.PreviousAttemptURLs {
+					fmt.Fprintf(buf, "<li><a class=\"text-danger\" href=\"%s\">Attempt %d Failed</a></li>", template.HTMLEscapeString(releasecontroller.GenerateProwJobResultsURL(retryURL)), i+1)
+				}
+				attemptNum := len(value.PreviousAttemptURLs) + 1
+				fmt.Fprintf(buf, "<li><a class=\"%s\" href=\"%s\">Attempt %d%s</a></li>", stateClass, template.HTMLEscapeString(releasecontroller.GenerateProwJobResultsURL(value.URL)), attemptNum, stateText)
+				buf.WriteString("</ul></details>")
+				continue
+			}
 			switch value.State {
 			case releasecontroller.ReleaseVerificationStateFailed:
 				buf.WriteString("<li><a class=\"text-danger\" href=\"")

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -390,6 +390,7 @@ type VerificationStatus struct {
 	State          string       `json:"state"`
 	URL            string       `json:"url"`
 	Retries        int          `json:"retries,omitempty"`
+	PreviousAttemptURLs []string `json:"previousAttemptURLs,omitempty"`
 	TransitionTime *metav1.Time `json:"transitionTime,omitempty"`
 }
 

--- a/pkg/releasepayload/utils.go
+++ b/pkg/releasepayload/utils.go
@@ -31,10 +31,12 @@ func GenerateVerificationStatusMap(payload *v1alpha1.ReleasePayload, status *rel
 }
 
 func convertToVerificationStatusMapResult(job v1alpha1.JobStatus) (*releasecontroller.VerificationStatus, bool) {
+	url := getVerificationStatusUrl(job.JobRunResults)
 	status := &releasecontroller.VerificationStatus{
-		Retries: getVerificationStatusRetries(job),
-		State:   getVerificationStatusState(job.AggregateState),
-		URL:     getVerificationStatusUrl(job.JobRunResults),
+		Retries:   getVerificationStatusRetries(job),
+		PreviousAttemptURLs: getVerificationStatusPreviousAttemptURLs(job.JobRunResults, url),
+		State:     getVerificationStatusState(job.AggregateState),
+		URL:       url,
 	}
 	return status, true
 }
@@ -80,6 +82,23 @@ func getVerificationStatusState(state v1alpha1.JobState) string {
 	default:
 		return releasecontroller.ReleaseVerificationStatePending
 	}
+}
+
+func getVerificationStatusPreviousAttemptURLs(jobRunResults []v1alpha1.JobRunResult, primaryURL string) []string {
+	if len(jobRunResults) <= 1 {
+		return nil
+	}
+	sorted := make([]v1alpha1.JobRunResult, len(jobRunResults))
+	copy(sorted, jobRunResults)
+	sort.Sort(jobrunresult.ByStartTime(sorted))
+
+	var urls []string
+	for _, result := range sorted {
+		if result.HumanProwResultsURL != "" && result.HumanProwResultsURL != primaryURL {
+			urls = append(urls, result.HumanProwResultsURL)
+		}
+	}
+	return urls
 }
 
 func getVerificationStatusUrl(jobRunResults []v1alpha1.JobRunResult) string {

--- a/pkg/releasepayload/utils_test.go
+++ b/pkg/releasepayload/utils_test.go
@@ -181,6 +181,100 @@ func Test_getVerificationStatusState(t *testing.T) {
 	}
 }
 
+func Test_getVerificationStatusPreviousAttemptURLs(t *testing.T) {
+	tests := []struct {
+		name       string
+		results    []v1alpha1.JobRunResult
+		primaryURL string
+		want       []string
+	}{
+		{
+			name:       "No Results",
+			results:    []v1alpha1.JobRunResult{},
+			primaryURL: "",
+			want:       nil,
+		},
+		{
+			name: "Single Result",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateSuccess,
+				},
+			},
+			primaryURL: "https://abc.123/",
+			want:       nil,
+		},
+		{
+			name: "Multiple Results - Primary Is Success",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://def.456/",
+					State:               v1alpha1.JobRunStateSuccess,
+				},
+			},
+			primaryURL: "https://def.456/",
+			want:       []string{"https://abc.123/"},
+		},
+		{
+			name: "Multiple Results - All Failures",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "https://abc.123/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://def.456/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://ghi.789/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+			},
+			primaryURL: "https://ghi.789/",
+			want:       []string{"https://abc.123/", "https://def.456/"},
+		},
+		{
+			name: "Results With Empty URL Excluded",
+			results: []v1alpha1.JobRunResult{
+				{
+					HumanProwResultsURL: "",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://def.456/",
+					State:               v1alpha1.JobRunStateFailure,
+				},
+				{
+					HumanProwResultsURL: "https://ghi.789/",
+					State:               v1alpha1.JobRunStateSuccess,
+				},
+			},
+			primaryURL: "https://ghi.789/",
+			want:       []string{"https://def.456/"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getVerificationStatusPreviousAttemptURLs(tt.results, tt.primaryURL)
+			if len(tt.want) != len(got) {
+				t.Errorf("%s: Expected %v, got %v", tt.name, tt.want, got)
+				return
+			}
+			for i := range tt.want {
+				if tt.want[i] != got[i] {
+					t.Errorf("%s: Expected %v at index %d, got %v", tt.name, tt.want[i], i, got[i])
+				}
+			}
+		})
+	}
+}
+
 func Test_getVerificationStatusUrl(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Adds `PreviousAttemptURLs` field to `VerificationStatus` to expose URLs for all retry attempts in the JSON API
- Renders retried jobs as expandable `<details>` rows in the release page UI — clicking expands to show each individual attempt with a link to its prow results
- Preserves the existing "(N retries)" text for backwards compatibility with scrapers
- Falls back to the existing non-expandable format when `PreviousAttemptURLs` are not populated

Preview: https://htmlpreview.github.io/?https://gist.githubusercontent.com/stbenjam/491679fc2a2b6d4ec401d433006b0a73/raw/release-page-local.html


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added expandable retry attempt history for verification jobs, allowing users to view all previous failed attempts and the current status in the verification job list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->