### PR TITLE
jira: include rejected payloads when verifying payload component bugs

### DIFF
--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -217,8 +217,8 @@ func (c *Controller) syncJira(key queueKey) error {
 	// confirms that all blocking tests have been executed (accepted or rejected) and that the code
 	// fix is present in the payload, allowing the bug status to be automatically transitioned to
 	// VERIFIED and notifying assignees which payload contains their fix.
-	acceptedTags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseAccepted, releasecontroller.ReleasePhaseRejected)
-	tag, prevTag := getNonVerifiedTagsJira(acceptedTags)
+	completedTags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseAccepted, releasecontroller.ReleasePhaseRejected)
+	tag, prevTag := getNonVerifiedTagsJira(completedTags)
 	if tag == nil {
 		klog.V(6).Infof("jira: All accepted/rejected tags for %s have already been verified", release.Config.Name)
 		return nil

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -211,11 +211,16 @@ func (c *Controller) syncJira(key queueKey) error {
 
 	klog.V(4).Infof("Verifying fixed issues in %s", release.Config.Name)
 
-	// get accepted tags
-	acceptedTags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseAccepted)
+	// Include both accepted and rejected tags when looking for bugs to verify.
+	// Bugs are pre-merge verified by QA on ephemeral clusters (via qe-approved/verified PR labels),
+	// so no additional payload-level QA verification is needed. The payload phase check here simply
+	// confirms that all blocking tests have been executed (accepted or rejected) and that the code
+	// fix is present in the payload, allowing the bug status to be automatically transitioned to
+	// VERIFIED and notifying assignees which payload contains their fix.
+	acceptedTags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseAccepted, releasecontroller.ReleasePhaseRejected)
 	tag, prevTag := getNonVerifiedTagsJira(acceptedTags)
 	if tag == nil {
-		klog.V(6).Infof("jira: All accepted tags for %s have already been verified", release.Config.Name)
+		klog.V(6).Infof("jira: All accepted/rejected tags for %s have already been verified", release.Config.Name)
 		return nil
 	}
 	if prevTag == nil {

--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -107,7 +107,7 @@ func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {
 
 func (c *Verifier) verifyExtPRs(issue *jiraBaseClient.Issue, extPRs []pr, errs *[]error, tagName string) (ticketMessage string, isSuccess, verifiedLater bool) {
 	var success bool
-	message := fmt.Sprintf("Fix included in accepted release %s", tagName)
+	message := fmt.Sprintf("Fix included in release %s", tagName)
 	var unApprovedPRs []pr
 	if !strings.EqualFold(issue.Fields.Status.Name, jira.StatusOnQA) && !strings.EqualFold(issue.Fields.Status.Name, jira.StatusModified) {
 		klog.V(4).Infof("Issue %s is in %s status; ignoring", issue.Key, issue.Fields.Status.Name)

--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -92,8 +92,11 @@ func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {
 		return err, false
 	}
 	// Check to see if the same message has already been posted.
+	// Also check the legacy message format ("accepted release") to avoid duplicates
+	// after the wording change from "Fix included in accepted release" to "Fix included in release".
+	legacyMessage := strings.Replace(message, "in release ", "in accepted release ", 1)
 	for _, comment := range comments {
-		if strings.Contains(comment.Body, message) {
+		if strings.Contains(comment.Body, message) || strings.Contains(comment.Body, legacyMessage) {
 			return nil, true
 		}
 	}

--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -80,6 +80,36 @@ func TestCommentOnPR(t *testing.T) {
 	}
 }
 
+// TestCommentOnPRLegacyDedupe tests that commentOnPR does not post a duplicate
+// comment when an existing comment uses the legacy "accepted release" wording,
+// after the message was changed to "Fix included in release".
+func TestCommentOnPRLegacyDedupe(t *testing.T) {
+	tagName := "4.20.0-0.nightly-2026-04-01-022028"
+	newMessage := fmt.Sprintf("Fix included in release %s", tagName)
+	legacyMessage := fmt.Sprintf("Fix included in accepted release %s", tagName)
+
+	// Seed the fake client with an existing comment using the legacy wording
+	existingComments := map[int][]github.IssueComment{
+		1: {{Body: legacyMessage}},
+	}
+	mockClient := &fakegithub.FakeClient{IssueComments: existingComments}
+	verifier := &Verifier{ghClient: mockClient}
+	extPR := pr{org: "testOrg", repo: "testRepo", prNum: 1}
+
+	// commentOnPR should detect the legacy comment and not post a duplicate
+	err, created := verifier.commentOnPR(extPR, newMessage)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !created {
+		t.Errorf("Expected created=true (comment already exists), but got false")
+	}
+	// Verify no new comment was posted
+	if len(mockClient.IssueComments[1]) != 1 {
+		t.Errorf("Expected 1 comment (no duplicate), but got %d", len(mockClient.IssueComments[1]))
+	}
+}
+
 func TestGetPRS(t *testing.T) {
 	issue := jira.Issue{ID: "OCPBUGS-0000"}
 	removeLinkArray := []jira.RemoteLink{

--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -295,7 +295,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "",
-				message: "Fix included in accepted release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				message: "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
 			},
 		},
 		{
@@ -312,7 +312,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "Verified",
-				message: "Fix included in accepted release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
 			},
 		},
 		{
@@ -327,7 +327,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "Verified",
-				message: "Fix included in accepted release 4.10",
+				message: "Fix included in release 4.10",
 			},
 		},
 		{
@@ -342,7 +342,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "Verified",
-				message: "Fix included in accepted release 4.13.0-0.nightly-2022-11-12",
+				message: "Fix included in release 4.13.0-0.nightly-2022-11-12",
 			},
 		},
 		{
@@ -411,7 +411,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "Verified",
-				message: "Fix included in accepted release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
 			},
 		},
 		{
@@ -430,7 +430,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "Verified",
-				message: "Fix included in accepted release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
 			},
 		},
 		{
@@ -447,7 +447,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  nil,
 				status:  "Verified",
-				message: "Fix included in accepted release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
 			},
 		},
 		{
@@ -467,7 +467,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  []error{},
 				status:  "ON_QA",
-				message: "Fix included in accepted release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				message: "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
 			},
 		},
 		{
@@ -487,7 +487,7 @@ func TestVerifyIssues(t *testing.T) {
 			expected: expectedResult{
 				errors:  []error{},
 				status:  "ON_QA",
-				message: "Fix included in accepted release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				message: "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
 			},
 		},
 	}
@@ -1035,7 +1035,7 @@ const (
 				"active": true,
 				"timeZone": "America/New_York"
 			},
-			"body": "Fix included in accepted release 4.13.0-0.nightly-2022-11-12",
+			"body": "Fix included in release 4.13.0-0.nightly-2022-11-12",
 			"updateAuthor": {
 				"self": "https://issues.redhat.com/rest/api/2/user?username=openshift-crt-jira-release-controller",
 				"name": "openshift-crt-jira-release-controller",


### PR DESCRIPTION
## Summary

Previously, payload component bugs were only moved to VERIFIED when the fix landed in an **accepted** release payload. This change also considers **rejected** payloads, so bugs can be verified as soon as blocking tests complete — regardless of whether they pass or fail.

- Bugs fixed in payload components are pre-merge verified by QA on ephemeral clusters via `qe-approved`/`verified` PR labels
- The payload phase check is only used to confirm blocking tests have executed and the fix is present — not as an additional QA gate
- Both `Accepted` and `Rejected` payload phases satisfy this condition: all blocking tests have run and the fix is confirmed in the payload
- This reduces noise in QE tracking queues and allows release leads to focus escalations on genuinely unresolved issues

Jira: [OCPERT-358](https://redhat.atlassian.net/browse/OCPERT-358)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release verification now considers both accepted and rejected release tags when determining Jira issue verification status.
  * Jira notification text simplified by removing the redundant "accepted" qualifier for clearer messaging.

* **Tests**
  * Updated tests to match the revised Jira notification format and added a test ensuring legacy comment deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->