### PR TITLE
OCPCRT-459: Add support for reference-based release payloads

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -537,7 +537,7 @@ func (c *Controller) apiReleaseLatest(w http.ResponseWriter, req *http.Request) 
 	downloadURL, _ := c.urlForArtifacts(latest.Name)
 	resp := releasecontroller.APITag{
 		Name:        latest.Name,
-		PullSpec:    releasecontroller.FindPublicImagePullSpec(r.Target, latest.Name),
+		PullSpec:    resolveReleasePullSpec(r, latest.Name),
 		DownloadURL: downloadURL,
 		Phase:       latest.Annotations[releasecontroller.ReleaseAnnotationPhase],
 	}
@@ -622,7 +622,7 @@ func (c *Controller) apiReleaseTags(w http.ResponseWriter, req *http.Request) {
 		}
 		tags = append(tags, releasecontroller.APITag{
 			Name:        tag.Name,
-			PullSpec:    releasecontroller.FindPublicImagePullSpec(r.Release.Target, tag.Name),
+			PullSpec:    resolveReleasePullSpec(r.Release, tag.Name),
 			DownloadURL: downloadURL,
 			Phase:       phase,
 		})
@@ -793,18 +793,18 @@ func (c *Controller) httpReleaseChangelog(w http.ResponseWriter, req *http.Reque
 		}
 	}
 
-	fromBase := tags[from].Release.Target.Status.PublicDockerImageRepository
-	if len(fromBase) == 0 {
+	fromPullSpec := resolveReleasePullSpec(tags[from].Release, from)
+	if len(fromPullSpec) == 0 {
 		http.Error(w, fmt.Sprintf("release target %s does not have a configured registry", tags[from].Release.Target.Name), http.StatusBadRequest)
 		return
 	}
-	toBase := tags[to].Release.Target.Status.PublicDockerImageRepository
-	if len(toBase) == 0 {
+	toPullSpec := resolveReleasePullSpec(tags[to].Release, to)
+	if len(toPullSpec) == 0 {
 		http.Error(w, fmt.Sprintf("release target %s does not have a configured registry", tags[to].Release.Target.Name), http.StatusBadRequest)
 		return
 	}
 
-	out, err := c.releaseInfo.ChangeLog(fromBase+":"+from, toBase+":"+to, isJson)
+	out, err := c.releaseInfo.ChangeLog(fromPullSpec, toPullSpec, isJson)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Internal error\n%v", err), http.StatusInternalServerError)
 		return
@@ -872,7 +872,7 @@ func (c *Controller) httpReleaseInfoJson(w http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	tagPullSpec := releasecontroller.FindPublicImagePullSpec(tags[tag].Release.Target, tag)
+	tagPullSpec := resolveReleasePullSpec(tags[tag].Release, tag)
 	if len(tagPullSpec) == 0 {
 		http.Error(w, fmt.Sprintf("could not find pull spec for tag %s in image stream %s", tag, tags[tag].Release.Target.Name), http.StatusBadRequest)
 		return
@@ -966,10 +966,10 @@ func (c *Controller) getReleaseTagInfo(req *http.Request) (*releaseTagInfo, erro
 	}
 
 	// require public pull specs because we can't get the x509 cert for the internal registry without service-ca.crt
-	tagPull := releasecontroller.FindPublicImagePullSpec(info.Release.Target, info.Tag.Name)
+	tagPull := resolveReleasePullSpec(info.Release, info.Tag.Name)
 	var previousTagPull string
 	if info.Previous != nil {
-		previousTagPull = releasecontroller.FindPublicImagePullSpec(info.PreviousRelease.Target, info.Previous.Name)
+		previousTagPull = resolveReleasePullSpec(info.PreviousRelease, info.Previous.Name)
 	}
 
 	return &releaseTagInfo{
@@ -1596,16 +1596,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 	now := time.Now()
 	var releasePage = template.Must(template.New("releasePageHtml.tmpl").Funcs(
 		template.FuncMap{
-			"publishSpec": func(r *ReleaseStream) string {
-				if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
-					for _, target := range r.Release.Config.Publish {
-						if target.TagRef != nil && len(target.TagRef.Name) > 0 {
-							return r.Release.Target.Status.PublicDockerImageRepository + ":" + target.TagRef.Name
-						}
-					}
-				}
-				return ""
-			},
+			"publishSpec": referencePublishSpec,
 			"publishDescription": func(r *ReleaseStream) string {
 				streamMessage := generateStreamMessage(r)
 				if len(streamMessage) > 0 {
@@ -1626,16 +1617,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 					out = append(out, fmt.Sprintf(`<span>updated when <code>%s/%s</code> changes</span>`, r.Release.Source.Namespace, r.Release.Source.Name))
 				}
 
-				if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
-					for _, target := range r.Release.Config.Publish {
-						if target.Disabled {
-							continue
-						}
-						if target.TagRef != nil && len(target.TagRef.Name) > 0 {
-							out = append(out, fmt.Sprintf(`<span>promote to pull spec <code>%s:%s</code></span>`, r.Release.Target.Status.PublicDockerImageRepository, target.TagRef.Name))
-						}
-					}
-				}
+				out = append(out, referencePublishDescriptionEntries(r)...)
 				for _, target := range r.Release.Config.Publish {
 					if target.Disabled {
 						continue
@@ -1854,16 +1836,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 	now := time.Now()
 	var releasePage = template.Must(template.New("releaseStreamPageHtml.tmpl").Funcs(
 		template.FuncMap{
-			"publishSpec": func(r *ReleaseStream) string {
-				if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
-					for _, target := range r.Release.Config.Publish {
-						if target.TagRef != nil && len(target.TagRef.Name) > 0 {
-							return r.Release.Target.Status.PublicDockerImageRepository + ":" + target.TagRef.Name
-						}
-					}
-				}
-				return ""
-			},
+			"publishSpec": referencePublishSpec,
 			"publishDescription": func(r *ReleaseStream) string {
 				streamMessage := generateStreamMessage(r)
 				if len(streamMessage) > 0 {
@@ -1884,16 +1857,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 					out = append(out, fmt.Sprintf(`<span>updated when <code>%s/%s</code> changes</span>`, r.Release.Source.Namespace, r.Release.Source.Name))
 				}
 
-				if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
-					for _, target := range r.Release.Config.Publish {
-						if target.Disabled {
-							continue
-						}
-						if target.TagRef != nil && len(target.TagRef.Name) > 0 {
-							out = append(out, fmt.Sprintf(`<span>promote to pull spec <code>%s:%s</code></span>`, r.Release.Target.Status.PublicDockerImageRepository, target.TagRef.Name))
-						}
-					}
-				}
+				out = append(out, referencePublishDescriptionEntries(r)...)
 				for _, target := range r.Release.Config.Publish {
 					if target.Disabled {
 						continue
@@ -2027,16 +1991,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 	now := time.Now()
 	var releasePage = template.Must(template.New("releaseDashboardPage.tmpl").Funcs(
 		template.FuncMap{
-			"publishSpec": func(r *ReleaseStream) string {
-				if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
-					for _, target := range r.Release.Config.Publish {
-						if target.TagRef != nil && len(target.TagRef.Name) > 0 {
-							return r.Release.Target.Status.PublicDockerImageRepository + ":" + target.TagRef.Name
-						}
-					}
-				}
-				return ""
-			},
+			"publishSpec": referencePublishSpec,
 			"publishDescription": func(r *ReleaseStream) string {
 				streamMessage := generateStreamMessage(r)
 				if len(streamMessage) > 0 {
@@ -2052,16 +2007,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 					out = append(out, fmt.Sprintf(`<span>updated when <code>%s/%s</code> changes</span>`, r.Release.Source.Namespace, r.Release.Source.Name))
 				}
 
-				if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
-					for _, target := range r.Release.Config.Publish {
-						if target.Disabled {
-							continue
-						}
-						if target.TagRef != nil && len(target.TagRef.Name) > 0 {
-							out = append(out, fmt.Sprintf(`<span>promote to pull spec <code>%s:%s</code></span>`, r.Release.Target.Status.PublicDockerImageRepository, target.TagRef.Name))
-						}
-					}
-				}
+				out = append(out, referencePublishDescriptionEntries(r)...)
 				for _, target := range r.Release.Config.Publish {
 					if target.Disabled {
 						continue
@@ -2526,15 +2472,19 @@ func (c *Controller) apiReleaseApprovals(w http.ResponseWriter, req *http.Reques
 
 	var tags []releasecontroller.APITag
 	for _, payload := range results {
-		imageStream, err := c.releaseLister.ImageStreams(payload.Spec.PayloadCoordinates.Namespace).Get(payload.Spec.PayloadCoordinates.ImagestreamName)
-		if err != nil {
-			klog.Errorf("Unable to locate imagestream \"%s/%s\": %v", payload.Spec.PayloadCoordinates.Namespace, payload.Spec.PayloadCoordinates.ImagestreamName, err)
-			continue
+		pullSpec := pullSpecFromCoordinates(payload.Spec.ReleaseCoordinates)
+		if len(pullSpec) == 0 {
+			imageStream, err := c.releaseLister.ImageStreams(payload.Spec.PayloadCoordinates.Namespace).Get(payload.Spec.PayloadCoordinates.ImagestreamName)
+			if err != nil {
+				klog.Errorf("Unable to locate imagestream \"%s/%s\": %v", payload.Spec.PayloadCoordinates.Namespace, payload.Spec.PayloadCoordinates.ImagestreamName, err)
+				continue
+			}
+			pullSpec = releasecontroller.FindPublicImagePullSpec(imageStream, payload.Name)
 		}
 		downloadURL, _ := c.urlForArtifacts(payload.Name)
 		tag := releasecontroller.APITag{
 			Name:        payload.Name,
-			PullSpec:    releasecontroller.FindPublicImagePullSpec(imageStream, payload.Name),
+			PullSpec:    pullSpec,
 			DownloadURL: downloadURL,
 			Phase:       releasecontroller.GetReleasePhase(payload),
 		}

--- a/cmd/release-controller-api/http_compare.go
+++ b/cmd/release-controller-api/http_compare.go
@@ -104,7 +104,7 @@ func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Reque
 	for _, stream := range page.Streams {
 		for _, tag := range stream.Tags {
 			if len(fromRelease) > 0 && len(toRelease) > 0 {
-				pullSpec := releasecontroller.FindPublicImagePullSpec(stream.Release.Target, tag.Name)
+				pullSpec := resolveReleasePullSpec(stream.Release, tag.Name)
 				switch tag.Name {
 				case fromRelease:
 					fromComparison.PullSpec = pullSpec

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -88,6 +88,36 @@ type ReleaseTagUpgradeVisual struct {
 	Begin, Current, End *releasecontroller.UpgradeHistory
 }
 
+// pullSpecFromCoordinates constructs a pull spec from a ReleasePayload's
+// ReleaseCoordinates.  Returns empty string when no usable coordinates exist.
+func pullSpecFromCoordinates(coords []v1alpha1.ReleaseCoordinates) string {
+	if len(coords) == 0 {
+		return ""
+	}
+	c := coords[0]
+	if len(c.Repository) == 0 {
+		return ""
+	}
+	if len(c.Digest) > 0 {
+		return c.Repository + "@" + c.Digest
+	}
+	if len(c.Tag) > 0 {
+		return c.Repository + ":" + c.Tag
+	}
+	return ""
+}
+
+// resolveReleasePullSpec returns the pull spec for the given tag within the
+// release. For reference-based releases (external repo) it uses ReleasePullSpec;
+// for local releases it falls back to FindPublicImagePullSpec which handles
+// digest resolution and status-tag checking.
+func resolveReleasePullSpec(release *releasecontroller.Release, tagName string) string {
+	if releasecontroller.IsReferenceRelease(release) {
+		return releasecontroller.ReleasePullSpec(release, tagName)
+	}
+	return releasecontroller.FindPublicImagePullSpec(release.Target, tagName)
+}
+
 func phaseCell(tag imagev1.TagReference) string {
 	phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
 	switch phase {
@@ -997,4 +1027,49 @@ func pruneEndOfLifeTags(page *ReleasePage, endOfLifePrefixes sets.Set[string]) {
 func pruneTagInfo(tagInfo string) string {
 	tagInfoParts := strings.Split(tagInfo, ".")
 	return fmt.Sprintf("%s.%s", tagInfoParts[0], tagInfoParts[1])
+}
+
+func referencePublishSpec(r *ReleaseStream) string {
+	if releasecontroller.IsReferenceRelease(r.Release) {
+		for _, target := range r.Release.Config.Publish {
+			if target.TagRef != nil && len(target.TagRef.Name) > 0 {
+				return r.Release.Config.ReferenceRelease.PullRepository + ":" + target.TagRef.Name
+			}
+		}
+		return ""
+	}
+	if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
+		for _, target := range r.Release.Config.Publish {
+			if target.TagRef != nil && len(target.TagRef.Name) > 0 {
+				return r.Release.Target.Status.PublicDockerImageRepository + ":" + target.TagRef.Name
+			}
+		}
+	}
+	return ""
+}
+
+func referencePublishDescriptionEntries(r *ReleaseStream) []string {
+	var out []string
+	if releasecontroller.IsReferenceRelease(r.Release) {
+		for _, target := range r.Release.Config.Publish {
+			if target.Disabled {
+				continue
+			}
+			if target.TagRef != nil && len(target.TagRef.Name) > 0 {
+				out = append(out, fmt.Sprintf(`<span>promote to pull spec <code>%s:%s</code></span>`,
+					r.Release.Config.ReferenceRelease.PullRepository, target.TagRef.Name))
+			}
+		}
+	} else if len(r.Release.Target.Status.PublicDockerImageRepository) > 0 {
+		for _, target := range r.Release.Config.Publish {
+			if target.Disabled {
+				continue
+			}
+			if target.TagRef != nil && len(target.TagRef.Name) > 0 {
+				out = append(out, fmt.Sprintf(`<span>promote to pull spec <code>%s:%s</code></span>`,
+					r.Release.Target.Status.PublicDockerImageRepository, target.TagRef.Name))
+			}
+		}
+	}
+	return out
 }

--- a/cmd/release-controller-api/http_helper_test.go
+++ b/cmd/release-controller-api/http_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 
 	"github.com/blang/semver"
@@ -299,6 +300,161 @@ func Test_takeUpgradesFromNames(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotWithoutNames, tt.wantWithoutNames) {
 				t.Errorf("takeUpgradesFromNames() gotWithoutNames = %v, want %v", gotWithoutNames, tt.wantWithoutNames)
+			}
+		})
+	}
+}
+
+func TestResolveReleasePullSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		release *releasecontroller.Release
+		tag     string
+		want    string
+	}{
+		{
+			name: "reference release with ReferenceRelease",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					ReferenceRelease: &releasecontroller.ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			tag:  "4.18.0-0.nightly-2025-01-01-000000",
+			want: "quay.io/openshift-release-dev/ocp-release:rc_payload__4.18.0-0.nightly-2025-01-01-000000",
+		},
+		{
+			name: "reference release without ReferenceRelease falls back to FindPublicImagePullSpec",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+						Tags: []imagev1.NamedTagEventList{
+							{
+								Tag:   "4.18.0-0.nightly-2025-01-01-000000",
+								Items: []imagev1.TagEvent{{DockerImageReference: "sha256:abc123", Generation: 1}},
+							},
+						},
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{},
+			},
+			tag:  "4.18.0-0.nightly-2025-01-01-000000",
+			want: "registry.ci.openshift.org/ocp/release:4.18.0-0.nightly-2025-01-01-000000",
+		},
+		{
+			name: "local release uses FindPublicImagePullSpec",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+						Tags: []imagev1.NamedTagEventList{
+							{
+								Tag:   "4.12.0",
+								Items: []imagev1.TagEvent{{DockerImageReference: "sha256:def456", Generation: 1}},
+							},
+						},
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{},
+			},
+			tag:  "4.12.0",
+			want: "registry.ci.openshift.org/ocp/release:4.12.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveReleasePullSpec(tt.release, tt.tag)
+			if got != tt.want {
+				t.Errorf("resolveReleasePullSpec() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPullSpecFromCoordinates(t *testing.T) {
+	tests := []struct {
+		name   string
+		coords []v1alpha1.ReleaseCoordinates
+		want   string
+	}{
+		{
+			name:   "nil coordinates",
+			coords: nil,
+			want:   "",
+		},
+		{
+			name:   "empty slice",
+			coords: []v1alpha1.ReleaseCoordinates{},
+			want:   "",
+		},
+		{
+			name:   "empty repository",
+			coords: []v1alpha1.ReleaseCoordinates{{Tag: "v1.0"}},
+			want:   "",
+		},
+		{
+			name:   "tag-based",
+			coords: []v1alpha1.ReleaseCoordinates{{Repository: "quay.io/ocp/release", Tag: "rc_payload__4.18.0"}},
+			want:   "quay.io/ocp/release:rc_payload__4.18.0",
+		},
+		{
+			name:   "digest-based",
+			coords: []v1alpha1.ReleaseCoordinates{{Repository: "quay.io/ocp/release", Digest: "sha256:abc123"}},
+			want:   "quay.io/ocp/release@sha256:abc123",
+		},
+		{
+			name:   "digest takes precedence over tag",
+			coords: []v1alpha1.ReleaseCoordinates{{Repository: "quay.io/ocp/release", Tag: "v1", Digest: "sha256:abc123"}},
+			want:   "quay.io/ocp/release@sha256:abc123",
+		},
+		{
+			name:   "repository only with no tag or digest",
+			coords: []v1alpha1.ReleaseCoordinates{{Repository: "quay.io/ocp/release"}},
+			want:   "",
+		},
+		{
+			name: "uses first coordinate",
+			coords: []v1alpha1.ReleaseCoordinates{
+				{Repository: "quay.io/ocp/release", Tag: "first"},
+				{Repository: "registry.example.com/release", Tag: "second"},
+			},
+			want: "quay.io/ocp/release:first",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pullSpecFromCoordinates(tt.coords)
+			if got != tt.want {
+				t.Errorf("pullSpecFromCoordinates() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/release-controller-api/http_upgrade_graph.go
+++ b/cmd/release-controller-api/http_upgrade_graph.go
@@ -64,7 +64,7 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 				} else {
 					nodes = append(nodes, ReleaseNode{
 						Version: tag.Name,
-						Payload: s.Release.Target.Status.PublicDockerImageRepository + ":" + tag.Name,
+						Payload: resolveReleasePullSpec(s.Release, tag.Name),
 					})
 				}
 			}

--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -345,7 +345,7 @@ func (a *AuditTracker) Sync(release *releasecontroller.Release) {
 
 		id := releasecontroller.FindImageIDForTag(from, tag.Name)
 		// TODO: this should really be the digest
-		location := releasecontroller.FindPublicImagePullSpec(from, tag.Name)
+		location := releasecontroller.ReleasePullSpec(release, tag.Name)
 		existing, ok := a.records[tag.Name]
 		if !ok {
 			a.records[tag.Name] = &AuditRecord{

--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -57,6 +57,13 @@ func (c *Controller) syncAuditTag(releaseName string) error {
 		return nil
 	}
 
+	if len(record.ID) == 0 && len(record.Location) > 0 {
+		info, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, record.Location)
+		if err == nil && len(info.Digest) > 0 {
+			record.ID = info.Digest
+			c.auditTracker.SetID(record.Name, info.Digest)
+		}
+	}
 	if len(record.ID) == 0 {
 		msg := fmt.Sprintf("Release %s has no digest and cannot be verified", record.Name)
 		c.auditTracker.SetFailure(record.Name, msg)
@@ -283,6 +290,14 @@ func NewAuditTracker(queue workqueue.TypedDelayingInterface[string]) *AuditTrack
 	return &AuditTracker{
 		records: make(map[string]*AuditRecord),
 		queue:   queue,
+	}
+}
+
+func (a *AuditTracker) SetID(name, id string) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	if existing, ok := a.records[name]; ok {
+		existing.ID = id
 	}
 }
 

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -247,14 +247,15 @@ func (c *Controller) syncJira(key queueKey) error {
 	// and it also allows us to handle the case where the imagestream fails to update below.
 	defer c.queue.AddAfter(key, time.Second)
 
-	dockerRepo := release.Target.Status.PublicDockerImageRepository
-	if len(dockerRepo) == 0 {
+	prevPullSpec := releasecontroller.ReleasePullSpec(release, prevTag.Name)
+	curPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
+	if len(prevPullSpec) == 0 || len(curPullSpec) == 0 {
 		klog.V(4).Infof("jira: release target %s does not have a configured registry", release.Target.Name)
 		c.jiraErrorMetrics.WithLabelValues(jiraNoRegistry).Inc()
 		return fmt.Errorf("jira: release target %s does not have a configured registry", release.Target.Name)
 	}
 
-	issues, err := c.releaseInfo.Bugs(dockerRepo+":"+prevTag.Name, dockerRepo+":"+tag.Name)
+	issues, err := c.releaseInfo.Bugs(prevPullSpec, curPullSpec)
 	var issueList []string
 	for _, issue := range issues {
 		if issue.Source == 1 {
@@ -275,7 +276,7 @@ func (c *Controller) syncJira(key queueKey) error {
 
 	// Handle feature tags
 	// Generate the change log from image digests; this should be pretty quick since the Bugs function was run recently
-	changelogJSON, err := c.releaseInfo.ChangeLog(dockerRepo+":"+prevTag.Name, dockerRepo+":"+tag.Name, true)
+	changelogJSON, err := c.releaseInfo.ChangeLog(prevPullSpec, curPullSpec, true)
 	if err != nil {
 		klog.V(4).Infof("Jira: Unable to generate changelog from %s to %s: %v", prevTag.Name, tag.Name, err)
 		c.jiraErrorMetrics.WithLabelValues(jiraChangelogGeneration).Inc()

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -223,6 +223,7 @@ func (c *Controller) syncJira(key queueKey) error {
 		klog.V(6).Infof("jira: All accepted/rejected tags for %s have already been verified", release.Config.Name)
 		return nil
 	}
+	prevReleaseForPullSpec := release
 	if prevTag == nil {
 		if verifyIssues.PreviousReleaseTag == nil {
 			klog.V(2).Infof("jira error: previous release unset for %s", release.Config.Name)
@@ -241,13 +242,21 @@ func (c *Controller) syncJira(key queueKey) error {
 			c.jiraErrorMetrics.WithLabelValues(jiraMissingTag).Inc()
 			return fmt.Errorf("failed to find tag %s in imagestream %s/%s", verifyIssues.PreviousReleaseTag.Tag, verifyIssues.PreviousReleaseTag.Namespace, verifyIssues.PreviousReleaseTag.Name)
 		}
+		prevRelease, prevOk, prevErr := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		if prevErr != nil {
+			return prevErr
+		}
+		if !prevOk {
+			return fmt.Errorf("jira: previous release imagestream %s/%s is not a valid release definition", verifyIssues.PreviousReleaseTag.Namespace, verifyIssues.PreviousReleaseTag.Name)
+		}
+		prevReleaseForPullSpec = prevRelease
 	}
 	// To make sure all tags are up-to-date, requeue when non-verified tags are found; this allows us to make
 	// sure tags that may not have been passed to this function (such as older tags) get processed,
 	// and it also allows us to handle the case where the imagestream fails to update below.
 	defer c.queue.AddAfter(key, time.Second)
 
-	prevPullSpec := releasecontroller.ReleasePullSpec(release, prevTag.Name)
+	prevPullSpec := releasecontroller.ReleasePullSpec(prevReleaseForPullSpec, prevTag.Name)
 	curPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
 	if len(prevPullSpec) == 0 || len(curPullSpec) == 0 ||
 		strings.HasPrefix(prevPullSpec, ":") || strings.HasPrefix(curPullSpec, ":") {

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -249,7 +249,8 @@ func (c *Controller) syncJira(key queueKey) error {
 
 	prevPullSpec := releasecontroller.ReleasePullSpec(release, prevTag.Name)
 	curPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
-	if len(prevPullSpec) == 0 || len(curPullSpec) == 0 {
+	if len(prevPullSpec) == 0 || len(curPullSpec) == 0 ||
+		strings.HasPrefix(prevPullSpec, ":") || strings.HasPrefix(curPullSpec, ":") {
 		klog.V(4).Infof("jira: release target %s does not have a configured registry", release.Target.Name)
 		c.jiraErrorMetrics.WithLabelValues(jiraNoRegistry).Inc()
 		return fmt.Errorf("jira: release target %s does not have a configured registry", release.Target.Name)

--- a/cmd/release-controller/legacy_results.go
+++ b/cmd/release-controller/legacy_results.go
@@ -92,7 +92,7 @@ func (c *Controller) syncLegacyResults(key queueKey) error {
 		// Ensure the existing state is preserved.  This is a big hammer, but it's the only way we have to guarantee that
 		// the ReleasePayload's status matches the status of the ImageStream's Annotation.
 		payloadType := v1alpha1.PayloadTypeLocal
-		if releasecontroller.HasReferenceSpecTags(release.Source) {
+		if releasecontroller.IsReferenceRelease(release) {
 			payloadType = v1alpha1.PayloadTypeReference
 		}
 		releasePayload := newReleasePayload(release, tag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceImageStream, payloadType)

--- a/cmd/release-controller/legacy_results.go
+++ b/cmd/release-controller/legacy_results.go
@@ -91,7 +91,11 @@ func (c *Controller) syncLegacyResults(key queueKey) error {
 
 		// Ensure the existing state is preserved.  This is a big hammer, but it's the only way we have to guarantee that
 		// the ReleasePayload's status matches the status of the ImageStream's Annotation.
-		releasePayload := newReleasePayload(release, tag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceImageStream)
+		payloadType := v1alpha1.PayloadTypeLocal
+		if releasecontroller.HasReferenceSpecTags(release.Source) {
+			payloadType = v1alpha1.PayloadTypeReference
+		}
+		releasePayload := newReleasePayload(release, tag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceImageStream, payloadType)
 		setPayloadOverride(tag, releasePayload)
 
 		// Create the payload

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -382,7 +382,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 				}
 				if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
 					go func() {
-						fromPullSpec := releasecontroller.FindPublicImagePullSpec(release.Target, tags[0].Name)
+						fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0].Name)
 						if len(fromPullSpec) == 0 {
 							klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
 							return
@@ -393,7 +393,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 							return
 						}
 
-						toPullSpec := releasecontroller.FindPublicImagePullSpec(release.Target, tag.Name)
+						toPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
 						if len(toPullSpec) == 0 {
 							klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
 							return
@@ -434,7 +434,12 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 			return fmt.Errorf("mirror hash for %q does not match, release cannot be created", tag.Name)
 		}
 
-		job, err := c.ensureReleaseJob(release, tag.Name, mirror)
+		var job *batchv1.Job
+		if releasecontroller.IsReferenceRelease(release) {
+			job, err = c.ensureReferenceReleaseJob(release, tag.Name, mirror)
+		} else {
+			job, err = c.ensureReleaseJob(release, tag.Name, mirror)
+		}
 		if err != nil || job == nil {
 			return err
 		}
@@ -455,13 +460,23 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 			}
 			if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
 				go func() {
-					fromImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, tags[0].Name)
+					fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0].Name)
+					if len(fromPullSpec) == 0 {
+						klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
+						return
+					}
+					fromImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, fromPullSpec)
 					if err != nil {
 						klog.Errorf("Unable to get from image info for release %s: %v", tags[0].Name, err)
 						return
 					}
 
-					toImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, tag.Name)
+					toPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
+					if len(toPullSpec) == 0 {
+						klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
+						return
+					}
+					toImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, toPullSpec)
 					if err != nil {
 						klog.Errorf("Unable to get to image info for release %s: %v", tag.Name, err)
 						return

--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -58,9 +58,13 @@ func (c *Controller) ensureReleaseMirror(release *releasecontroller.Release, rel
 		}
 	}
 
-	switch release.Config.As {
-	case releasecontroller.ReleaseConfigModeStable:
+	switch {
+	case release.Config.As == releasecontroller.ReleaseConfigModeStable:
 		// stream will be populated later
+	case releasecontroller.HasReferenceSpecTags(release.Source):
+		if err := calculateReferenceMirrorImageStream(release, is); err != nil {
+			return nil, err
+		}
 	default:
 		if err := calculateMirrorImageStream(release, is); err != nil {
 			return nil, err
@@ -83,6 +87,21 @@ func (c *Controller) ensureReleaseMirror(release *releasecontroller.Release, rel
 		}
 	}
 	return is, err
+}
+
+// calculateReferenceMirrorImageStream populates the mirror imagestream from
+// the source's spec tags. This is used for reference-type payloads where tags
+// have reference: true and status tags are never populated via import.
+func calculateReferenceMirrorImageStream(release *releasecontroller.Release, is *imagev1.ImageStream) error {
+	for _, tag := range release.Source.Spec.Tags {
+		if tag.From == nil {
+			continue
+		}
+		ref := tag.DeepCopy()
+		ref.ImportPolicy.Scheduled = false
+		is.Spec.Tags = append(is.Spec.Tags, *ref)
+	}
+	return nil
 }
 
 func calculateMirrorImageStream(release *releasecontroller.Release, is *imagev1.ImageStream) error {

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -22,9 +22,9 @@ import (
 func (c *Controller) ensureReleaseJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) {
 	return c.ensureJob(name, nil, func() (*batchv1.Job, error) {
 		toImage := fmt.Sprintf("%s:%s", release.Target.Status.PublicDockerImageRepository, name)
-		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)
-		if len(release.Config.OverrideCLIImage) > 0 {
-			cliImage = release.Config.OverrideCLIImage
+		cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)
+		if err != nil {
+			return nil, err
 		}
 
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
@@ -72,14 +72,9 @@ func buildReferenceReleaseJob(release *releasecontroller.Release, name string, m
 		return nil, fmt.Errorf("release %q ReferenceRelease.PushRepository is empty", name)
 	}
 	toImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferencePayloadTag(name))
-	cliImage := release.Config.OverrideCLIImage
-	if len(cliImage) == 0 {
-		if cliTag := releasecontroller.FindSpecTag(mirror.Spec.Tags, "cli"); cliTag != nil && cliTag.From != nil && cliTag.From.Kind == "DockerImage" {
-			cliImage = cliTag.From.Name
-		}
-	}
-	if len(cliImage) == 0 {
-		return nil, fmt.Errorf("unable to determine CLI image for reference payload release: set overrideCLIImage or ensure a 'cli' tag exists in the source imagestream")
+	cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)
+	if err != nil {
+		return nil, err
 	}
 
 	secretName := release.Config.ReferenceRelease.SecretName
@@ -152,9 +147,9 @@ func (c *Controller) ensureRewriteJob(release *releasecontroller.Release, name s
 	}
 	return c.ensureJob(name, preconditions, func() (*batchv1.Job, error) {
 		toImage := fmt.Sprintf("%s:%s", release.Source.Status.PublicDockerImageRepository, name)
-		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)
-		if len(release.Config.OverrideCLIImage) > 0 {
-			cliImage = release.Config.OverrideCLIImage
+		cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)
+		if err != nil {
+			return nil, err
 		}
 
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
@@ -226,9 +221,9 @@ func (c *Controller) ensureImportJob(release *releasecontroller.Release, name st
 	}
 	return c.ensureJob(name, preconditions, func() (*batchv1.Job, error) {
 		toImage := fmt.Sprintf("%s:%s", release.Source.Status.PublicDockerImageRepository, name)
-		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)
-		if len(release.Config.OverrideCLIImage) > 0 {
-			cliImage = release.Config.OverrideCLIImage
+		cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)
+		if err != nil {
+			return nil, err
 		}
 
 		job, prefix := newReleaseJobBase(name, cliImage, release.Config.PullSecretName)
@@ -474,9 +469,9 @@ func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, 
 		fromImage := releasecontroller.ReleasePullSpec(release, name)
 		toImage := fmt.Sprintf("%s:%s", release.Config.AlternateImageRepository, name)
 
-		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)
-		if len(release.Config.OverrideCLIImage) > 0 {
-			cliImage = release.Config.OverrideCLIImage
+		cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)
+		if err != nil {
+			return nil, err
 		}
 
 		job, prefix := newReleaseJobBase(releaseMirrorJobName(name), cliImage, release.Config.AlternateImageRepositorySecretName)

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -95,6 +95,7 @@ func buildReferenceReleaseJob(release *releasecontroller.Release, name string, m
 		prefix + `
 			oc get imagestream "$1" -n "$2" -o yaml > /tmp/mirror-full.yaml
 			awk '/^status:/{s=1;next} s&&/^[^ ]/{s=0} !s' /tmp/mirror-full.yaml > /tmp/mirror.yaml
+			if [ ! -s /tmp/mirror.yaml ]; then echo "ERROR: mirror.yaml is empty after status stripping" >&2; exit 1; fi
 			oc adm release new "--name=$3" "--from-image-stream-file=/tmp/mirror.yaml" "--to-image=$4" "--reference-mode=$5" "--keep-manifest-list=$6"
 			`,
 		"", mirror.Name, mirror.Namespace, name, toImage, release.Config.ReferenceMode, keepManifestList,

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -53,6 +53,90 @@ func (c *Controller) ensureReleaseJob(release *releasecontroller.Release, name s
 	})
 }
 
+func (c *Controller) ensureReferenceReleaseJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream) (*batchv1.Job, error) {
+	return c.ensureJob(name, nil, func() (*batchv1.Job, error) {
+		job, err := buildReferenceReleaseJob(release, name, mirror, c.manifestListMode)
+		if err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("Running reference release creation job %s/%s for %s", c.jobNamespace, job.Name, name)
+		return job, nil
+	})
+}
+
+func buildReferenceReleaseJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream, manifestListMode bool) (*batchv1.Job, error) {
+	if release.Config.ReferenceRelease == nil {
+		return nil, fmt.Errorf("release %q has no ReferenceRelease configuration", name)
+	}
+	toImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferencePayloadTag(name))
+	cliImage := release.Config.OverrideCLIImage
+	if len(cliImage) == 0 {
+		if cliTag := releasecontroller.FindSpecTag(mirror.Spec.Tags, "cli"); cliTag != nil && cliTag.From != nil && cliTag.From.Kind == "DockerImage" {
+			cliImage = cliTag.From.Name
+		}
+	}
+	if len(cliImage) == 0 {
+		return nil, fmt.Errorf("unable to determine CLI image for reference payload release: set overrideCLIImage or ensure a 'cli' tag exists in the source imagestream")
+	}
+
+	secretName := release.Config.ReferenceRelease.SecretName
+	if len(secretName) == 0 {
+		secretName = release.Config.PullSecretName
+	}
+	job, prefix := newReleaseJobBase(name, cliImage, secretName)
+
+	keepManifestList := "false"
+	if manifestListMode && !release.Config.DisableManifestListMode {
+		keepManifestList = "true"
+	}
+
+	job.Spec.Template.Spec.Containers[0].Command = []string{
+		"/bin/bash", "-c",
+		prefix + `
+			oc get imagestream "$1" -n "$2" -o yaml > /tmp/mirror-full.yaml
+			awk '/^status:/{s=1;next} s&&/^[^ ]/{s=0} !s' /tmp/mirror-full.yaml > /tmp/mirror.yaml
+			oc adm release new "--name=$3" "--from-image-stream-file=/tmp/mirror.yaml" "--to-image=$4" "--reference-mode=$5" "--keep-manifest-list=$6"
+			`,
+		"", mirror.Name, mirror.Namespace, name, toImage, release.Config.ReferenceMode, keepManifestList,
+	}
+
+	job.Annotations[releasecontroller.ReleaseAnnotationSource] = mirror.Annotations[releasecontroller.ReleaseAnnotationSource]
+	job.Annotations[releasecontroller.ReleaseAnnotationTarget] = mirror.Annotations[releasecontroller.ReleaseAnnotationTarget]
+	job.Annotations[releasecontroller.ReleaseAnnotationGeneration] = strconv.FormatInt(release.Target.Generation, 10)
+	job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag] = mirror.Annotations[releasecontroller.ReleaseAnnotationReleaseTag]
+
+	return job, nil
+}
+
+func buildReferenceRemovalJob(release *releasecontroller.Release, name, cliImage string) (*batchv1.Job, error) {
+	if release.Config.ReferenceRelease == nil {
+		return nil, fmt.Errorf("release %q has no ReferenceRelease configuration", name)
+	}
+	fromImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferencePayloadTag(name))
+	toImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferenceRemovalTag(name))
+
+	secretName := release.Config.ReferenceRelease.SecretName
+	if len(secretName) == 0 {
+		secretName = release.Config.PullSecretName
+	}
+	job, prefix := newReleaseJobBase(referenceRemovalJobName(name), cliImage, secretName)
+
+	job.Spec.Template.Spec.Containers[0].Command = []string{
+		"/bin/bash", "-c",
+		prefix + `
+			oc image mirror --keep-manifest-list=true $1 $2
+			`,
+		"",
+		fromImage, toImage,
+	}
+
+	return job, nil
+}
+
+func referenceRemovalJobName(tagName string) string {
+	return fmt.Sprintf("remove-%s", tagName)
+}
+
 func (c *Controller) ensureRewriteJob(release *releasecontroller.Release, name string, mirror *imagev1.ImageStream, metadataJSON string) (*batchv1.Job, error) {
 	ref := releasecontroller.FindTagReference(release.Source, name)
 	generation := *ref.Generation
@@ -380,7 +464,7 @@ func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, 
 		return nil, nil
 	}
 	return c.ensureJob(releaseMirrorJobName(name), nil, func() (*batchv1.Job, error) {
-		fromImage := fmt.Sprintf("%s:%s", release.Target.Status.PublicDockerImageRepository, name)
+		fromImage := releasecontroller.ReleasePullSpec(release, name)
 		toImage := fmt.Sprintf("%s:%s", release.Config.AlternateImageRepository, name)
 
 		cliImage := fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository)

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -68,6 +68,9 @@ func buildReferenceReleaseJob(release *releasecontroller.Release, name string, m
 	if release.Config.ReferenceRelease == nil {
 		return nil, fmt.Errorf("release %q has no ReferenceRelease configuration", name)
 	}
+	if release.Config.ReferenceRelease.PushRepository == "" {
+		return nil, fmt.Errorf("release %q ReferenceRelease.PushRepository is empty", name)
+	}
 	toImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferencePayloadTag(name))
 	cliImage := release.Config.OverrideCLIImage
 	if len(cliImage) == 0 {
@@ -112,6 +115,9 @@ func buildReferenceReleaseJob(release *releasecontroller.Release, name string, m
 func buildReferenceRemovalJob(release *releasecontroller.Release, name, cliImage string) (*batchv1.Job, error) {
 	if release.Config.ReferenceRelease == nil {
 		return nil, fmt.Errorf("release %q has no ReferenceRelease configuration", name)
+	}
+	if release.Config.ReferenceRelease.PushRepository == "" {
+		return nil, fmt.Errorf("release %q ReferenceRelease.PushRepository is empty", name)
 	}
 	fromImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferencePayloadTag(name))
 	toImage := fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PushRepository, releasecontroller.ReferenceRemovalTag(name))

--- a/cmd/release-controller/sync_release_payload.go
+++ b/cmd/release-controller/sync_release_payload.go
@@ -18,7 +18,11 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 	if err != nil {
 		return nil, err
 	}
-	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceBuildFarm), metav1.CreateOptions{})
+	payloadType := v1alpha1.PayloadTypeLocal
+	if releasecontroller.HasReferenceSpecTags(release.Source) {
+		payloadType = v1alpha1.PayloadTypeReference
+	}
+	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceBuildFarm, payloadType), metav1.CreateOptions{})
 	if err == nil {
 		klog.V(4).Infof("ReleasePayload: %s/%s created", payload.Namespace, payload.Name)
 		return payload, nil
@@ -29,7 +33,7 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 	return nil, err
 }
 
-func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, prowNamespace string, verificationJobs map[string]releasecontroller.ReleaseVerification, upgradeJobs map[string]releasecontroller.UpgradeVerification, dataSource v1alpha1.PayloadVerificationDataSource) *v1alpha1.ReleasePayload {
+func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, prowNamespace string, verificationJobs map[string]releasecontroller.ReleaseVerification, upgradeJobs map[string]releasecontroller.UpgradeVerification, dataSource v1alpha1.PayloadVerificationDataSource, payloadType v1alpha1.PayloadType) *v1alpha1.ReleasePayload {
 	payload := v1alpha1.ReleasePayload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -58,7 +62,20 @@ func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, p
 				UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 				PayloadVerificationDataSource: dataSource,
 			},
+			PayloadType: payloadType,
 		},
+	}
+
+	if releasecontroller.IsReferenceRelease(release) {
+		payload.Spec.ReleaseCoordinates = []v1alpha1.ReleaseCoordinates{{
+			Repository: release.Config.ReferenceRelease.PullRepository,
+			Tag:        releasecontroller.ReferencePayloadTag(name),
+		}}
+	} else if len(release.Target.Status.PublicDockerImageRepository) > 0 {
+		payload.Spec.ReleaseCoordinates = []v1alpha1.ReleaseCoordinates{{
+			Repository: release.Target.Status.PublicDockerImageRepository,
+			Tag:        name,
+		}}
 	}
 
 	// Sort the ReleaseVerification items into a consistent order

--- a/cmd/release-controller/sync_release_payload.go
+++ b/cmd/release-controller/sync_release_payload.go
@@ -19,7 +19,7 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 		return nil, err
 	}
 	payloadType := v1alpha1.PayloadTypeLocal
-	if releasecontroller.HasReferenceSpecTags(release.Source) {
+	if releasecontroller.IsReferenceRelease(release) {
 		payloadType = v1alpha1.PayloadTypeReference
 	}
 	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceBuildFarm, payloadType), metav1.CreateOptions{})

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -387,7 +387,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
-			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -461,7 +461,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
-			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -722,7 +722,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
-			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
 			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -31,6 +31,7 @@ func TestNewReleasePayload(t *testing.T) {
 		verificationJobs map[string]releasecontroller.ReleaseVerification
 		upgradeJobs      map[string]releasecontroller.UpgradeVerification
 		dataSource       v1alpha1.PayloadVerificationDataSource
+		payloadType      v1alpha1.PayloadType
 		expected         *v1alpha1.ReleasePayload
 	}{
 		{
@@ -794,11 +795,201 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "ReferencePayloadType",
+			release:       release,
+			payloadName:   "4.11.0-0.nightly-2022-03-11-113341",
+			jobNamespace:  "ci-release",
+			prowNamespace: "ci",
+			verificationJobs: map[string]releasecontroller.ReleaseVerification{
+				"blocking-job": {
+					ProwJob: &releasecontroller.ProwJobVerification{
+						Name: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+					},
+				},
+			},
+			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
+			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeReference,
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-03-11-113341",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.11.0-0.nightly-2022-03-11-113341",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.11.0-0.nightly-2022-03-11-113341",
+						},
+						ReleaseMirrorCoordinates: v1alpha1.ReleaseMirrorCoordinates{
+							Namespace:            "ci-release",
+							ReleaseMirrorJobName: "4.11.0-0.nightly-2022-03-11-113341-alternate-mirror",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs: []v1alpha1.CIConfiguration{
+							{
+								CIConfigurationName:    "blocking-job",
+								CIConfigurationJobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial",
+							},
+						},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+					},
+					PayloadType: v1alpha1.PayloadTypeReference,
+				},
+			},
+		},
+		{
+			name: "ReleaseCoordinates populated for reference release",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					ReferenceRelease: &releasecontroller.ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			payloadName:      "4.18.0-0.nightly-2025-01-01-000000",
+			jobNamespace:     "ci-release",
+			prowNamespace:    "ci",
+			verificationJobs: map[string]releasecontroller.ReleaseVerification{},
+			upgradeJobs:      map[string]releasecontroller.UpgradeVerification{},
+			dataSource:       v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType:      v1alpha1.PayloadTypeReference,
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.18.0-0.nightly-2025-01-01-000000",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.18.0-0.nightly-2025-01-01-000000",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.18.0-0.nightly-2025-01-01-000000",
+						},
+						ReleaseMirrorCoordinates: v1alpha1.ReleaseMirrorCoordinates{
+							Namespace:            "ci-release",
+							ReleaseMirrorJobName: "4.18.0-0.nightly-2025-01-01-000000-alternate-mirror",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:                  []v1alpha1.CIConfiguration{},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+					},
+					ReleaseCoordinates: []v1alpha1.ReleaseCoordinates{{
+						Repository: "quay.io/openshift-release-dev/ocp-release",
+						Tag:        "rc_payload__4.18.0-0.nightly-2025-01-01-000000",
+					}},
+					PayloadType: v1alpha1.PayloadTypeReference,
+				},
+			},
+		},
+		{
+			name: "ReleaseCoordinates populated for local release",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "release",
+						Namespace: "ocp",
+					},
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{},
+			},
+			payloadName:      "4.12.0",
+			jobNamespace:     "ci-release",
+			prowNamespace:    "ci",
+			verificationJobs: map[string]releasecontroller.ReleaseVerification{},
+			upgradeJobs:      map[string]releasecontroller.UpgradeVerification{},
+			dataSource:       v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.12.0",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadCoordinates: v1alpha1.PayloadCoordinates{
+						Namespace:          "ocp",
+						ImagestreamName:    "release",
+						ImagestreamTagName: "4.12.0",
+					},
+					PayloadCreationConfig: v1alpha1.PayloadCreationConfig{
+						ReleaseCreationCoordinates: v1alpha1.ReleaseCreationCoordinates{
+							Namespace:              "ci-release",
+							ReleaseCreationJobName: "4.12.0",
+						},
+						ReleaseMirrorCoordinates: v1alpha1.ReleaseMirrorCoordinates{
+							Namespace:            "ci-release",
+							ReleaseMirrorJobName: "4.12.0-alternate-mirror",
+						},
+						ProwCoordinates: v1alpha1.ProwCoordinates{
+							Namespace: "ci",
+						},
+					},
+					PayloadVerificationConfig: v1alpha1.PayloadVerificationConfig{
+						BlockingJobs:                  []v1alpha1.CIConfiguration{},
+						InformingJobs:                 []v1alpha1.CIConfiguration{},
+						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
+						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+					},
+					ReleaseCoordinates: []v1alpha1.ReleaseCoordinates{{
+						Repository: "registry.ci.openshift.org/ocp/release",
+						Tag:        "4.12.0",
+					}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			payload := newReleasePayload(tc.release, tc.payloadName, tc.jobNamespace, tc.prowNamespace, tc.verificationJobs, tc.upgradeJobs, tc.dataSource)
+			payload := newReleasePayload(tc.release, tc.payloadName, tc.jobNamespace, tc.prowNamespace, tc.verificationJobs, tc.upgradeJobs, tc.dataSource, tc.payloadType)
 			if !reflect.DeepEqual(payload, tc.expected) {
 				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, payload)
 			}

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -47,6 +47,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -77,6 +78,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -95,6 +97,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -130,6 +133,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -148,6 +152,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceImageStream,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -183,6 +188,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceImageStream,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -202,6 +208,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -238,6 +245,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -257,6 +265,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -292,6 +301,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -312,6 +322,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -348,6 +359,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -376,6 +388,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.12.11",
@@ -419,6 +432,7 @@ func TestNewReleasePayload(t *testing.T) {
 						},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -448,6 +462,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.12.11",
@@ -487,6 +502,7 @@ func TestNewReleasePayload(t *testing.T) {
 						},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -509,6 +525,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -550,6 +567,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -575,6 +593,7 @@ func TestNewReleasePayload(t *testing.T) {
 			},
 			upgradeJobs: map[string]releasecontroller.UpgradeVerification{},
 			dataSource:  v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -616,6 +635,7 @@ func TestNewReleasePayload(t *testing.T) {
 						UpgradeJobs:                   []v1alpha1.CIConfiguration{},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -703,6 +723,7 @@ func TestNewReleasePayload(t *testing.T) {
 				},
 			},
 			dataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType: v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.11.0-0.nightly-2022-03-11-113341",
@@ -792,6 +813,7 @@ func TestNewReleasePayload(t *testing.T) {
 						},
 						PayloadVerificationDataSource: v1alpha1.PayloadVerificationDataSourceBuildFarm,
 					},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},
@@ -948,6 +970,7 @@ func TestNewReleasePayload(t *testing.T) {
 			verificationJobs: map[string]releasecontroller.ReleaseVerification{},
 			upgradeJobs:      map[string]releasecontroller.UpgradeVerification{},
 			dataSource:       v1alpha1.PayloadVerificationDataSourceBuildFarm,
+			payloadType:      v1alpha1.PayloadTypeLocal,
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "4.12.0",
@@ -982,6 +1005,7 @@ func TestNewReleasePayload(t *testing.T) {
 						Repository: "registry.ci.openshift.org/ocp/release",
 						Tag:        "4.12.0",
 					}},
+					PayloadType: v1alpha1.PayloadTypeLocal,
 				},
 			},
 		},

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -409,6 +409,24 @@ func TestBuildReferenceReleaseJob(t *testing.T) {
 		}
 	})
 
+	t.Run("empty PushRepository returns error", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.ReferenceRelease = &releasecontroller.ReferenceRelease{
+			PullRepository: configCopy.ReferenceRelease.PullRepository,
+			PushRepository: "",
+		}
+		releaseCopy.Config = &configCopy
+
+		_, err := buildReferenceReleaseJob(&releaseCopy, releaseName, mirror, false)
+		if err == nil {
+			t.Fatal("expected error when PushRepository is empty")
+		}
+		if !strings.Contains(err.Error(), "PushRepository is empty") {
+			t.Errorf("expected error about empty PushRepository, got: %v", err)
+		}
+	})
+
 	t.Run("manifest list mode disabled", func(t *testing.T) {
 		job, err := buildReferenceReleaseJob(release, releaseName, mirror, false)
 		if err != nil {
@@ -558,6 +576,24 @@ func TestBuildReferenceRemovalJob(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "no ReferenceRelease configuration") {
 			t.Errorf("expected error about missing ReferenceRelease configuration, got: %v", err)
+		}
+	})
+
+	t.Run("empty PushRepository returns error", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.ReferenceRelease = &releasecontroller.ReferenceRelease{
+			PullRepository: configCopy.ReferenceRelease.PullRepository,
+			PushRepository: "",
+		}
+		releaseCopy.Config = &configCopy
+
+		_, err := buildReferenceRemovalJob(&releaseCopy, releaseName, cliImage)
+		if err == nil {
+			t.Fatal("expected error when PushRepository is empty")
+		}
+		if !strings.Contains(err.Error(), "PushRepository is empty") {
+			t.Errorf("expected error about empty PushRepository, got: %v", err)
 		}
 	})
 

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCalculateReferenceMirrorImageStream(t *testing.T) {
+	testCases := []struct {
+		name       string
+		release    *releasecontroller.Release
+		expectTags int
+		expectSkip int
+	}{
+		{
+			name: "copies spec tags with From references",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{
+								Name:      "cli",
+								Reference: true,
+								From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/cli@sha256:abc"},
+							},
+							{
+								Name:      "installer",
+								Reference: true,
+								From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/installer@sha256:def"},
+							},
+						},
+					},
+				},
+			},
+			expectTags: 2,
+		},
+		{
+			name: "skips tags without From",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{
+								Name:      "has-from",
+								Reference: true,
+								From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/img@sha256:aaa"},
+							},
+							{
+								Name:      "no-from",
+								Reference: true,
+							},
+						},
+					},
+				},
+			},
+			expectTags: 1,
+		},
+		{
+			name: "no tags produces empty mirror",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{},
+				},
+			},
+			expectTags: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			is := &imagev1.ImageStream{}
+			if err := calculateReferenceMirrorImageStream(tc.release, is); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(is.Spec.Tags) != tc.expectTags {
+				t.Errorf("expected %d tags, got %d", tc.expectTags, len(is.Spec.Tags))
+			}
+			for _, tag := range is.Spec.Tags {
+				if tag.ImportPolicy.Scheduled {
+					t.Errorf("tag %q should not have scheduled import", tag.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildReferenceReleaseJob(t *testing.T) {
+	mirror := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "4.17-art-latest-2024-08-30-110931",
+			Namespace: "ocp",
+			Annotations: map[string]string{
+				releasecontroller.ReleaseAnnotationSource:     "ocp/4.17-art-latest",
+				releasecontroller.ReleaseAnnotationTarget:     "ocp/release",
+				releasecontroller.ReleaseAnnotationReleaseTag: "4.17.0-0.nightly-2024-08-30-110931",
+			},
+		},
+		Spec: imagev1.ImageStreamSpec{
+			Tags: []imagev1.TagReference{
+				{
+					Name:      "cli",
+					Reference: true,
+					From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/cli@sha256:abc"},
+				},
+				{
+					Name:      "installer",
+					Reference: true,
+					From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/installer@sha256:def"},
+				},
+			},
+		},
+	}
+
+	release := &releasecontroller.Release{
+		Source: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "4.17-art-latest", Namespace: "ocp"},
+		},
+		Target: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "ocp", Generation: 5},
+		},
+		Config: &releasecontroller.ReleaseConfig{
+			Name:             "4.17.0-0.nightly",
+			OverrideCLIImage: "quay.io/org/cli:latest",
+			ReferenceMode:    "source",
+			ReferenceRelease: &releasecontroller.ReferenceRelease{
+				PushRepository: "quay.io/openshift-release-dev/ocp-release",
+				PullRepository: "quay.io/openshift-release-dev/ocp-release",
+				SecretName:     "quay-secret",
+			},
+		},
+	}
+	releaseName := "4.17.0-0.nightly-2024-08-30-110931"
+
+	t.Run("produces correct job spec", func(t *testing.T) {
+		job, err := buildReferenceReleaseJob(release, releaseName, mirror, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if job.Name != releaseName {
+			t.Errorf("expected job name %q, got %q", releaseName, job.Name)
+		}
+
+		container := job.Spec.Template.Spec.Containers[0]
+		if container.Image != "quay.io/org/cli:latest" {
+			t.Errorf("expected CLI image %q, got %q", "quay.io/org/cli:latest", container.Image)
+		}
+
+		cmd := strings.Join(container.Command, " ")
+		if !strings.Contains(cmd, "oc get imagestream") {
+			t.Errorf("expected command to contain 'oc get imagestream' fetch step, got: %s", cmd)
+		}
+		if !strings.Contains(cmd, "awk") {
+			t.Errorf("expected command to contain awk status-strip step, got: %s", cmd)
+		}
+		if !strings.Contains(cmd, "--from-image-stream-file=/tmp/mirror.yaml") {
+			t.Errorf("expected command to contain --from-image-stream-file, got: %s", cmd)
+		}
+		if !strings.Contains(cmd, "--name=$3") {
+			t.Errorf("expected command to contain --name=$3, got: %s", cmd)
+		}
+
+		expectedToImage := "quay.io/openshift-release-dev/ocp-release:rc_payload__" + releaseName
+		if !strings.Contains(cmd, expectedToImage) {
+			t.Errorf("expected command args to contain %q, got: %s", expectedToImage, cmd)
+		}
+
+		args := container.Command
+		if args[4] != mirror.Name {
+			t.Errorf("expected $1 arg to be mirror name %q, got %q", mirror.Name, args[4])
+		}
+		if args[5] != mirror.Namespace {
+			t.Errorf("expected $2 arg to be mirror namespace %q, got %q", mirror.Namespace, args[5])
+		}
+		if args[6] != releaseName {
+			t.Errorf("expected $3 arg to be release name %q, got %q", releaseName, args[6])
+		}
+
+		// Verify annotations
+		if job.Annotations[releasecontroller.ReleaseAnnotationSource] != "ocp/4.17-art-latest" {
+			t.Errorf("expected source annotation %q, got %q", "ocp/4.17-art-latest", job.Annotations[releasecontroller.ReleaseAnnotationSource])
+		}
+		if job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag] != releaseName {
+			t.Errorf("expected releaseTag annotation %q, got %q", releaseName, job.Annotations[releasecontroller.ReleaseAnnotationReleaseTag])
+		}
+	})
+
+	t.Run("uses reference repository secret", func(t *testing.T) {
+		job, err := buildReferenceReleaseJob(release, releaseName, mirror, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		foundSecret := false
+		for _, vol := range job.Spec.Template.Spec.Volumes {
+			if vol.Secret != nil && vol.Secret.SecretName == "quay-secret" {
+				foundSecret = true
+			}
+		}
+		if !foundSecret {
+			t.Errorf("expected volume with secret %q", "quay-secret")
+		}
+	})
+
+	t.Run("falls back to pullSecretName when referenceRepositorySecretName is empty", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.ReferenceRelease = &releasecontroller.ReferenceRelease{
+			PushRepository: configCopy.ReferenceRelease.PushRepository,
+			PullRepository: configCopy.ReferenceRelease.PullRepository,
+		}
+		configCopy.PullSecretName = "pull-secret"
+		releaseCopy.Config = &configCopy
+
+		job, err := buildReferenceReleaseJob(&releaseCopy, releaseName, mirror, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		foundSecret := false
+		for _, vol := range job.Spec.Template.Spec.Volumes {
+			if vol.Secret != nil && vol.Secret.SecretName == "pull-secret" {
+				foundSecret = true
+			}
+		}
+		if !foundSecret {
+			t.Errorf("expected volume with fallback secret %q", "pull-secret")
+		}
+	})
+
+	t.Run("falls back to cli spec tag when overrideCLIImage is empty", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.OverrideCLIImage = ""
+		releaseCopy.Config = &configCopy
+
+		job, err := buildReferenceReleaseJob(&releaseCopy, releaseName, mirror, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		container := job.Spec.Template.Spec.Containers[0]
+		if container.Image != "quay.io/org/cli@sha256:abc" {
+			t.Errorf("expected CLI image from spec tag %q, got %q", "quay.io/org/cli@sha256:abc", container.Image)
+		}
+	})
+
+	t.Run("fails when no CLI image source is available", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.OverrideCLIImage = ""
+		releaseCopy.Config = &configCopy
+
+		mirrorNoCLI := &imagev1.ImageStream{
+			ObjectMeta: mirror.ObjectMeta,
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name:      "installer",
+						Reference: true,
+						From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/installer@sha256:def"},
+					},
+				},
+			},
+		}
+
+		_, err := buildReferenceReleaseJob(&releaseCopy, releaseName, mirrorNoCLI, false)
+		if err == nil {
+			t.Fatal("expected error when no CLI image is available")
+		}
+		if !strings.Contains(err.Error(), "CLI image") {
+			t.Errorf("expected error about CLI image, got: %v", err)
+		}
+	})
+
+	t.Run("nil ReferenceRelease returns error", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.ReferenceRelease = nil
+		releaseCopy.Config = &configCopy
+
+		_, err := buildReferenceReleaseJob(&releaseCopy, releaseName, mirror, false)
+		if err == nil {
+			t.Fatal("expected error when ReferenceRelease is nil")
+		}
+		if !strings.Contains(err.Error(), "no ReferenceRelease configuration") {
+			t.Errorf("expected error about missing ReferenceRelease configuration, got: %v", err)
+		}
+	})
+
+	t.Run("manifest list mode disabled", func(t *testing.T) {
+		job, err := buildReferenceReleaseJob(release, releaseName, mirror, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		args := job.Spec.Template.Spec.Containers[0].Command
+		// The last arg is the manifest list mode value
+		lastArg := args[len(args)-1]
+		if lastArg != "false" {
+			t.Errorf("expected manifest list mode %q, got %q", "false", lastArg)
+		}
+	})
+
+	t.Run("manifest list mode enabled", func(t *testing.T) {
+		job, err := buildReferenceReleaseJob(release, releaseName, mirror, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		args := job.Spec.Template.Spec.Containers[0].Command
+		lastArg := args[len(args)-1]
+		if lastArg != "true" {
+			t.Errorf("expected manifest list mode %q, got %q", "true", lastArg)
+		}
+	})
+}
+
+func TestBuildReferenceRemovalJob(t *testing.T) {
+	release := &releasecontroller.Release{
+		Source: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "4.22-art-latest", Namespace: "ocp"},
+		},
+		Target: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "ocp", Generation: 3},
+		},
+		Config: &releasecontroller.ReleaseConfig{
+			Name: "4.22.0-0.ci",
+			ReferenceRelease: &releasecontroller.ReferenceRelease{
+				PushRepository: "quay.io/openshift-release-dev/ocp-release",
+				PullRepository: "quay.io/openshift-release-dev/ocp-release",
+				SecretName:     "quay-secret",
+			},
+		},
+	}
+	releaseName := "4.22.0-0.ci-2026-01-30-070825"
+	cliImage := "quay.io/org/cli:latest"
+
+	t.Run("produces correct oc image mirror command", func(t *testing.T) {
+		job, err := buildReferenceRemovalJob(release, releaseName, cliImage)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedJobName := "remove-" + releaseName
+		if job.Name != expectedJobName {
+			t.Errorf("expected job name %q, got %q", expectedJobName, job.Name)
+		}
+
+		container := job.Spec.Template.Spec.Containers[0]
+		if container.Image != cliImage {
+			t.Errorf("expected CLI image %q, got %q", cliImage, container.Image)
+		}
+
+		cmd := strings.Join(container.Command, " ")
+		if !strings.Contains(cmd, "oc image mirror") {
+			t.Errorf("expected command to contain 'oc image mirror', got: %s", cmd)
+		}
+
+		expectedFrom := "quay.io/openshift-release-dev/ocp-release:rc_payload__" + releaseName
+		if !strings.Contains(cmd, expectedFrom) {
+			t.Errorf("expected command to contain from image %q, got: %s", expectedFrom, cmd)
+		}
+
+		expectedTo := "quay.io/openshift-release-dev/ocp-release:remove__rc_payload__" + releaseName
+		if !strings.Contains(cmd, expectedTo) {
+			t.Errorf("expected command to contain to image %q, got: %s", expectedTo, cmd)
+		}
+	})
+
+	t.Run("uses reference repository secret", func(t *testing.T) {
+		job, err := buildReferenceRemovalJob(release, releaseName, cliImage)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		foundSecret := false
+		for _, vol := range job.Spec.Template.Spec.Volumes {
+			if vol.Secret != nil && vol.Secret.SecretName == "quay-secret" {
+				foundSecret = true
+			}
+		}
+		if !foundSecret {
+			t.Errorf("expected volume with secret %q", "quay-secret")
+		}
+	})
+
+	t.Run("falls back to pullSecretName when referenceRepositorySecretName is empty", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.ReferenceRelease = &releasecontroller.ReferenceRelease{
+			PushRepository: configCopy.ReferenceRelease.PushRepository,
+			PullRepository: configCopy.ReferenceRelease.PullRepository,
+		}
+		configCopy.PullSecretName = "pull-secret"
+		releaseCopy.Config = &configCopy
+
+		job, err := buildReferenceRemovalJob(&releaseCopy, releaseName, cliImage)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		foundSecret := false
+		for _, vol := range job.Spec.Template.Spec.Volumes {
+			if vol.Secret != nil && vol.Secret.SecretName == "pull-secret" {
+				foundSecret = true
+			}
+		}
+		if !foundSecret {
+			t.Errorf("expected volume with fallback secret %q", "pull-secret")
+		}
+	})
+
+	t.Run("nil ReferenceRelease returns error", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.ReferenceRelease = nil
+		releaseCopy.Config = &configCopy
+
+		_, err := buildReferenceRemovalJob(&releaseCopy, releaseName, cliImage)
+		if err == nil {
+			t.Fatal("expected error when ReferenceRelease is nil")
+		}
+		if !strings.Contains(err.Error(), "no ReferenceRelease configuration") {
+			t.Errorf("expected error about missing ReferenceRelease configuration, got: %v", err)
+		}
+	})
+
+	t.Run("from and to images are correctly constructed", func(t *testing.T) {
+		job, err := buildReferenceRemovalJob(release, releaseName, cliImage)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		args := job.Spec.Template.Spec.Containers[0].Command
+		expectedFrom := "quay.io/openshift-release-dev/ocp-release:rc_payload__" + releaseName
+		expectedTo := "quay.io/openshift-release-dev/ocp-release:remove__rc_payload__" + releaseName
+
+		foundFrom := false
+		foundTo := false
+		for _, arg := range args {
+			if arg == expectedFrom {
+				foundFrom = true
+			}
+			if arg == expectedTo {
+				foundTo = true
+			}
+		}
+		if !foundFrom {
+			t.Errorf("expected from image %q in command args, got: %v", expectedFrom, args)
+		}
+		if !foundTo {
+			t.Errorf("expected to image %q in command args, got: %v", expectedTo, args)
+		}
+	})
+}

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -237,6 +237,15 @@ func TestBuildReferenceReleaseJob(t *testing.T) {
 	release := &releasecontroller.Release{
 		Source: &imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{Name: "4.17-art-latest", Namespace: "ocp"},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: []imagev1.TagReference{
+					{
+						Name:      "cli",
+						Reference: true,
+						From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/cli@sha256:abc"},
+					},
+				},
+			},
 		},
 		Target: &imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "ocp", Generation: 5},

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -433,6 +433,23 @@ func TestBuildReferenceReleaseJob(t *testing.T) {
 			t.Errorf("expected manifest list mode %q, got %q", "true", lastArg)
 		}
 	})
+
+	t.Run("manifest list mode disabled by config override", func(t *testing.T) {
+		releaseCopy := *release
+		configCopy := *release.Config
+		configCopy.DisableManifestListMode = true
+		releaseCopy.Config = &configCopy
+
+		job, err := buildReferenceReleaseJob(&releaseCopy, releaseName, mirror, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		args := job.Spec.Template.Spec.Containers[0].Command
+		lastArg := args[len(args)-1]
+		if lastArg != "false" {
+			t.Errorf("expected manifest list mode %q when DisableManifestListMode is set, got %q", "false", lastArg)
+		}
+	})
 }
 
 func TestBuildReferenceRemovalJob(t *testing.T) {

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -89,6 +89,124 @@ func TestCalculateReferenceMirrorImageStream(t *testing.T) {
 	}
 }
 
+func TestReleaseTagFromForReferenceRelease(t *testing.T) {
+	testCases := []struct {
+		name       string
+		release    *releasecontroller.Release
+		expectFrom bool
+		expectSpec string
+	}{
+		{
+			name: "reference release sets From with DockerImage pullspec",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: "4.18-art-latest", Namespace: "ocp"},
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true, From: &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/cli@sha256:abc"}},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "ocp"},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Name: "4.18.0-0.nightly",
+					ReferenceRelease: &releasecontroller.ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release-push",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release-pull",
+						SecretName:     "quay-secret",
+					},
+				},
+			},
+			expectFrom: true,
+			expectSpec: "quay.io/openshift-release-dev/ocp-release-pull:" + releasecontroller.ReferencePayloadTagPrefix + "4.18.0-0.nightly-2025-01-15-120000",
+		},
+		{
+			name: "non-reference release does not set From",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: "4.18-art-latest", Namespace: "ocp"},
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{Tag: "cli", Items: []imagev1.TagEvent{{Image: "sha256:abc"}}}},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "ocp"},
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Name: "4.18.0-0.ci",
+				},
+			},
+			expectFrom: false,
+		},
+		{
+			name: "reference spec tags without ReferenceRelease config does not set From",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: "4.18-art-latest", Namespace: "ocp"},
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true, From: &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/cli@sha256:abc"}},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "ocp"},
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					Name: "4.18.0-0.ci",
+				},
+			},
+			expectFrom: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tagName := tc.release.Config.Name + "-2025-01-15-120000"
+
+			tag := imagev1.TagReference{
+				Name:         tagName,
+				Reference:    releasecontroller.HasReferenceSpecTags(tc.release.Source),
+				ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+			}
+			if releasecontroller.IsReferenceRelease(tc.release) {
+				tag.From = &corev1.ObjectReference{
+					Kind: "DockerImage",
+					Name: releasecontroller.ReleasePullSpec(tc.release, tag.Name),
+				}
+			}
+
+			if tc.expectFrom {
+				if tag.From == nil {
+					t.Fatal("expected From to be set, got nil")
+				}
+				if tag.From.Kind != "DockerImage" {
+					t.Errorf("expected From.Kind %q, got %q", "DockerImage", tag.From.Kind)
+				}
+				if tag.From.Name != tc.expectSpec {
+					t.Errorf("expected From.Name %q, got %q", tc.expectSpec, tag.From.Name)
+				}
+			} else {
+				if tag.From != nil {
+					t.Errorf("expected From to be nil, got %+v", tag.From)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildReferenceReleaseJob(t *testing.T) {
 	mirror := &imagev1.ImageStream{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -12,6 +12,7 @@ import (
 	"github.com/blang/semver"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -33,6 +34,12 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 		},
 		Reference:    releasecontroller.HasReferenceSpecTags(release.Source),
 		ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+	}
+	if releasecontroller.IsReferenceRelease(release) {
+		tag.From = &corev1.ObjectReference{
+			Kind: "DockerImage",
+			Name: releasecontroller.ReleasePullSpec(release, tag.Name),
+		}
 	}
 	target.Spec.Tags = append(target.Spec.Tags, tag)
 

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/blang/semver"
 
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -30,6 +31,7 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 			releasecontroller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
 			releasecontroller.ReleaseAnnotationPhase:             releasecontroller.ReleasePhasePending,
 		},
+		Reference:    releasecontroller.HasReferenceSpecTags(release.Source),
 		ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 	}
 	target.Spec.Tags = append(target.Spec.Tags, tag)
@@ -98,6 +100,7 @@ func (c *Controller) replaceReleaseTagWithNext(release *releasecontroller.Releas
 	}
 	origin.From = tag.From
 	origin.ImportPolicy = tag.ImportPolicy
+	origin.Reference = tag.Reference
 
 	klog.V(2).Infof("Updating next tag for %s to be %s", release.Config.Name, next)
 	is, err := c.imageClient.ImageStreams(target.Namespace).Update(context.TODO(), target, metav1.UpdateOptions{})
@@ -109,6 +112,16 @@ func (c *Controller) replaceReleaseTagWithNext(release *releasecontroller.Releas
 }
 
 func (c *Controller) removeReleaseTags(release *releasecontroller.Release, removeTags []*imagev1.TagReference) error {
+	if releasecontroller.IsReferenceRelease(release) {
+		allComplete, err := c.ensureReferenceRemovalTags(release, removeTags)
+		if err != nil {
+			return err
+		}
+		if !allComplete {
+			return nil
+		}
+	}
+
 	for _, tag := range removeTags {
 		ctx := context.TODO()
 		name := fmt.Sprintf("%s:%s", release.Target.Name, tag.Name)
@@ -142,6 +155,50 @@ func (c *Controller) removeReleaseTags(release *releasecontroller.Release, remov
 		}
 	}
 	return nil
+}
+
+// ensureReferenceRemovalTags creates jobs to push remove__ prefixed tags to the
+// ReferenceRepository for each tag being removed. Returns true when all jobs
+// have completed successfully.
+func (c *Controller) ensureReferenceRemovalTags(release *releasecontroller.Release, removeTags []*imagev1.TagReference) (bool, error) {
+	cliImage := release.Config.OverrideCLIImage
+	if len(cliImage) == 0 {
+		if cliTag := releasecontroller.FindSpecTag(release.Source.Spec.Tags, "cli"); cliTag != nil && cliTag.From != nil && cliTag.From.Kind == "DockerImage" {
+			cliImage = cliTag.From.Name
+		}
+	}
+	if len(cliImage) == 0 {
+		klog.Warningf("Unable to determine CLI image for reference removal tags, skipping removal tagging")
+		return true, nil
+	}
+
+	allComplete := true
+	for _, tag := range removeTags {
+		job, err := c.ensureJob(referenceRemovalJobName(tag.Name), nil, func() (*batchv1.Job, error) {
+			job, err := buildReferenceRemovalJob(release, tag.Name, cliImage)
+			if err != nil {
+				return nil, err
+			}
+			klog.V(2).Infof("Running reference removal job %s/%s for %s", c.jobNamespace, job.Name, tag.Name)
+			return job, nil
+		})
+		if err != nil {
+			return false, err
+		}
+		if job == nil {
+			continue
+		}
+		succeeded, complete := jobIsComplete(job)
+		if !complete {
+			klog.V(2).Infof("Waiting for reference removal job %s to complete for %s", job.Name, tag.Name)
+			allComplete = false
+			continue
+		}
+		if !succeeded {
+			klog.Warningf("Reference removal job %s failed for %s, proceeding with tag deletion", job.Name, tag.Name)
+		}
+	}
+	return allComplete, nil
 }
 
 func (c *Controller) setReleaseAnnotation(release *releasecontroller.Release, phase string, annotations map[string]string, names ...string) error {

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -168,19 +168,18 @@ func (c *Controller) removeReleaseTags(release *releasecontroller.Release, remov
 // ReferenceRepository for each tag being removed. Returns true when all jobs
 // have completed successfully.
 func (c *Controller) ensureReferenceRemovalTags(release *releasecontroller.Release, removeTags []*imagev1.TagReference) (bool, error) {
-	cliImage := release.Config.OverrideCLIImage
-	if len(cliImage) == 0 {
-		if cliTag := releasecontroller.FindSpecTag(release.Source.Spec.Tags, "cli"); cliTag != nil && cliTag.From != nil && cliTag.From.Kind == "DockerImage" {
-			cliImage = cliTag.From.Name
-		}
-	}
-	if len(cliImage) == 0 {
-		klog.Warningf("Unable to determine CLI image for reference removal tags, skipping removal tagging")
-		return true, nil
-	}
-
 	allComplete := true
 	for _, tag := range removeTags {
+		mirror, err := releasecontroller.GetMirror(release, tag.Name, c.releaseLister)
+		if err != nil {
+			klog.Warningf("Unable to get mirror for tag %s, skipping removal tagging: %v", tag.Name, err)
+			continue
+		}
+		cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)
+		if err != nil {
+			klog.Warningf("Unable to determine CLI image for tag %s, skipping removal tagging: %v", tag.Name, err)
+			continue
+		}
 		job, err := c.ensureJob(referenceRemovalJobName(tag.Name), nil, func() (*batchv1.Job, error) {
 			job, err := buildReferenceRemovalJob(release, tag.Name, cliImage)
 			if err != nil {

--- a/cmd/release-controller/sync_upgrade.go
+++ b/cmd/release-controller/sync_upgrade.go
@@ -35,7 +35,7 @@ func (c *Controller) ensureReleaseUpgradeJobs(release *releasecontroller.Release
 	if err != nil {
 		return fmt.Errorf("unable to determine platform distribution: %v", err)
 	}
-	pullSpec := releasecontroller.FindPublicImagePullSpec(release.Target, releaseTag.Name)
+	pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag.Name)
 	if len(pullSpec) == 0 {
 		return fmt.Errorf("unable to get determine pullSpec for for release: %s", releaseTag.Name)
 	}

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -160,12 +160,12 @@ func (c *Controller) getUpgradeTagAndPullSpec(release *releasecontroller.Release
 	case releasecontroller.ReleaseUpgradeFromPrevious:
 		if tags := releasecontroller.SortedReleaseTags(release, releasecontroller.ReleasePhaseAccepted); len(tags) > 0 {
 			previousTag = tags[0].Name
-			previousReleasePullSpec = release.Target.Status.PublicDockerImageRepository + ":" + previousTag
+			previousReleasePullSpec = releasecontroller.ReleasePullSpec(release, previousTag)
 		}
 	case releasecontroller.ReleaseUpgradeFromPreviousMinus1:
 		if tags := releasecontroller.SortedReleaseTags(release, releasecontroller.ReleasePhaseAccepted); len(tags) > 1 {
 			previousTag = tags[1].Name
-			previousReleasePullSpec = release.Target.Status.PublicDockerImageRepository + ":" + previousTag
+			previousReleasePullSpec = releasecontroller.ReleasePullSpec(release, previousTag)
 		}
 	case releasecontroller.ReleaseUpgradeFromPreviousMinor:
 		if version, err := semver.Parse(releaseTag.Name); err == nil && version.Minor > 0 {
@@ -196,7 +196,7 @@ func findLatestStableForVersion(ref *releasecontroller.StableReferences, version
 			if currentLatestRelease == nil || v.Version.Compare(*currentLatestRelease) > 0 {
 				currentLatestRelease = v.Version
 				latestTag = v.Tag.Name
-				latestPullSpec = stable.Release.Target.Status.PublicDockerImageRepository + ":" + latestTag
+				latestPullSpec = releasecontroller.ReleasePullSpec(stable.Release, latestTag)
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 			return "", "", fmt.Errorf("failed to get latest tag in 4-stable stream: %w", err)
 		}
 		tag := latest.Name
-		pullSpec := r.Target.Status.PublicDockerImageRepository + ":" + tag
+		pullSpec := releasecontroller.ReleasePullSpec(r, tag)
 		return tag, pullSpec, nil
 	} else if upgradeRelease.Candidate != nil {
 		// create blank semver.Range
@@ -226,7 +226,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 			return "", "", fmt.Errorf("failed to get latest tag for stream %s: %w", stream, err)
 		}
 		tag := latest.Name
-		pullSpec := r.Target.Status.PublicDockerImageRepository + ":" + tag
+		pullSpec := releasecontroller.ReleasePullSpec(r, tag)
 		return tag, pullSpec, nil
 	} else if upgradeRelease.Official != nil {
 		httpClient := retryablehttp.NewClient()

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -174,7 +174,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			switch name := c.Env[j].Name; {
 			case name == "RELEASE_IMAGE_LATEST":
 				hasReleaseImage = true
-				c.Env[j].Value = release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name
+				c.Env[j].Value = releasecontroller.ReleasePullSpec(release, releaseTag.Name)
 			case name == "RELEASE_IMAGE_INITIAL":
 				if len(previousReleasePullSpec) == 0 {
 					return false, nil
@@ -182,6 +182,9 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 				hasUpgradeImage = true
 				c.Env[j].Value = previousReleasePullSpec
 			case name == "IMAGE_FORMAT":
+				if releasecontroller.HasReferenceSpecTags(release.Source) {
+					break
+				}
 				if mirror == nil {
 					return false, fmt.Errorf("unable to determine IMAGE_FORMAT for prow job %s", spec.Job)
 				}
@@ -189,6 +192,9 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			case strings.HasPrefix(name, "IMAGE_"):
 				suffix := strings.TrimPrefix(name, "IMAGE_")
 				if len(suffix) == 0 {
+					break
+				}
+				if releasecontroller.HasReferenceSpecTags(release.Source) {
 					break
 				}
 				if mirror == nil {
@@ -199,36 +205,38 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			}
 		}
 		if !hasReleaseImage {
+			pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag.Name)
 			switch architecture {
 			case "arm64":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_LATEST", Value: pullSpec})
 			case "s390x":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_S390X_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_S390X_LATEST", Value: pullSpec})
 			case "ppc64le":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_LATEST", Value: pullSpec})
 			case "multi":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: pullSpec})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_LATEST", Value: pullSpec})
 			default:
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_LATEST", Value: pullSpec})
 			}
 		}
 		if !isUpgrade {
 			// If an initial release is specified in the ci-operator config, ci-operator will always try to pull it. This can cause jobs to fail
 			// if there are not at least 2 accepted releases for the release being tested. To prevent this issue, always set RELEASE_IMAGE_INITIAL,
 			// even for non-upgrade jobs
+			pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag.Name)
 			switch architecture {
 			case "arm64":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_INITIAL", Value: pullSpec})
 			case "s390x":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_S390X_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_S390X_INITIAL", Value: pullSpec})
 			case "ppc64le":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_PPC64LE_INITIAL", Value: pullSpec})
 			case "multi":
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: pullSpec})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_MULTI_INITIAL", Value: pullSpec})
 			default:
-				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: release.Target.Status.PublicDockerImageRepository + ":" + releaseTag.Name})
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_INITIAL", Value: pullSpec})
 			}
 		} else if !hasUpgradeImage {
 			if len(previousReleasePullSpec) == 0 {

--- a/cmd/release-controller/sync_verify_prow_test.go
+++ b/cmd/release-controller/sync_verify_prow_test.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/release-controller/pkg/prow"
+	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 
+	corev1 "k8s.io/api/core/v1"
+	prowjobv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 )
 
@@ -129,5 +133,237 @@ func TestGenerateSafeProwJobName(t *testing.T) {
 				t.Errorf("Expected string of length less than %d, got string of length %d", prow.MaxProwJobNameLength, len(result))
 			}
 		})
+	}
+}
+
+func newRelease(reference bool, refRepo string) *releasecontroller.Release {
+	tags := []imagev1.TagReference{{Name: "cli"}}
+	if reference {
+		tags[0].Reference = true
+	}
+	config := &releasecontroller.ReleaseConfig{
+		Name: "4.17.0-0.nightly",
+	}
+	if len(refRepo) > 0 {
+		config.ReferenceRelease = &releasecontroller.ReferenceRelease{
+			PushRepository: refRepo,
+			PullRepository: refRepo,
+		}
+	}
+	return &releasecontroller.Release{
+		Source: &imagev1.ImageStream{
+			Spec: imagev1.ImageStreamSpec{Tags: tags},
+		},
+		Target: &imagev1.ImageStream{
+			Status: imagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+			},
+		},
+		Config: config,
+	}
+}
+
+func findEnv(envs []corev1.EnvVar, name string) (string, bool) {
+	for _, e := range envs {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+func TestAddReleaseEnvToProwJobSpec_NonReference(t *testing.T) {
+	release := newRelease(false, "")
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	spec := prowjobv1.ProwJobSpec{
+		PodSpec: &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test"}},
+		},
+	}
+
+	ok, err := addReleaseEnvToProwJobSpec(&spec, release, nil, tag, "", false, "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+
+	expected := "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000"
+	env := spec.PodSpec.Containers[0].Env
+	if val, found := findEnv(env, "RELEASE_IMAGE_LATEST"); !found || val != expected {
+		t.Errorf("RELEASE_IMAGE_LATEST: expected %q, got %q (found=%v)", expected, val, found)
+	}
+	if val, found := findEnv(env, "RELEASE_IMAGE_INITIAL"); !found || val != expected {
+		t.Errorf("RELEASE_IMAGE_INITIAL: expected %q, got %q (found=%v)", expected, val, found)
+	}
+}
+
+func TestAddReleaseEnvToProwJobSpec_Reference(t *testing.T) {
+	release := newRelease(true, "quay.io/openshift-release-dev/ocp-release")
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	spec := prowjobv1.ProwJobSpec{
+		PodSpec: &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test"}},
+		},
+	}
+
+	ok, err := addReleaseEnvToProwJobSpec(&spec, release, nil, tag, "", false, "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+
+	expected := "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2025-01-01-000000"
+	env := spec.PodSpec.Containers[0].Env
+	if val, found := findEnv(env, "RELEASE_IMAGE_LATEST"); !found || val != expected {
+		t.Errorf("RELEASE_IMAGE_LATEST: expected %q, got %q (found=%v)", expected, val, found)
+	}
+	if val, found := findEnv(env, "RELEASE_IMAGE_INITIAL"); !found || val != expected {
+		t.Errorf("RELEASE_IMAGE_INITIAL: expected %q, got %q (found=%v)", expected, val, found)
+	}
+}
+
+func TestAddReleaseEnvToProwJobSpec_ReferenceUpgrade(t *testing.T) {
+	release := newRelease(true, "quay.io/openshift-release-dev/ocp-release")
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	prevPullSpec := "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2024-12-31-000000"
+	spec := prowjobv1.ProwJobSpec{
+		PodSpec: &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test"}},
+		},
+	}
+
+	ok, err := addReleaseEnvToProwJobSpec(&spec, release, nil, tag, prevPullSpec, true, "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+
+	expectedLatest := "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2025-01-01-000000"
+	env := spec.PodSpec.Containers[0].Env
+	if val, found := findEnv(env, "RELEASE_IMAGE_LATEST"); !found || val != expectedLatest {
+		t.Errorf("RELEASE_IMAGE_LATEST: expected %q, got %q (found=%v)", expectedLatest, val, found)
+	}
+	if val, found := findEnv(env, "RELEASE_IMAGE_INITIAL"); !found || val != prevPullSpec {
+		t.Errorf("RELEASE_IMAGE_INITIAL: expected %q, got %q (found=%v)", prevPullSpec, val, found)
+	}
+}
+
+func TestAddReleaseEnvToProwJobSpec_ArchVariants(t *testing.T) {
+	testCases := []struct {
+		arch             string
+		expectedLatest   string
+		expectedInitial  string
+		extraLatestName  string
+		extraInitialName string
+	}{
+		{
+			arch:            "arm64",
+			expectedLatest:  "RELEASE_IMAGE_ARM64_LATEST",
+			expectedInitial: "RELEASE_IMAGE_ARM64_INITIAL",
+		},
+		{
+			arch:            "s390x",
+			expectedLatest:  "RELEASE_IMAGE_S390X_LATEST",
+			expectedInitial: "RELEASE_IMAGE_S390X_INITIAL",
+		},
+		{
+			arch:            "ppc64le",
+			expectedLatest:  "RELEASE_IMAGE_PPC64LE_LATEST",
+			expectedInitial: "RELEASE_IMAGE_PPC64LE_INITIAL",
+		},
+		{
+			arch:             "multi",
+			expectedLatest:   "RELEASE_IMAGE_LATEST",
+			expectedInitial:  "RELEASE_IMAGE_INITIAL",
+			extraLatestName:  "RELEASE_IMAGE_MULTI_LATEST",
+			extraInitialName: "RELEASE_IMAGE_MULTI_INITIAL",
+		},
+	}
+
+	for _, tc := range testCases {
+		for _, isRef := range []bool{false, true} {
+			name := fmt.Sprintf("%s/reference=%v", tc.arch, isRef)
+			t.Run(name, func(t *testing.T) {
+				var refRepo string
+				if isRef {
+					refRepo = "quay.io/openshift-release-dev/ocp-release"
+				}
+				release := newRelease(isRef, refRepo)
+				tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+				spec := prowjobv1.ProwJobSpec{
+					PodSpec: &corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test"}},
+					},
+				}
+
+				ok, err := addReleaseEnvToProwJobSpec(&spec, release, nil, tag, "", false, tc.arch)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !ok {
+					t.Fatal("expected ok=true")
+				}
+
+				var expectedPullSpec string
+				if isRef {
+					expectedPullSpec = "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2025-01-01-000000"
+				} else {
+					expectedPullSpec = "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000"
+				}
+
+				env := spec.PodSpec.Containers[0].Env
+				if val, found := findEnv(env, tc.expectedLatest); !found || val != expectedPullSpec {
+					t.Errorf("%s: expected %q, got %q (found=%v)", tc.expectedLatest, expectedPullSpec, val, found)
+				}
+				if val, found := findEnv(env, tc.expectedInitial); !found || val != expectedPullSpec {
+					t.Errorf("%s: expected %q, got %q (found=%v)", tc.expectedInitial, expectedPullSpec, val, found)
+				}
+				if tc.extraLatestName != "" {
+					if val, found := findEnv(env, tc.extraLatestName); !found || val != expectedPullSpec {
+						t.Errorf("%s: expected %q, got %q (found=%v)", tc.extraLatestName, expectedPullSpec, val, found)
+					}
+				}
+				if tc.extraInitialName != "" {
+					if val, found := findEnv(env, tc.extraInitialName); !found || val != expectedPullSpec {
+						t.Errorf("%s: expected %q, got %q (found=%v)", tc.extraInitialName, expectedPullSpec, val, found)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAddReleaseEnvToProwJobSpec_ExistingEnvVar(t *testing.T) {
+	release := newRelease(true, "quay.io/openshift-release-dev/ocp-release")
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	spec := prowjobv1.ProwJobSpec{
+		PodSpec: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "test",
+				Env: []corev1.EnvVar{
+					{Name: "RELEASE_IMAGE_LATEST", Value: "placeholder"},
+				},
+			}},
+		},
+	}
+
+	ok, err := addReleaseEnvToProwJobSpec(&spec, release, nil, tag, "", false, "amd64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+
+	expected := "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2025-01-01-000000"
+	env := spec.PodSpec.Containers[0].Env
+	if val, found := findEnv(env, "RELEASE_IMAGE_LATEST"); !found || val != expected {
+		t.Errorf("RELEASE_IMAGE_LATEST: expected %q, got %q (found=%v)", expected, val, found)
 	}
 }

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -97,8 +97,12 @@ func ReleaseDefinition(is *imagev1.ImageStream, releaseConfigCache *lru.Cache, e
 	}
 
 	if len(is.Status.Tags) == 0 {
-		klog.V(4).Infof("The release input has no status tags, waiting")
-		return nil, false, nil
+		if len(is.Spec.Tags) > 0 && HasReferenceSpecTags(is) {
+			klog.V(4).Infof("The release input has no status tags, but has reference true spec tags, assuming reference-based release")
+		} else {
+			klog.V(4).Infof("The release input has no status tags, waiting")
+			return nil, false, nil
+		}
 	}
 
 	switch cfg.As {
@@ -206,6 +210,13 @@ func ReleaseGenerationFromObject(name string, annotations map[string]string) (in
 }
 
 func HashSpecTagImageDigests(is *imagev1.ImageStream) string {
+	if HasReferenceSpecTags(is) {
+		return hashReferenceSpecTags(is)
+	}
+	return hashStatusTags(is)
+}
+
+func hashStatusTags(is *imagev1.ImageStream) string {
 	h := sha256.New()
 	for _, tag := range is.Status.Tags {
 		if len(tag.Items) == 0 {
@@ -217,6 +228,20 @@ func HashSpecTagImageDigests(is *imagev1.ImageStream) string {
 			input = latest.DockerImageReference
 		}
 		h.Write([]byte(input))
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil))
+}
+
+// hashReferenceSpecTags computes a hash from the spec tags of an imagestream
+// whose tags have reference: true. These tags are not imported, so status
+// fields are not populated; we hash the From reference instead.
+func hashReferenceSpecTags(is *imagev1.ImageStream) string {
+	h := sha256.New()
+	for _, tag := range is.Spec.Tags {
+		if tag.From == nil {
+			continue
+		}
+		h.Write([]byte(tag.From.Name))
 	}
 	return fmt.Sprintf("sha256:%x", h.Sum(nil))
 }
@@ -236,6 +261,18 @@ func Int32p(i int32) *int32 {
 func ContainsTagReference(tags []*imagev1.TagReference, name string) bool {
 	for _, tag := range tags {
 		if name == tag.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// HasReferenceSpecTags returns true if any tag in the imagestream's spec has
+// Reference set to true, indicating the payload uses external image references
+// rather than imported images.
+func HasReferenceSpecTags(is *imagev1.ImageStream) bool {
+	for _, tag := range is.Spec.Tags {
+		if tag.Reference {
 			return true
 		}
 	}
@@ -569,4 +606,24 @@ func GetVerificationJobs(rcCache *lru.Cache, eventRecorder record.EventRecorder,
 		}
 	}
 	return jobs, nil
+}
+
+// IsReferenceRelease returns true when the release is configured to use
+// external image references (reference: true spec tags) backed by an
+// external ReferenceRelease repository.
+func IsReferenceRelease(release *Release) bool {
+	return release.Source != nil &&
+		HasReferenceSpecTags(release.Source) &&
+		release.Config != nil &&
+		release.Config.ReferenceRelease != nil
+}
+
+// ReleasePullSpec returns the correct pull spec for a release payload tag.
+// For reference-based releases the payload lives in the external ReferenceRepository;
+// for traditional releases it lives in the Target imagestream.
+func ReleasePullSpec(release *Release, tagName string) string {
+	if IsReferenceRelease(release) {
+		return fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PullRepository, ReferencePayloadTag(tagName))
+	}
+	return release.Target.Status.PublicDockerImageRepository + ":" + tagName
 }

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -624,6 +624,29 @@ func IsReferenceRelease(release *Release) bool {
 		release.Config.ReferenceRelease != nil
 }
 
+// ResolveCLIImage determines the CLI image to use for job creation.
+// For reference-based releases the CLI image is taken from the mirror's spec
+// tag "cli"; for traditional releases it comes from the mirror's
+// DockerImageRepository. An explicit OverrideCLIImage always takes precedence.
+func ResolveCLIImage(release *Release, mirror *imagev1.ImageStream) (string, error) {
+	if mirror == nil {
+		return "", fmt.Errorf("unable to determine CLI image: mirror imagestream is nil")
+	}
+	if len(release.Config.OverrideCLIImage) > 0 {
+		return release.Config.OverrideCLIImage, nil
+	}
+	if IsReferenceRelease(release) {
+		if cliTag := FindSpecTag(mirror.Spec.Tags, "cli"); cliTag != nil && cliTag.From != nil && cliTag.From.Kind == "DockerImage" {
+			return cliTag.From.Name, nil
+		}
+		return "", fmt.Errorf("unable to determine CLI image for reference release: ensure a 'cli' spec tag exists in the mirror imagestream %s/%s", mirror.Namespace, mirror.Name)
+	}
+	if len(mirror.Status.DockerImageRepository) == 0 {
+		return "", fmt.Errorf("unable to determine CLI image: mirror imagestream %s/%s has no DockerImageRepository", mirror.Namespace, mirror.Name)
+	}
+	return fmt.Sprintf("%s:cli", mirror.Status.DockerImageRepository), nil
+}
+
 // ReleasePullSpec returns the correct pull spec for a release payload tag.
 // For reference-based releases the payload lives in the external ReferenceRepository;
 // for traditional releases it lives in the Target imagestream.

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -91,7 +91,7 @@ func ReleaseDefinition(is *imagev1.ImageStream, releaseConfigCache *lru.Cache, e
 		return nil, false, TerminalError{err}
 	}
 
-	if is.Status.PublicDockerImageRepository == "" && !(cfg.ReferenceRelease != nil && HasReferenceSpecTags(is) && len(is.Spec.Tags) > 0) {
+	if is.Status.PublicDockerImageRepository == "" && (cfg.ReferenceRelease == nil || !HasReferenceSpecTags(is) || len(is.Spec.Tags) == 0) {
 		klog.V(4).Infof("The release input has no public docker image repository, waiting")
 		return nil, false, nil
 	}

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -97,7 +97,7 @@ func ReleaseDefinition(is *imagev1.ImageStream, releaseConfigCache *lru.Cache, e
 	}
 
 	if len(is.Status.Tags) == 0 {
-		if len(is.Spec.Tags) > 0 && HasReferenceSpecTags(is) {
+		if len(is.Spec.Tags) > 0 && HasReferenceSpecTags(is) && cfg.ReferenceRelease != nil {
 			klog.V(4).Infof("The release input has no status tags, but has reference true spec tags, assuming reference-based release")
 		} else {
 			klog.V(4).Infof("The release input has no status tags, waiting")

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -218,7 +218,10 @@ func HashSpecTagImageDigests(is *imagev1.ImageStream) string {
 
 func hashStatusTags(is *imagev1.ImageStream) string {
 	h := sha256.New()
-	for _, tag := range is.Status.Tags {
+	tags := make([]imagev1.NamedTagEventList, len(is.Status.Tags))
+	copy(tags, is.Status.Tags)
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Tag < tags[j].Tag })
+	for _, tag := range tags {
 		if len(tag.Items) == 0 {
 			continue
 		}
@@ -237,7 +240,10 @@ func hashStatusTags(is *imagev1.ImageStream) string {
 // fields are not populated; we hash the From reference instead.
 func hashReferenceSpecTags(is *imagev1.ImageStream) string {
 	h := sha256.New()
-	for _, tag := range is.Spec.Tags {
+	tags := make([]imagev1.TagReference, len(is.Spec.Tags))
+	copy(tags, is.Spec.Tags)
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Name < tags[j].Name })
+	for _, tag := range tags {
 		if tag.From == nil {
 			continue
 		}

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -91,7 +91,7 @@ func ReleaseDefinition(is *imagev1.ImageStream, releaseConfigCache *lru.Cache, e
 		return nil, false, TerminalError{err}
 	}
 
-	if is.Status.PublicDockerImageRepository == "" {
+	if is.Status.PublicDockerImageRepository == "" && !(cfg.ReferenceRelease != nil && HasReferenceSpecTags(is) && len(is.Spec.Tags) > 0) {
 		klog.V(4).Infof("The release input has no public docker image repository, waiting")
 		return nil, false, nil
 	}
@@ -629,7 +629,13 @@ func IsReferenceRelease(release *Release) bool {
 // for traditional releases it lives in the Target imagestream.
 func ReleasePullSpec(release *Release, tagName string) string {
 	if IsReferenceRelease(release) {
+		if release.Config.ReferenceRelease.PullRepository == "" {
+			return ""
+		}
 		return fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PullRepository, ReferencePayloadTag(tagName))
+	}
+	if release.Target.Status.PublicDockerImageRepository == "" {
+		return ""
 	}
 	return release.Target.Status.PublicDockerImageRepository + ":" + tagName
 }

--- a/pkg/release-controller/release_test.go
+++ b/pkg/release-controller/release_test.go
@@ -1,0 +1,219 @@
+package releasecontroller
+
+import (
+	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+)
+
+func TestIsReferenceRelease(t *testing.T) {
+	testCases := []struct {
+		name     string
+		release  *Release
+		expected bool
+	}{
+		{
+			name: "nil source returns false",
+			release: &Release{
+				Source: nil,
+				Config: &ReleaseConfig{
+					ReferenceRelease: &ReferenceRelease{
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "nil config returns false",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Config: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "nil ReferenceRelease returns false",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-reference tags returns false",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+					ReferenceRelease: &ReferenceRelease{
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "fully configured reference release returns true",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+					ReferenceRelease: &ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsReferenceRelease(tc.release)
+			if actual != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestReleasePullSpec(t *testing.T) {
+	testCases := []struct {
+		name     string
+		release  *Release
+		tagName  string
+		expected string
+	}{
+		{
+			name: "non-reference release uses Target pull spec",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+				},
+			},
+			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
+		},
+		{
+			name: "reference release uses ReferenceRelease with payload tag prefix",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+					ReferenceRelease: &ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			expected: "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2025-01-01-000000",
+		},
+		{
+			name: "reference tags but nil ReferenceRelease falls back to Target",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+				},
+			},
+			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
+		},
+		{
+			name: "no spec tags means non-reference",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+					ReferenceRelease: &ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ReleasePullSpec(tc.release, tc.tagName)
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/release-controller/release_test.go
+++ b/pkg/release-controller/release_test.go
@@ -1,9 +1,12 @@
 package releasecontroller
 
 import (
+	"strings"
 	"testing"
 
 	imagev1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsReferenceRelease(t *testing.T) {
@@ -101,6 +104,151 @@ func TestIsReferenceRelease(t *testing.T) {
 			actual := IsReferenceRelease(tc.release)
 			if actual != tc.expected {
 				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestResolveCLIImage(t *testing.T) {
+	testCases := []struct {
+		name          string
+		release       *Release
+		mirror        *imagev1.ImageStream
+		expected      string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "override set returns override regardless of release type",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Config: &ReleaseConfig{
+					OverrideCLIImage: "quay.io/custom/cli:latest",
+					ReferenceRelease: &ReferenceRelease{},
+				},
+			},
+			mirror: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "cli", From: &corev1.ObjectReference{Kind: "DockerImage", Name: "registry.example.com/cli:v1"}},
+					},
+				},
+			},
+			expected: "quay.io/custom/cli:latest",
+		},
+		{
+			name: "reference release with cli spec tag returns spec tag image",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Config: &ReleaseConfig{
+					ReferenceRelease: &ReferenceRelease{},
+				},
+			},
+			mirror: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "cli", From: &corev1.ObjectReference{Kind: "DockerImage", Name: "registry.example.com/cli:v1"}},
+					},
+				},
+			},
+			expected: "registry.example.com/cli:v1",
+		},
+		{
+			name: "reference release with no cli spec tag returns error",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "other", Reference: true},
+						},
+					},
+				},
+				Config: &ReleaseConfig{
+					ReferenceRelease: &ReferenceRelease{},
+				},
+			},
+			mirror: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.17-art-latest"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "other"},
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "4.17-art-latest",
+		},
+		{
+			name: "traditional release with DockerImageRepository returns repo:cli",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Config: &ReleaseConfig{},
+			},
+			mirror: &imagev1.ImageStream{
+				Status: imagev1.ImageStreamStatus{
+					DockerImageRepository: "image-registry.openshift-image-registry.svc:5000/ocp/release",
+				},
+			},
+			expected: "image-registry.openshift-image-registry.svc:5000/ocp/release:cli",
+		},
+		{
+			name: "traditional release with empty DockerImageRepository returns error",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Config: &ReleaseConfig{},
+			},
+			mirror: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ocp", Name: "4.17-art-latest"},
+				Status:     imagev1.ImageStreamStatus{},
+			},
+			expectError:   true,
+			errorContains: "4.17-art-latest",
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual, err := ResolveCLIImage(tc.release, tc.mirror)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errorContains != "" && !strings.Contains(err.Error(), tc.errorContains) {
+					t.Errorf("expected error to contain %q, got %q", tc.errorContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
 			}
 		})
 	}

--- a/pkg/release-controller/release_test.go
+++ b/pkg/release-controller/release_test.go
@@ -184,6 +184,54 @@ func TestReleasePullSpec(t *testing.T) {
 			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
 		},
 		{
+			name: "reference release with empty PullRepository returns empty string",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+					ReferenceRelease: &ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "",
+					},
+				},
+			},
+			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			expected: "",
+		},
+		{
+			name: "non-reference release with empty PublicDockerImageRepository returns empty string",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli"},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "",
+					},
+				},
+				Config: &ReleaseConfig{
+					Name: "4.17.0-0.nightly",
+				},
+			},
+			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			expected: "",
+		},
+		{
 			name: "no spec tags means non-reference",
 			release: &Release{
 				Source: &imagev1.ImageStream{

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -165,11 +165,31 @@ type ReleaseConfig struct {
 	//   "alternateImageRepositorySecretName": "quay-openshift-release-dev-pull-secret"
 	AlternateImageRepositorySecretName string `json:"alternateImageRepositorySecretName"`
 
+	// ReferenceRelease configures reference-based releases where payloads are
+	// pushed to and pulled from an external image repository, with no local
+	// imagestream copy. When nil, reference releases are disabled.
+	ReferenceRelease *ReferenceRelease `json:"referenceRelease"`
+
 	// DisableManifestListMode indicates this release stream should not utilize the --keep-manifest-list for release
 	// creation.  This flag should NOT be used unless absolutely necessary...
 	// Currently, it's being added to work around a limitation with `oc` and images from konflux:
 	// https://issues.redhat.com/browse/OCPBUGS-50660
 	DisableManifestListMode bool `json:"disableManifestListMode"`
+}
+
+// ReferenceRelease holds configuration for reference-based releases that
+// live in an external image repository rather than in a local imagestream.
+type ReferenceRelease struct {
+	// PushRepository is the full path to the external image repository where
+	// release payloads are created (pushed).
+	PushRepository string `json:"pushRepository"`
+	// PullRepository is the full path to the external image repository used
+	// when resolving pull specs for release payloads.
+	PullRepository string `json:"pullRepository"`
+	// SecretName is the name of the secret containing credentials to the
+	// reference repository. Secret must exist in the job namespace. The secret
+	// must contain a single file config.json with a valid Docker auths array.
+	SecretName string `json:"secretName"`
 }
 
 type ReleaseCheck struct {
@@ -391,11 +411,11 @@ type ProwJobVerification struct {
 }
 
 type VerificationStatus struct {
-	State          string       `json:"state"`
-	URL            string       `json:"url"`
-	Retries        int          `json:"retries,omitempty"`
-	PreviousAttemptURLs []string `json:"previousAttemptURLs,omitempty"`
-	TransitionTime *metav1.Time `json:"transitionTime,omitempty"`
+	State               string       `json:"state"`
+	URL                 string       `json:"url"`
+	Retries             int          `json:"retries,omitempty"`
+	PreviousAttemptURLs []string     `json:"previousAttemptURLs,omitempty"`
+	TransitionTime      *metav1.Time `json:"transitionTime,omitempty"`
 }
 
 type VerificationStatusMap map[string]*VerificationStatus
@@ -522,6 +542,16 @@ const (
 
 	ReleaseConfigModeStable = "Stable"
 
+	// ReferencePayloadTagPrefix is prepended to release names when pushing
+	// to ReferenceRepository, so that image cleanup tooling can identify
+	// payload images created by the release controller.
+	ReferencePayloadTagPrefix = "rc_payload__"
+
+	// ReferenceRemovalTagPrefix is prepended to a reference payload tag when
+	// signaling to external cleanup tooling that the release image is ready
+	// to be pruned from the ReferenceRepository.
+	ReferenceRemovalTagPrefix = "remove__"
+
 	ReleaseUpgradeFromPreviousMinor  = "PreviousMinor"
 	ReleaseUpgradeFromPreviousPatch  = "PreviousPatch"
 	ReleaseUpgradeFromPrevious       = "Previous"
@@ -607,6 +637,18 @@ const (
 	// ReleaseStreamAnnotationMessageOverride overrides the message specified in ReleaseConfig.Message
 	ReleaseStreamAnnotationMessageOverride = "release.openshift.io/messageOverride"
 )
+
+// ReferencePayloadTag returns the image tag to use when pushing a release
+// payload to the ReferenceRepository.
+func ReferencePayloadTag(name string) string {
+	return ReferencePayloadTagPrefix + name
+}
+
+// ReferenceRemovalTag returns the image tag to push when signaling that a
+// release payload should be pruned from the ReferenceRepository.
+func ReferenceRemovalTag(name string) string {
+	return ReferenceRemovalTagPrefix + ReferencePayloadTag(name)
+}
 
 // TagReferencesByAge returns the newest tag first, the oldest tag last
 type TagReferencesByAge []*imagev1.TagReference

--- a/pkg/release-controller/types_test.go
+++ b/pkg/release-controller/types_test.go
@@ -1,7 +1,12 @@
 package releasecontroller
 
 import (
+	"strings"
 	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIncomplete(t *testing.T) {
@@ -42,7 +47,7 @@ func TestIncomplete(t *testing.T) {
 			expectIncludesName: "optional-job",
 		},
 		{
-			name: "disabled job is not counted as incomplete",
+			name:   "disabled job is not counted as incomplete",
 			status: VerificationStatusMap{},
 			required: map[string]ReleaseVerification{
 				"disabled-job": {Disabled: true},
@@ -127,6 +132,294 @@ func TestVerificationJobsWithRetries_Async(t *testing.T) {
 			}
 			if len(tc.expectRetryNames) == 0 && len(names) > 0 {
 				t.Errorf("expected no retry names, got %v", names)
+			}
+		})
+	}
+}
+
+func TestHasReferenceSpecTags(t *testing.T) {
+	testCases := []struct {
+		name   string
+		is     *imagev1.ImageStream
+		expect bool
+	}{
+		{
+			name: "no tags returns false",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			expect: false,
+		},
+		{
+			name: "tags without reference returns false",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "component-a"},
+						{Name: "component-b"},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "single tag with reference true returns true",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "component-a", Reference: true},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "mixed tags with one reference true returns true",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "component-a"},
+						{Name: "component-b", Reference: true},
+						{Name: "component-c"},
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := HasReferenceSpecTags(tc.is)
+			if got != tc.expect {
+				t.Errorf("expected %v, got %v", tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestHashSpecTagImageDigests(t *testing.T) {
+	testCases := []struct {
+		name       string
+		is         *imagev1.ImageStream
+		expectSame *imagev1.ImageStream
+		expectDiff *imagev1.ImageStream
+	}{
+		{
+			name: "non-reference imagestream hashes from status tags",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "component-a"},
+					},
+				},
+				Status: imagev1.ImageStreamStatus{
+					Tags: []imagev1.NamedTagEventList{
+						{Tag: "component-a", Items: []imagev1.TagEvent{{Image: "sha256:aaa"}}},
+					},
+				},
+			},
+			expectSame: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-copy"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "component-a"},
+					},
+				},
+				Status: imagev1.ImageStreamStatus{
+					Tags: []imagev1.NamedTagEventList{
+						{Tag: "component-a", Items: []imagev1.TagEvent{{Image: "sha256:aaa"}}},
+					},
+				},
+			},
+			expectDiff: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-diff"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "component-a"},
+					},
+				},
+				Status: imagev1.ImageStreamStatus{
+					Tags: []imagev1.NamedTagEventList{
+						{Tag: "component-a", Items: []imagev1.TagEvent{{Image: "sha256:bbb"}}},
+					},
+				},
+			},
+		},
+		{
+			name: "reference imagestream hashes from spec tags",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{
+							Name:      "component-a",
+							Reference: true,
+							From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/repo@sha256:aaa"},
+						},
+					},
+				},
+			},
+			expectSame: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-copy"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{
+							Name:      "component-a",
+							Reference: true,
+							From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/repo@sha256:aaa"},
+						},
+					},
+				},
+			},
+			expectDiff: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-diff"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{
+							Name:      "component-a",
+							Reference: true,
+							From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/repo@sha256:bbb"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reference imagestream ignores tags without From",
+			is: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "no-from", Reference: true},
+						{
+							Name:      "has-from",
+							Reference: true,
+							From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/repo@sha256:aaa"},
+						},
+					},
+				},
+			},
+			expectSame: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-same"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "no-from", Reference: true},
+						{
+							Name:      "has-from",
+							Reference: true,
+							From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/repo@sha256:aaa"},
+						},
+					},
+				},
+			},
+			expectDiff: &imagev1.ImageStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-diff"},
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{
+						{Name: "no-from", Reference: true},
+						{
+							Name:      "has-from",
+							Reference: true,
+							From:      &corev1.ObjectReference{Kind: "DockerImage", Name: "quay.io/org/repo@sha256:ccc"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hash := HashSpecTagImageDigests(tc.is)
+			if hash == "" {
+				t.Fatal("expected non-empty hash")
+			}
+			if tc.expectSame != nil {
+				sameHash := HashSpecTagImageDigests(tc.expectSame)
+				if hash != sameHash {
+					t.Errorf("expected same hash, got %q vs %q", hash, sameHash)
+				}
+			}
+			if tc.expectDiff != nil {
+				diffHash := HashSpecTagImageDigests(tc.expectDiff)
+				if hash == diffHash {
+					t.Errorf("expected different hash, both got %q", hash)
+				}
+			}
+		})
+	}
+}
+func TestReferencePayloadTag(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "nightly release name",
+			input:  "4.17.0-0.nightly-2024-08-30-110931",
+			expect: "rc_payload__4.17.0-0.nightly-2024-08-30-110931",
+		},
+		{
+			name:   "ci release name",
+			input:  "4.17.0-0.ci-2024-08-30-110931",
+			expect: "rc_payload__4.17.0-0.ci-2024-08-30-110931",
+		},
+		{
+			name:   "simple name",
+			input:  "test",
+			expect: "rc_payload__test",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ReferencePayloadTag(tc.input)
+			if got != tc.expect {
+				t.Errorf("expected %q, got %q", tc.expect, got)
+			}
+			if !strings.HasPrefix(got, ReferencePayloadTagPrefix) {
+				t.Errorf("expected prefix %q, got %q", ReferencePayloadTagPrefix, got)
+			}
+		})
+	}
+}
+
+func TestReferenceRemovalTag(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "ci release name",
+			input:  "4.22.0-0.ci-2026-01-30-070825",
+			expect: "remove__rc_payload__4.22.0-0.ci-2026-01-30-070825",
+		},
+		{
+			name:   "nightly release name",
+			input:  "4.17.0-0.nightly-2024-08-30-110931",
+			expect: "remove__rc_payload__4.17.0-0.nightly-2024-08-30-110931",
+		},
+		{
+			name:   "simple name",
+			input:  "test",
+			expect: "remove__rc_payload__test",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ReferenceRemovalTag(tc.input)
+			if got != tc.expect {
+				t.Errorf("expected %q, got %q", tc.expect, got)
+			}
+			if !strings.HasPrefix(got, ReferenceRemovalTagPrefix) {
+				t.Errorf("expected prefix %q, got %q", ReferenceRemovalTagPrefix, got)
+			}
+			if !strings.HasPrefix(got, ReferenceRemovalTagPrefix+ReferencePayloadTagPrefix) {
+				t.Errorf("expected combined prefix %q, got %q", ReferenceRemovalTagPrefix+ReferencePayloadTagPrefix, got)
 			}
 		})
 	}


### PR DESCRIPTION
Introduce a new "Reference" payload type where release images are created directly in an external repository instead of a local imagestream. This enables release workflows that do not require a cluster-local copy of the payload.

Key changes:
- Add PayloadType (Local/Reference) to the ReleasePayload CRD
- Add ReferenceRelease config (push/pull repos, secret) to ReleaseConfig
- Create reference release jobs using oc adm release new with --from-image-stream-file to push payloads to external repos
- Add reference removal jobs that push remove__ prefixed tags to signal external cleanup tooling
- Centralize pull spec resolution via ReleasePullSpec() replacing hardcoded Target.Status.PublicDockerImageRepository references
- Compute content hashes from spec tag references for imagestreams with reference: true tags (status tags are never populated)
- Handle reference releases in mirror imagestream creation, prow job env injection, upgrade resolution, and HTTP API handlers
- Extract duplicated publishSpec/publishDescription logic into shared helpers in http_helper.go
- Add comprehensive tests for new and refactored functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reference-based releases, enabling alternative release configurations with external payload management and custom pull repositories.
  * Implemented reference release job creation and cleanup operations for release deployments and removals.

* **Bug Fixes**
  * Improved pull spec resolution consistency across changelog generation, upgrade tracking, and release verification.
  * Enhanced CLI image resolution with better fallback handling and configuration override support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->