### PR TITLE
Adding OCP v5 support to files-cache

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -1399,7 +1399,7 @@ class FileServer(handler):
             release = segments[0]
 
             parts = release.split('.')
-            if len(parts) < 2 or int(parts[1]) < 11:
+            if len(parts) < 2 or int(parts[0]) < 4 or (int(parts[0]) == 4 and int(parts[1]) < 11):
                 self._present_blocked_content(release)
                 return
             


### PR DESCRIPTION
Folks are unable to download any of the version 5.0 installers from the files-cache:

```
You are attempting to download an Openshift release (5.0.0-0.nightly-2026-03-11-012605) that has past it's end of life and is no longer available via this utility!
Please contact us in: #forum-ocp-crt if this is a problem.
Thank you!
```

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release version validation logic to enforce stricter requirements. Releases with major versions below 4 are now blocked. For major version 4, minor version 11 or higher is required to proceed with release extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->