### PR TITLE
Add post-merge-verification label to issues that are verified-later

### DIFF
--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -19,6 +19,12 @@ import (
 	"sigs.k8s.io/prow/pkg/plugins"
 )
 
+const (
+	// postMergeVerificationLabel is the label that is added to a JIRA issue when a PR is merged
+	// without pre-merge verification. This allows us to filter issues that need to be manually verified.
+	postMergeVerificationLabel = "post-merge-verification"
+)
+
 type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	CreateComment(org, repo string, number int, comment string) error
@@ -85,6 +91,19 @@ func hasLabel(labels []github.Label, name string) bool {
 	return false
 }
 
+// hasJiraLabel checks if a JIRA issue already has the specified label
+func hasJiraLabel(issue *jiraBaseClient.Issue, labelName string) bool {
+	if issue.Fields == nil || issue.Fields.Labels == nil {
+		return false
+	}
+	for _, label := range issue.Fields.Labels {
+		if label == labelName {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {
 	// Get the comments from that PR
 	comments, err := c.ghClient.ListIssueComments(extPR.org, extPR.repo, extPR.prNum)
@@ -106,6 +125,35 @@ func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {
 		return err, false
 	}
 	return nil, true
+}
+
+// addJiraLabel adds a label to a JIRA issue if it doesn't already exist
+func (c *Verifier) addJiraLabel(issue *jiraBaseClient.Issue, labelName string) error {
+	if hasJiraLabel(issue, labelName) {
+		klog.V(4).Infof("Issue %s already has label '%s'; skipping", issue.Key, labelName)
+		return nil
+	}
+
+	// Create a copy of existing labels and append the new one
+	existingLabels := make([]string, len(issue.Fields.Labels))
+	copy(existingLabels, issue.Fields.Labels)
+	updatedLabels := append(existingLabels, labelName)
+
+	// Create update issue struct
+	tmpIssue := &jiraBaseClient.Issue{
+		Key: issue.Key,
+		Fields: &jiraBaseClient.IssueFields{
+			Labels: updatedLabels,
+		},
+	}
+
+	// Execute the update
+	if _, err := c.jiraClient.UpdateIssue(tmpIssue); err != nil {
+		return fmt.Errorf("failed to add label '%s' to issue %s: %w", labelName, issue.Key, err)
+	}
+
+	klog.V(4).Infof("Added label '%s' to issue %s", labelName, issue.Key)
+	return nil
 }
 
 func (c *Verifier) verifyExtPRs(issue *jiraBaseClient.Issue, extPRs []pr, errs *[]error, tagName string) (ticketMessage string, isSuccess, verifiedLater bool) {
@@ -176,6 +224,9 @@ func (c *Verifier) verifyExtPRs(issue *jiraBaseClient.Issue, extPRs []pr, errs *
 		if qaContact != nil && err == nil {
 			message = fmt.Sprintf("%s by %s", message, qaContact.DisplayName)
 		}
+
+		// For the legacy behaviour, a lack of qe approval is effectively verified later.
+		verifiedLater = true
 	} else {
 		success = true
 	}
@@ -354,6 +405,11 @@ func (c *Verifier) VerifyIssues(issues []string, tagName string) []error {
 		} else {
 			klog.V(4).Infof("Jira issue %s (current status %s) not approved by QA contact", issue.Key, issue.Fields.Status.Name)
 			if verifyLater {
+				// Add the post-merge-verification label
+				if err := c.addJiraLabel(issue, postMergeVerificationLabel); err != nil {
+					errs = append(errs, fmt.Errorf("failed to add %s label to issue %s: %w", postMergeVerificationLabel, issue.Key, err))
+				}
+
 				// Ensure we're not duplicating messages
 				if !strings.EqualFold(issue.Fields.Status.Name, jira.StatusOnQA) {
 					klog.V(4).Infof("Updating issue %s (current status %s) to ON_QA status", issue.ID, issue.Fields.Status.Name)

--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/andygrunwald/go-jira"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/github/fakegithub"
 	"sigs.k8s.io/prow/pkg/jira/fakejira"
@@ -31,10 +32,11 @@ type gitHubFakeClientData struct {
 }
 
 type expectedResult struct {
-	errors     []error
-	status     string
-	message    string
-	fixVersion string
+	errors                           []error
+	status                           string
+	message                          string
+	fixVersion                       string
+	expectPostMergeVerificationLabel bool
 }
 
 type fakeGHClient struct {
@@ -323,9 +325,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify:        "OCPBUGS-123",
 			tagName:              "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "",
-				message: "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				errors:                           nil,
+				status:                           "",
+				message:                          "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				expectPostMergeVerificationLabel: true,
 			},
 		},
 		{
@@ -340,9 +343,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify:        "OCPBUGS-123",
 			tagName:              "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "Verified",
-				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				errors:                           nil,
+				status:                           "Verified",
+				message:                          "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -355,9 +359,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "Verified",
-				message: "Fix included in release 4.10",
+				errors:                           nil,
+				status:                           "Verified",
+				message:                          "Fix included in release 4.10",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -370,9 +375,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.13.0-0.nightly-2022-11-12",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "Verified",
-				message: "Fix included in release 4.13.0-0.nightly-2022-11-12",
+				errors:                           nil,
+				status:                           "Verified",
+				message:                          "Fix included in release 4.13.0-0.nightly-2022-11-12",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -385,9 +391,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "In Progress",
-				message: "",
+				errors:                           nil,
+				status:                           "In Progress",
+				message:                          "",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -402,9 +409,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify:        "OCPBUGS-123",
 			tagName:              "4.12",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "In Progress",
-				message: "",
+				errors:                           nil,
+				status:                           "In Progress",
+				message:                          "",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -418,9 +426,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  []error{errors.New("internal Error on Automation")},
-				status:  "ON_QA",
-				message: "",
+				errors:                           []error{errors.New("internal Error on Automation")},
+				status:                           "ON_QA",
+				message:                          "",
+				expectPostMergeVerificationLabel: false,
 			},
 			labelsError: errors.New("injected error"),
 		},
@@ -439,9 +448,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "Verified",
-				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				errors:                           nil,
+				status:                           "Verified",
+				message:                          "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -458,9 +468,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "Verified",
-				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				errors:                           nil,
+				status:                           "Verified",
+				message:                          "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -475,9 +486,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify:        "OCPBUGS-123",
 			tagName:              "4.10",
 			expected: expectedResult{
-				errors:  nil,
-				status:  "Verified",
-				message: "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				errors:                           nil,
+				status:                           "Verified",
+				message:                          "Fix included in release 4.10\nAll linked GitHub PRs have been approved by a QA contact; updating bug status to VERIFIED",
+				expectPostMergeVerificationLabel: false,
 			},
 		},
 		{
@@ -495,9 +507,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  []error{},
-				status:  "ON_QA",
-				message: "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				errors:                           []error{},
+				status:                           "ON_QA",
+				message:                          "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				expectPostMergeVerificationLabel: true,
 			},
 		},
 		{
@@ -515,9 +528,10 @@ func TestVerifyIssues(t *testing.T) {
 			issueToVerify: "OCPBUGS-123",
 			tagName:       "4.10",
 			expected: expectedResult{
-				errors:  []error{},
-				status:  "ON_QA",
-				message: "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				errors:                           []error{},
+				status:                           "ON_QA",
+				message:                          "Fix included in release 4.10\nJira issue will not be automatically moved to VERIFIED for the following reasons:\n- PR openshift/vmware-vsphere-csi-driver-operator#105 not approved by the QA Contact\n\nThis issue must now be manually moved to VERIFIED by Jack Smith",
+				expectPostMergeVerificationLabel: true,
 			},
 		},
 	}
@@ -567,6 +581,15 @@ func TestVerifyIssues(t *testing.T) {
 				if len(jc.Issues[0].Fields.Comments.Comments) > 0 {
 					t.Errorf("A comment was made when none were expected")
 				}
+			}
+
+			// Verify post-merge-verification label expectation
+			hasPostMergeLabel := slices.Contains(jc.Issues[0].Fields.Labels, "post-merge-verification")
+			if tc.expected.expectPostMergeVerificationLabel && !hasPostMergeLabel {
+				t.Errorf("Expected 'post-merge-verification' label to be present, but it was not found in labels: %v", jc.Issues[0].Fields.Labels)
+			}
+			if !tc.expected.expectPostMergeVerificationLabel && hasPostMergeLabel {
+				t.Errorf("Expected 'post-merge-verification' label to be absent, but it was found in labels: %v", jc.Issues[0].Fields.Labels)
 			}
 		})
 	}


### PR DESCRIPTION
I would like to be able to filter in Jira for all issues that will not automatically transition to verified. As far as I can tell, this means that they have a PR with `verified-later` as a label.

This PR updates the logic to add a `post-merge-verification` label at the point where it currently comments on issues to be verified later. The label will be applied even to issues already ON_QA so I _think_ this should update all of the existing issues out there too, which helps me in my goal I think.

CC @bradmwilliams

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-merge verification label for improved tracking of issues requiring later verification.

* **Updates**
  * External pull request verification now leverages label-based tracking instead of status updates for enhanced clarity and workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->