### PR TITLE
OCPCRT-458: Add node image RPM diff to release info API response

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -668,7 +668,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	var changeLog []byte
 	var changeLogJson releasecontroller.ChangeLog
-	var rpmDiff *releasecontroller.RpmDiff
+	var nodeImageStreams []releasecontroller.APINodeImageStream
 
 	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 {
 		var wg sync.WaitGroup
@@ -691,12 +691,42 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
+			streams, err := c.releaseInfo.ListMachineOSStreams(tagInfo.TagPullSpec)
 			if err != nil {
-				klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+				klog.V(4).Infof("Unable to list machine-OS streams for %s: %v", tagInfo.Tag, err)
+			}
+
+			if len(streams) == 0 {
+				diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
+				if err != nil {
+					klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+					return
+				}
+				nodeImageStreams = []releasecontroller.APINodeImageStream{{
+					Name:    "Red Hat Enterprise Linux CoreOS",
+					Tag:     "rhel-coreos",
+					RpmDiff: &diff,
+				}}
 				return
 			}
-			rpmDiff = &diff
+
+			result := make([]releasecontroller.APINodeImageStream, 0, len(streams))
+			for _, stream := range streams {
+				entry := releasecontroller.APINodeImageStream{
+					Name: stream.DisplayName,
+					Tag:  stream.Tag,
+				}
+				if _, errFrom := c.releaseInfo.ImageReferenceForComponent(tagInfo.PreviousTagPullSpec, stream.Tag); errFrom == nil {
+					diff, err := c.releaseInfo.RpmDiffForStream(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec, stream.Tag)
+					if err != nil {
+						klog.V(4).Infof("Unable to retrieve RPM diff for stream %s in %s: %v", stream.Tag, tagInfo.Tag, err)
+					} else {
+						entry.RpmDiff = &diff
+					}
+				}
+				result = append(result, entry)
+			}
+			nodeImageStreams = result
 		}()
 
 		wg.Wait()
@@ -719,14 +749,14 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	summary := releasecontroller.APIReleaseInfo{
-		Name:             tagInfo.Tag,
-		Phase:            tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
-		Results:          verificationJobs,
-		UpgradesTo:       c.graph.UpgradesTo(tagInfo.Tag),
-		UpgradesFrom:     c.graph.UpgradesFrom(tagInfo.Tag),
-		ChangeLog:        changeLog,
-		ChangeLogJson:    changeLogJson,
-		NodeImageRpmDiff: rpmDiff,
+		Name:            tagInfo.Tag,
+		Phase:           tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
+		Results:         verificationJobs,
+		UpgradesTo:      c.graph.UpgradesTo(tagInfo.Tag),
+		UpgradesFrom:    c.graph.UpgradesFrom(tagInfo.Tag),
+		ChangeLog:       changeLog,
+		ChangeLogJson:   changeLogJson,
+		NodeImageStreams: nodeImageStreams,
 	}
 
 	data, err := json.MarshalIndent(&summary, "", "  ")

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -668,6 +668,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	var changeLog []byte
 	var changeLogJson releasecontroller.ChangeLog
+	var rpmDiff *releasecontroller.RpmDiff
 
 	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 {
 		var wg sync.WaitGroup
@@ -686,6 +687,18 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				c.changeLogWorker(result, tagInfo, format)
 			}()
 		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
+			if err != nil {
+				klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+				return
+			}
+			rpmDiff = &diff
+		}()
+
 		wg.Wait()
 
 		if renderHTML.err == nil {
@@ -706,13 +719,14 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	summary := releasecontroller.APIReleaseInfo{
-		Name:          tagInfo.Tag,
-		Phase:         tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
-		Results:       verificationJobs,
-		UpgradesTo:    c.graph.UpgradesTo(tagInfo.Tag),
-		UpgradesFrom:  c.graph.UpgradesFrom(tagInfo.Tag),
-		ChangeLog:     changeLog,
-		ChangeLogJson: changeLogJson,
+		Name:             tagInfo.Tag,
+		Phase:            tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
+		Results:          verificationJobs,
+		UpgradesTo:       c.graph.UpgradesTo(tagInfo.Tag),
+		UpgradesFrom:     c.graph.UpgradesFrom(tagInfo.Tag),
+		ChangeLog:        changeLog,
+		ChangeLogJson:    changeLogJson,
+		NodeImageRpmDiff: rpmDiff,
 	}
 
 	data, err := json.MarshalIndent(&summary, "", "  ")

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -54,8 +54,18 @@ type APIReleaseInfo struct {
 	ChangeLog []byte `json:"changeLog,omitempty"`
 	//ChangeLogJson is the json representation of the changes included in this release tag
 	ChangeLogJson ChangeLog `json:"changeLogJson,omitempty"`
-	// NodeImageRpmDiff is the RPM package diff between the previous and current node images
-	NodeImageRpmDiff *RpmDiff `json:"nodeImageRpmDiff,omitempty"`
+	// NodeImageStreams contains per-stream RPM diffs for each machine-OS image (e.g. rhel-coreos, rhel-coreos-10).
+	NodeImageStreams []APINodeImageStream `json:"nodeImageStreams,omitempty"`
+}
+
+// APINodeImageStream holds RPM diff information for a single machine-OS stream in a release payload.
+type APINodeImageStream struct {
+	// Name is the human-readable display name (e.g. "Red Hat Enterprise Linux CoreOS").
+	Name string `json:"name"`
+	// Tag is the payload component tag (e.g. "rhel-coreos", "rhel-coreos-10").
+	Tag string `json:"tag"`
+	// RpmDiff is the RPM package diff between previous and current releases for this stream.
+	RpmDiff *RpmDiff `json:"rpmDiff,omitempty"`
 }
 
 // Release holds information about the release used during processing.

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -54,6 +54,8 @@ type APIReleaseInfo struct {
 	ChangeLog []byte `json:"changeLog,omitempty"`
 	//ChangeLogJson is the json representation of the changes included in this release tag
 	ChangeLogJson ChangeLog `json:"changeLogJson,omitempty"`
+	// NodeImageRpmDiff is the RPM package diff between the previous and current node images
+	NodeImageRpmDiff *RpmDiff `json:"nodeImageRpmDiff,omitempty"`
 }
 
 // Release holds information about the release used during processing.


### PR DESCRIPTION
## Summary
- Adds `nodeImageRpmDiff` field to the `APIReleaseInfo` struct, exposing the RPM package diff between previous and current node images in the JSON API response
- The RPM diff is fetched concurrently alongside the existing changelog generation, so it adds no additional latency
- This data was previously only available on the HTML page but missing from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Testing locally works for me:

```json
  "nodeImageRpmDiff": {
    "changed": {
      "kernel": {
        "old": "6.12.0-211.5.1.el10_2",
        "new": "6.12.0-211.6.1.el10_2"
      },
      "kernel-core": {
        "old": "6.12.0-211.5.1.el10_2",
        "new": "6.12.0-211.6.1.el10_2"
      },
      "kernel-modules": {
        "old": "6.12.0-211.5.1.el10_2",
        "new": "6.12.0-211.6.1.el10_2"
      },
      "kernel-modules-core": {
        "old": "6.12.0-211.5.1.el10_2",
        "new": "6.12.0-211.6.1.el10_2"
      },
      "kernel-modules-extra": {
        "old": "6.12.0-211.5.1.el10_2",
        "new": "6.12.0-211.6.1.el10_2"
      }
    }
  }
```

From http://localhost:8080/api/v1/releasestream/4.22.0-0.nightly/release/4.22.0-0.nightly-2026-03-30-221541?from=4.22.0-0.nightly-2026-03-30-132356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release payloads now include per-node-image stream entries showing name, tag, and optional RPM diffs.
  * When per-stream diffs aren't available, a fallback single RPM diff is provided so node-image changes remain visible.
  * RPM diff retrieval errors are logged and do not break the release response; missing diffs may be omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->