### PR TITLE
Quiet chatty log message

### DIFF
--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -590,7 +590,7 @@ func GetVerificationJobs(rcCache *lru.Cache, eventRecorder record.EventRecorder,
 		return nil, fmt.Errorf("failed to get full stable verification jobs: %w", err)
 	}
 	isName := fmt.Sprintf("%d.%d%s", version.Major, version.Minor, artSuffix)
-	klog.Infof("Getting imagestream %s/%s", release.Target.Namespace, isName)
+	klog.V(7).Infof("Getting imagestream %s/%s", release.Target.Namespace, isName)
 	isLister := lister.ImageStreams(release.Target.Namespace)
 	if isLister == nil {
 		return nil, fmt.Errorf("failed to get imagestream %s", release.Target.Namespace)


### PR DESCRIPTION
This message generates a lot of noise in our logs and provides little value.  Gating it behind a higher log level

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity levels to reduce diagnostic message output at default log levels, improving log clarity during standard operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->