### PR TITLE
release-controller: fix semaphore slot leaks in node-info processing

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"embed"
 	"encoding/json"
 	"errors"
@@ -731,7 +732,7 @@ func (c *Controller) changeLogWorker(result *renderResult, tagInfo *releaseTagIn
 	ch := make(chan renderResult)
 
 	// run the changelog in a goroutine because it may take significant time
-	go c.getChangeLog(ch, nil, tagInfo.PreviousTagPullSpec, tagInfo.Info.Previous.Name, tagInfo.TagPullSpec, tagInfo.Info.Tag.Name, format)
+	go c.getChangeLog(context.Background(), ch, nil, tagInfo.PreviousTagPullSpec, tagInfo.Info.Previous.Name, tagInfo.TagPullSpec, tagInfo.Info.Tag.Name, format)
 
 	select {
 	case *result = <-ch:

--- a/cmd/release-controller-api/http_changelog.go
+++ b/cmd/release-controller-api/http_changelog.go
@@ -123,7 +123,7 @@ func (c *Controller) renderChangeLog(w http.ResponseWriter, fromPull string, fro
 	flusher.Flush()
 
 	ch := make(chan renderResult)
-	chNodeInfo := make(chan renderResult)
+	chNodeInfo := make(chan renderResult, 1)
 
 	// run the changelog in a goroutine because it may take significant time
 	go c.getChangeLog(ch, chNodeInfo, fromPull, fromTag, toPull, toTag, format)

--- a/cmd/release-controller-api/http_changelog.go
+++ b/cmd/release-controller-api/http_changelog.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +25,7 @@ type renderResult struct {
 	err error
 }
 
-func (c *Controller) getChangeLog(ch chan renderResult, chNodeInfo chan renderResult, fromPull string, fromTag string, toPull string, toTag string, format string) {
+func (c *Controller) getChangeLog(ctx context.Context, ch chan renderResult, chNodeInfo chan renderResult, fromPull string, fromTag string, toPull string, toTag string, format string) {
 	fromImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, fromPull)
 	if err != nil {
 		ch <- renderResult{err: err}
@@ -106,7 +107,7 @@ func (c *Controller) getChangeLog(ch chan renderResult, chNodeInfo chan renderRe
 		return
 	}
 
-	nodeMD, err := rhcos.NodeImageSectionMarkdown(c.releaseInfo, fromImagePullspec, toImagePullspec, out)
+	nodeMD, err := rhcos.NodeImageSectionMarkdown(ctx, c.releaseInfo, fromImagePullspec, toImagePullspec, out)
 	if err != nil {
 		chNodeInfo <- renderResult{err: err}
 		return
@@ -122,11 +123,16 @@ func (c *Controller) renderChangeLog(w http.ResponseWriter, fromPull string, fro
 
 	flusher.Flush()
 
+	// Cancel ctx when the handler returns so orphaned goroutines release
+	// semaphore slots promptly instead of processing remaining streams.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	ch := make(chan renderResult)
 	chNodeInfo := make(chan renderResult, 1)
 
 	// run the changelog in a goroutine because it may take significant time
-	go c.getChangeLog(ch, chNodeInfo, fromPull, fromTag, toPull, toTag, format)
+	go c.getChangeLog(ctx, ch, chNodeInfo, fromPull, fromTag, toPull, toTag, format)
 
 	var render renderResult
 	select {

--- a/hack/changelog-preview/main.go
+++ b/hack/changelog-preview/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -67,7 +68,7 @@ func main() {
 	}
 
 	if !*skipNode {
-		nodeMD, err := rhcos.NodeImageSectionMarkdown(info, *from, *to, out)
+		nodeMD, err := rhcos.NodeImageSectionMarkdown(context.Background(), info, *from, *to, out)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "NodeImageSectionMarkdown: %v\n", err)
 			os.Exit(1)

--- a/pkg/rhcos/node_image.go
+++ b/pkg/rhcos/node_image.go
@@ -1,6 +1,7 @@
 package rhcos
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -15,7 +16,7 @@ import (
 // Newer oc releases may omit the "* Red Hat Enterprise Linux CoreOS upgraded from …" summary lines,
 // so that anchor is absent even when the payload has rhel-coreos* streams—we still render node
 // info when streams are discoverable.
-func NodeImageSectionMarkdown(info releasecontroller.ReleaseInfo, fromReleasePullSpec, toReleasePullSpec, changelogMarkdown string) (string, error) {
+func NodeImageSectionMarkdown(ctx context.Context, info releasecontroller.ReleaseInfo, fromReleasePullSpec, toReleasePullSpec, changelogMarkdown string) (string, error) {
 	streams, err := info.ListMachineOSStreams(toReleasePullSpec)
 	if err != nil {
 		return "", err
@@ -40,9 +41,14 @@ func NodeImageSectionMarkdown(info releasecontroller.ReleaseInfo, fromReleasePul
 		return RenderNodeImageInfo(changelogMarkdown, rpmlist, rpmdiff), nil
 	}
 
-	// Acquire single semaphore slot for all stream operations
+	// Acquire single semaphore slot for all stream operations.
+	// Respect context cancellation so orphaned goroutines from timed-out HTTP
+	// handlers release their slot promptly instead of holding it until all
+	// streams are processed.
 	select {
 	case releasecontroller.RpmdbOCSlots <- struct{}{}:
+	case <-ctx.Done():
+		return "", ctx.Err()
 	default:
 		return "", fmt.Errorf("too many concurrent oc adm release info --rpmdb/--rpmdb-diff operations (limit %d)",
 			releasecontroller.MaxConcurrentRpmdbOCCalls)
@@ -53,6 +59,13 @@ func NodeImageSectionMarkdown(info releasecontroller.ReleaseInfo, fromReleasePul
 	nodeStreams := make([]CoreOSNodeStream, len(streams))
 
 	for i, stream := range streams {
+		// Between stream iterations, check if the caller gave up (e.g. HTTP
+		// handler timed out). This releases the semaphore slot without waiting
+		// for remaining streams to finish.
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+
 		ext := stream.Tag + "-extensions"
 		list, err := info.RpmListForStream(toReleasePullSpec, stream.Tag, ext)
 		if err != nil {


### PR DESCRIPTION
## Summary

- **Buffer `chNodeInfo` channel** to prevent permanent goroutine leaks when the HTTP handler returns before the background goroutine finishes its node-info work
- **Thread cancellable context** from `renderChangeLog` through `getChangeLog` into `NodeImageSectionMarkdown` so orphaned goroutines release their semaphore slot promptly when the handler times out or decides node info is unneeded

## Problem

When multiple page loads trigger node-info processing and the HTTP handlers time out (60s), the background goroutines continue holding semaphore slots inside `NodeImageSectionMarkdown`. Between oc command invocations (or after all complete), no rpmdb processes are visible, but the slots remain occupied. After 8 such orphaned goroutines accumulate, all slots are exhausted and new requests immediately fail with "too many concurrent oc adm release info --rpmdb/--rpmdb-diff operations".

Additionally, because `chNodeInfo` was unbuffered, goroutines that finish their work but find no receiver (handler already returned) block forever on the channel send — a permanent goroutine leak.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./pkg/rhcos/... ./cmd/release-controller-api/...` passes
- [ ] Load a changelog page with RHCOS streams, verify node-info still renders
- [ ] Rapidly reload changelog pages and confirm "too many concurrent" errors recover promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Changelog generation now responds more quickly to cancellation requests during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->