### PR TITLE
Adding the ability to (re-)create the ReleasePayload CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,17 @@ verify-codegen-script:
 
 # Ensure codegen is run before generating the CRD, so updates to Godoc are included.
 update-crd: update-codegen-script update-codegen-crds
+.PHONY: update-crd
+
+# Create CRD from scratch using the 'crd' generator instead of 'schemapatch'
+# This target can regenerate the CRD even if it doesn't exist, unlike update-crd
+# which uses 'schemapatch' and only patches existing CRDs.
+create-crd: update-codegen-script ensure-controller-gen
+	'$(CONTROLLER_GEN)' \
+		crd \
+		paths="./pkg/apis/release/v1alpha1" \
+		'output:crd:dir=./artifacts'
+.PHONY: create-crd
 
 sonar-reports:
 	go test ./... -coverprofile=coverage.out -covermode=count -json > report.json


### PR DESCRIPTION
The latest/greatest k8s versions changed the way that CRDs were generated/updated.  This PR adds a new `create-crd` target that can be used to (re-)create the CRD as needed.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling to include an additional build target for custom resource definition generation, improving the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->