### PR TITLE
release-controller: double rpmdb semaphore slots and add 120s oc timeout

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -51,7 +51,7 @@ const coreosExtensionsMetadataPath = "usr/share/rpm-ostree/extensions.json"
 
 // MaxConcurrentRpmdbOCCalls limits parallel `oc adm release info` invocations that use
 // --rpmdb / --rpmdb-diff (heavy image pulls and RPM work). Additional callers get a clear error.
-const MaxConcurrentRpmdbOCCalls = 8
+const MaxConcurrentRpmdbOCCalls = 16
 
 var (
 	ocPath = ""
@@ -399,10 +399,17 @@ func ocCmdRpmdb(args ...string) ([]byte, []byte, error) {
 		)
 	}
 	defer func() { <-RpmdbOCSlots }()
-	return ocCmd(args...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	return ocCmdCtx(ctx, "", args...)
 }
 
 func ocCmdExt(dir string, args ...string) ([]byte, []byte, error) {
+	return ocCmdCtx(context.Background(), dir, args...)
+}
+
+func ocCmdCtx(ctx context.Context, dir string, args ...string) ([]byte, []byte, error) {
 	var err error
 
 	if ocPath == "" {
@@ -412,7 +419,7 @@ func ocCmdExt(dir string, args ...string) ([]byte, []byte, error) {
 		}
 	}
 
-	cmd := exec.Command(ocPath, args...)
+	cmd := exec.CommandContext(ctx, ocPath, args...)
 	klog.V(4).Infof("Running oc command: %s", cmd.String())
 
 	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
@@ -429,6 +436,9 @@ func ocCmdExt(dir string, args ...string) ([]byte, []byte, error) {
 		msg := errOut.String()
 		if len(msg) == 0 {
 			msg = err.Error()
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, nil, fmt.Errorf("oc command timed out: %v", msg)
 		}
 		return nil, nil, fmt.Errorf("could not run oc command: %v", msg)
 	}


### PR DESCRIPTION
## Summary
- Increase `MaxConcurrentRpmdbOCCalls` from 8 to 16 to reduce "too many concurrent" rejections under moderate load
- Add a 120-second `context.WithTimeout` to rpmdb `oc` commands so hung processes release their semaphore slot instead of holding it indefinitely
- Extract `ocCmdCtx` helper using `exec.CommandContext` so non-rpmdb commands remain unaffected

## Test plan
- [ ] Verify release-controller builds cleanly
- [ ] Confirm rpmdb changelog pages load under concurrent access without "too many concurrent" errors
- [ ] Verify a hung `oc` process is killed after 120s and the semaphore slot is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection (120 seconds) with improved error messages for release info operations
  * Enhanced concurrent processing capacity for better performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->