### PR TITLE
cmd,pkg: add IsReferenceReleaseTag

### DIFF
--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -108,12 +108,13 @@ func pullSpecFromCoordinates(coords []v1alpha1.ReleaseCoordinates) string {
 }
 
 // resolveReleasePullSpec returns the pull spec for the given tag within the
-// release. For reference-based releases (external repo) it uses ReleasePullSpec;
-// for local releases it falls back to FindPublicImagePullSpec which handles
-// digest resolution and status-tag checking.
+// release. For reference-based tags (external repo) it uses ReleasePullSpec;
+// for local or legacy tags it falls back to FindPublicImagePullSpec which
+// handles digest resolution and status-tag checking.
 func resolveReleasePullSpec(release *releasecontroller.Release, tagName string) string {
-	if releasecontroller.IsReferenceRelease(release) {
-		return releasecontroller.ReleasePullSpec(release, tagName)
+	tag := releasecontroller.FindTagReference(release.Target, tagName)
+	if releasecontroller.IsReferenceReleaseTag(release, tag) {
+		return releasecontroller.ReleasePullSpec(release, tag)
 	}
 	return releasecontroller.FindPublicImagePullSpec(release.Target, tagName)
 }

--- a/cmd/release-controller-api/http_helper_test.go
+++ b/cmd/release-controller-api/http_helper_test.go
@@ -313,7 +313,7 @@ func TestResolveReleasePullSpec(t *testing.T) {
 		want    string
 	}{
 		{
-			name: "reference release with ReferenceRelease",
+			name: "reference tag in Target resolves to external repo",
 			release: &releasecontroller.Release{
 				Source: &imagev1.ImageStream{
 					Spec: imagev1.ImageStreamSpec{
@@ -323,6 +323,11 @@ func TestResolveReleasePullSpec(t *testing.T) {
 					},
 				},
 				Target: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "4.18.0-0.nightly-2025-01-01-000000", Reference: true},
+						},
+					},
 					Status: imagev1.ImageStreamStatus{
 						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
 					},
@@ -338,7 +343,7 @@ func TestResolveReleasePullSpec(t *testing.T) {
 			want: "quay.io/openshift-release-dev/ocp-release:rc_payload__4.18.0-0.nightly-2025-01-01-000000",
 		},
 		{
-			name: "reference release without ReferenceRelease falls back to FindPublicImagePullSpec",
+			name: "reference source but tag not in Target falls back to FindPublicImagePullSpec",
 			release: &releasecontroller.Release{
 				Source: &imagev1.ImageStream{
 					Spec: imagev1.ImageStreamSpec{
@@ -358,7 +363,48 @@ func TestResolveReleasePullSpec(t *testing.T) {
 						},
 					},
 				},
-				Config: &releasecontroller.ReleaseConfig{},
+				Config: &releasecontroller.ReleaseConfig{
+					ReferenceRelease: &releasecontroller.ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
+			},
+			tag:  "4.18.0-0.nightly-2025-01-01-000000",
+			want: "registry.ci.openshift.org/ocp/release:4.18.0-0.nightly-2025-01-01-000000",
+		},
+		{
+			name: "transitional: reference source but legacy tag (Reference false) resolves to local Target",
+			release: &releasecontroller.Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "cli", Reference: true},
+						},
+					},
+				},
+				Target: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{
+							{Name: "4.18.0-0.nightly-2025-01-01-000000", Reference: false},
+						},
+					},
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+						Tags: []imagev1.NamedTagEventList{
+							{
+								Tag:   "4.18.0-0.nightly-2025-01-01-000000",
+								Items: []imagev1.TagEvent{{DockerImageReference: "sha256:abc123", Generation: 1}},
+							},
+						},
+					},
+				},
+				Config: &releasecontroller.ReleaseConfig{
+					ReferenceRelease: &releasecontroller.ReferenceRelease{
+						PushRepository: "quay.io/openshift-release-dev/ocp-release",
+						PullRepository: "quay.io/openshift-release-dev/ocp-release",
+					},
+				},
 			},
 			tag:  "4.18.0-0.nightly-2025-01-01-000000",
 			want: "registry.ci.openshift.org/ocp/release:4.18.0-0.nightly-2025-01-01-000000",

--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -360,7 +360,7 @@ func (a *AuditTracker) Sync(release *releasecontroller.Release) {
 
 		id := releasecontroller.FindImageIDForTag(from, tag.Name)
 		// TODO: this should really be the digest
-		location := releasecontroller.ReleasePullSpec(release, tag.Name)
+		location := releasecontroller.ReleasePullSpec(release, &tag)
 		existing, ok := a.records[tag.Name]
 		if !ok {
 			a.records[tag.Name] = &AuditRecord{

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -256,8 +256,8 @@ func (c *Controller) syncJira(key queueKey) error {
 	// and it also allows us to handle the case where the imagestream fails to update below.
 	defer c.queue.AddAfter(key, time.Second)
 
-	prevPullSpec := releasecontroller.ReleasePullSpec(prevReleaseForPullSpec, prevTag.Name)
-	curPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
+	prevPullSpec := releasecontroller.ReleasePullSpec(prevReleaseForPullSpec, prevTag)
+	curPullSpec := releasecontroller.ReleasePullSpec(release, tag)
 	if len(prevPullSpec) == 0 || len(curPullSpec) == 0 ||
 		strings.HasPrefix(prevPullSpec, ":") || strings.HasPrefix(curPullSpec, ":") {
 		klog.V(4).Infof("jira: release target %s does not have a configured registry", release.Target.Name)

--- a/cmd/release-controller/legacy_results.go
+++ b/cmd/release-controller/legacy_results.go
@@ -92,10 +92,10 @@ func (c *Controller) syncLegacyResults(key queueKey) error {
 		// Ensure the existing state is preserved.  This is a big hammer, but it's the only way we have to guarantee that
 		// the ReleasePayload's status matches the status of the ImageStream's Annotation.
 		payloadType := v1alpha1.PayloadTypeLocal
-		if releasecontroller.IsReferenceRelease(release) {
+		if releasecontroller.IsReferenceReleaseTag(release, tag) {
 			payloadType = v1alpha1.PayloadTypeReference
 		}
-		releasePayload := newReleasePayload(release, tag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceImageStream, payloadType)
+		releasePayload := newReleasePayload(release, tag, tag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceImageStream, payloadType)
 		setPayloadOverride(tag, releasePayload)
 
 		// Create the payload

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -382,7 +382,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 				}
 				if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
 					go func() {
-						fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0].Name)
+						fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0])
 						if len(fromPullSpec) == 0 {
 							klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
 							return
@@ -393,7 +393,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 							return
 						}
 
-						toPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
+						toPullSpec := releasecontroller.ReleasePullSpec(release, tag)
 						if len(toPullSpec) == 0 {
 							klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
 							return
@@ -435,7 +435,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 		}
 
 		var job *batchv1.Job
-		if releasecontroller.IsReferenceRelease(release) {
+		if releasecontroller.IsReferenceReleaseTag(release, tag) {
 			job, err = c.ensureReferenceReleaseJob(release, tag.Name, mirror)
 		} else {
 			job, err = c.ensureReleaseJob(release, tag.Name, mirror)
@@ -460,7 +460,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 			}
 			if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
 				go func() {
-					fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0].Name)
+					fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0])
 					if len(fromPullSpec) == 0 {
 						klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
 						return
@@ -471,7 +471,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 						return
 					}
 
-					toPullSpec := releasecontroller.ReleasePullSpec(release, tag.Name)
+					toPullSpec := releasecontroller.ReleasePullSpec(release, tag)
 					if len(toPullSpec) == 0 {
 						klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
 						return

--- a/cmd/release-controller/sync_mirror.go
+++ b/cmd/release-controller/sync_mirror.go
@@ -61,7 +61,7 @@ func (c *Controller) ensureReleaseMirror(release *releasecontroller.Release, rel
 	switch {
 	case release.Config.As == releasecontroller.ReleaseConfigModeStable:
 		// stream will be populated later
-	case releasecontroller.HasReferenceSpecTags(release.Source):
+	case releasecontroller.IsReferenceRelease(release):
 		if err := calculateReferenceMirrorImageStream(release, is); err != nil {
 			return nil, err
 		}

--- a/cmd/release-controller/sync_release.go
+++ b/cmd/release-controller/sync_release.go
@@ -466,7 +466,11 @@ func (c *Controller) ensureReleaseMirrorJob(release *releasecontroller.Release, 
 		return nil, nil
 	}
 	return c.ensureJob(releaseMirrorJobName(name), nil, func() (*batchv1.Job, error) {
-		fromImage := releasecontroller.ReleasePullSpec(release, name)
+		tag := releasecontroller.FindTagReference(release.Target, name)
+		if tag == nil {
+			return nil, fmt.Errorf("tag %q not found in target imagestream %s/%s", name, release.Target.Namespace, release.Target.Name)
+		}
+		fromImage := releasecontroller.ReleasePullSpec(release, tag)
 		toImage := fmt.Sprintf("%s:%s", release.Config.AlternateImageRepository, name)
 
 		cliImage, err := releasecontroller.ResolveCLIImage(release, mirror)

--- a/cmd/release-controller/sync_release_payload.go
+++ b/cmd/release-controller/sync_release_payload.go
@@ -19,10 +19,10 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 		return nil, err
 	}
 	payloadType := v1alpha1.PayloadTypeLocal
-	if releasecontroller.IsReferenceRelease(release) {
+	if releasecontroller.IsReferenceReleaseTag(release, releaseTag) {
 		payloadType = v1alpha1.PayloadTypeReference
 	}
-	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceBuildFarm, payloadType), metav1.CreateOptions{})
+	payload, err := c.releasePayloadClient.ReleasePayloads(release.Target.Namespace).Create(context.TODO(), newReleasePayload(release, releaseTag, releaseTag.Name, c.jobNamespace, c.prowNamespace, verificationJobs, release.Config.Upgrade, v1alpha1.PayloadVerificationDataSourceBuildFarm, payloadType), metav1.CreateOptions{})
 	if err == nil {
 		klog.V(4).Infof("ReleasePayload: %s/%s created", payload.Namespace, payload.Name)
 		return payload, nil
@@ -33,7 +33,7 @@ func (c *Controller) ensureReleasePayload(release *releasecontroller.Release, re
 	return nil, err
 }
 
-func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, prowNamespace string, verificationJobs map[string]releasecontroller.ReleaseVerification, upgradeJobs map[string]releasecontroller.UpgradeVerification, dataSource v1alpha1.PayloadVerificationDataSource, payloadType v1alpha1.PayloadType) *v1alpha1.ReleasePayload {
+func newReleasePayload(release *releasecontroller.Release, tag *imagev1.TagReference, name, jobNamespace, prowNamespace string, verificationJobs map[string]releasecontroller.ReleaseVerification, upgradeJobs map[string]releasecontroller.UpgradeVerification, dataSource v1alpha1.PayloadVerificationDataSource, payloadType v1alpha1.PayloadType) *v1alpha1.ReleasePayload {
 	payload := v1alpha1.ReleasePayload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -66,7 +66,7 @@ func newReleasePayload(release *releasecontroller.Release, name, jobNamespace, p
 		},
 	}
 
-	if releasecontroller.IsReferenceRelease(release) {
+	if releasecontroller.IsReferenceReleaseTag(release, tag) {
 		payload.Spec.ReleaseCoordinates = []v1alpha1.ReleaseCoordinates{{
 			Repository: release.Config.ReferenceRelease.PullRepository,
 			Tag:        releasecontroller.ReferencePayloadTag(name),

--- a/cmd/release-controller/sync_release_payload_test.go
+++ b/cmd/release-controller/sync_release_payload_test.go
@@ -25,6 +25,7 @@ func TestNewReleasePayload(t *testing.T) {
 	testCases := []struct {
 		name             string
 		release          *releasecontroller.Release
+		releaseTag       *imagev1.TagReference
 		payloadName      string
 		jobNamespace     string
 		prowNamespace    string
@@ -898,6 +899,7 @@ func TestNewReleasePayload(t *testing.T) {
 					},
 				},
 			},
+			releaseTag:       &imagev1.TagReference{Name: "4.18.0-0.nightly-2025-01-01-000000", Reference: true},
 			payloadName:      "4.18.0-0.nightly-2025-01-01-000000",
 			jobNamespace:     "ci-release",
 			prowNamespace:    "ci",
@@ -1013,7 +1015,7 @@ func TestNewReleasePayload(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			payload := newReleasePayload(tc.release, tc.payloadName, tc.jobNamespace, tc.prowNamespace, tc.verificationJobs, tc.upgradeJobs, tc.dataSource, tc.payloadType)
+			payload := newReleasePayload(tc.release, tc.releaseTag, tc.payloadName, tc.jobNamespace, tc.prowNamespace, tc.verificationJobs, tc.upgradeJobs, tc.dataSource, tc.payloadType)
 			if !reflect.DeepEqual(payload, tc.expected) {
 				t.Errorf("%s: Expected %v, got %v", tc.name, tc.expected, payload)
 			}

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -184,7 +184,7 @@ func TestReleaseTagFromForReferenceRelease(t *testing.T) {
 			if releasecontroller.IsReferenceRelease(tc.release) {
 				tag.From = &corev1.ObjectReference{
 					Kind: "DockerImage",
-					Name: releasecontroller.ReleasePullSpec(tc.release, tag.Name),
+					Name: releasecontroller.ReleasePullSpec(tc.release, &tag),
 				}
 			}
 

--- a/cmd/release-controller/sync_release_reference_test.go
+++ b/cmd/release-controller/sync_release_reference_test.go
@@ -178,7 +178,7 @@ func TestReleaseTagFromForReferenceRelease(t *testing.T) {
 
 			tag := imagev1.TagReference{
 				Name:         tagName,
-				Reference:    releasecontroller.HasReferenceSpecTags(tc.release.Source),
+				Reference:    releasecontroller.IsReferenceRelease(tc.release),
 				ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 			}
 			if releasecontroller.IsReferenceRelease(tc.release) {

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -38,7 +38,7 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 	if releasecontroller.IsReferenceRelease(release) {
 		tag.From = &corev1.ObjectReference{
 			Kind: "DockerImage",
-			Name: releasecontroller.ReleasePullSpec(release, tag.Name),
+			Name: releasecontroller.ReleasePullSpec(release, &tag),
 		}
 	}
 	target.Spec.Tags = append(target.Spec.Tags, tag)
@@ -119,17 +119,27 @@ func (c *Controller) replaceReleaseTagWithNext(release *releasecontroller.Releas
 }
 
 func (c *Controller) removeReleaseTags(release *releasecontroller.Release, removeTags []*imagev1.TagReference) error {
-	if releasecontroller.IsReferenceRelease(release) {
-		allComplete, err := c.ensureReferenceRemovalTags(release, removeTags)
-		if err != nil {
-			return err
-		}
-		if !allComplete {
-			return nil
+	var referenceTags []*imagev1.TagReference
+	var tagsToDelete []*imagev1.TagReference
+	for _, tag := range removeTags {
+		if tag.Reference {
+			referenceTags = append(referenceTags, tag)
+		} else {
+			tagsToDelete = append(tagsToDelete, tag)
 		}
 	}
 
-	for _, tag := range removeTags {
+	if len(referenceTags) > 0 {
+		allComplete, err := c.ensureReferenceRemovalTags(release, referenceTags)
+		if err != nil {
+			return err
+		}
+		if allComplete {
+			tagsToDelete = append(tagsToDelete, referenceTags...)
+		}
+	}
+
+	for _, tag := range tagsToDelete {
 		ctx := context.TODO()
 		name := fmt.Sprintf("%s:%s", release.Target.Name, tag.Name)
 		if c.softDeleteReleaseTags {

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -32,7 +32,7 @@ func (c *Controller) createReleaseTag(release *releasecontroller.Release, now ti
 			releasecontroller.ReleaseAnnotationCreationTimestamp: now.Format(time.RFC3339),
 			releasecontroller.ReleaseAnnotationPhase:             releasecontroller.ReleasePhasePending,
 		},
-		Reference:    releasecontroller.HasReferenceSpecTags(release.Source),
+		Reference:    releasecontroller.IsReferenceRelease(release),
 		ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 	}
 	if releasecontroller.IsReferenceRelease(release) {

--- a/cmd/release-controller/sync_upgrade.go
+++ b/cmd/release-controller/sync_upgrade.go
@@ -35,7 +35,7 @@ func (c *Controller) ensureReleaseUpgradeJobs(release *releasecontroller.Release
 	if err != nil {
 		return fmt.Errorf("unable to determine platform distribution: %v", err)
 	}
-	pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag.Name)
+	pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag)
 	if len(pullSpec) == 0 {
 		return fmt.Errorf("unable to get determine pullSpec for for release: %s", releaseTag.Name)
 	}

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -160,12 +160,12 @@ func (c *Controller) getUpgradeTagAndPullSpec(release *releasecontroller.Release
 	case releasecontroller.ReleaseUpgradeFromPrevious:
 		if tags := releasecontroller.SortedReleaseTags(release, releasecontroller.ReleasePhaseAccepted); len(tags) > 0 {
 			previousTag = tags[0].Name
-			previousReleasePullSpec = releasecontroller.ReleasePullSpec(release, previousTag)
+			previousReleasePullSpec = releasecontroller.ReleasePullSpec(release, tags[0])
 		}
 	case releasecontroller.ReleaseUpgradeFromPreviousMinus1:
 		if tags := releasecontroller.SortedReleaseTags(release, releasecontroller.ReleasePhaseAccepted); len(tags) > 1 {
 			previousTag = tags[1].Name
-			previousReleasePullSpec = releasecontroller.ReleasePullSpec(release, previousTag)
+			previousReleasePullSpec = releasecontroller.ReleasePullSpec(release, tags[1])
 		}
 	case releasecontroller.ReleaseUpgradeFromPreviousMinor:
 		if version, err := semver.Parse(releaseTag.Name); err == nil && version.Minor > 0 {
@@ -196,7 +196,7 @@ func findLatestStableForVersion(ref *releasecontroller.StableReferences, version
 			if currentLatestRelease == nil || v.Version.Compare(*currentLatestRelease) > 0 {
 				currentLatestRelease = v.Version
 				latestTag = v.Tag.Name
-				latestPullSpec = releasecontroller.ReleasePullSpec(stable.Release, latestTag)
+				latestPullSpec = releasecontroller.ReleasePullSpec(stable.Release, v.Tag)
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 			return "", "", fmt.Errorf("failed to get latest tag in 4-stable stream: %w", err)
 		}
 		tag := latest.Name
-		pullSpec := releasecontroller.ReleasePullSpec(r, tag)
+		pullSpec := releasecontroller.ReleasePullSpec(r, latest)
 		return tag, pullSpec, nil
 	} else if upgradeRelease.Candidate != nil {
 		// create blank semver.Range
@@ -226,7 +226,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 			return "", "", fmt.Errorf("failed to get latest tag for stream %s: %w", stream, err)
 		}
 		tag := latest.Name
-		pullSpec := releasecontroller.ReleasePullSpec(r, tag)
+		pullSpec := releasecontroller.ReleasePullSpec(r, latest)
 		return tag, pullSpec, nil
 	} else if upgradeRelease.Official != nil {
 		httpClient := retryablehttp.NewClient()

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -174,7 +174,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			switch name := c.Env[j].Name; {
 			case name == "RELEASE_IMAGE_LATEST":
 				hasReleaseImage = true
-				c.Env[j].Value = releasecontroller.ReleasePullSpec(release, releaseTag.Name)
+				c.Env[j].Value = releasecontroller.ReleasePullSpec(release, releaseTag)
 			case name == "RELEASE_IMAGE_INITIAL":
 				if len(previousReleasePullSpec) == 0 {
 					return false, nil
@@ -205,7 +205,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			}
 		}
 		if !hasReleaseImage {
-			pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag.Name)
+			pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag)
 			switch architecture {
 			case "arm64":
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_LATEST", Value: pullSpec})
@@ -224,7 +224,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 			// If an initial release is specified in the ci-operator config, ci-operator will always try to pull it. This can cause jobs to fail
 			// if there are not at least 2 accepted releases for the release being tested. To prevent this issue, always set RELEASE_IMAGE_INITIAL,
 			// even for non-upgrade jobs
-			pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag.Name)
+			pullSpec := releasecontroller.ReleasePullSpec(release, releaseTag)
 			switch architecture {
 			case "arm64":
 				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_INITIAL", Value: pullSpec})

--- a/cmd/release-controller/sync_verify_prow.go
+++ b/cmd/release-controller/sync_verify_prow.go
@@ -182,7 +182,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 				hasUpgradeImage = true
 				c.Env[j].Value = previousReleasePullSpec
 			case name == "IMAGE_FORMAT":
-				if releasecontroller.HasReferenceSpecTags(release.Source) {
+				if releasecontroller.IsReferenceReleaseTag(release, releaseTag) {
 					break
 				}
 				if mirror == nil {
@@ -194,7 +194,7 @@ func addReleaseEnvToProwJobSpec(spec *prowjobv1.ProwJobSpec, release *releasecon
 				if len(suffix) == 0 {
 					break
 				}
-				if releasecontroller.HasReferenceSpecTags(release.Source) {
+				if releasecontroller.IsReferenceReleaseTag(release, releaseTag) {
 					break
 				}
 				if mirror == nil {

--- a/cmd/release-controller/sync_verify_prow_test.go
+++ b/cmd/release-controller/sync_verify_prow_test.go
@@ -201,7 +201,7 @@ func TestAddReleaseEnvToProwJobSpec_NonReference(t *testing.T) {
 
 func TestAddReleaseEnvToProwJobSpec_Reference(t *testing.T) {
 	release := newRelease(true, "quay.io/openshift-release-dev/ocp-release")
-	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true}
 	spec := prowjobv1.ProwJobSpec{
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "test"}},
@@ -228,7 +228,7 @@ func TestAddReleaseEnvToProwJobSpec_Reference(t *testing.T) {
 
 func TestAddReleaseEnvToProwJobSpec_ReferenceUpgrade(t *testing.T) {
 	release := newRelease(true, "quay.io/openshift-release-dev/ocp-release")
-	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true}
 	prevPullSpec := "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2024-12-31-000000"
 	spec := prowjobv1.ProwJobSpec{
 		PodSpec: &corev1.PodSpec{
@@ -295,7 +295,7 @@ func TestAddReleaseEnvToProwJobSpec_ArchVariants(t *testing.T) {
 					refRepo = "quay.io/openshift-release-dev/ocp-release"
 				}
 				release := newRelease(isRef, refRepo)
-				tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+				tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: isRef}
 				spec := prowjobv1.ProwJobSpec{
 					PodSpec: &corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "test"}},
@@ -341,7 +341,7 @@ func TestAddReleaseEnvToProwJobSpec_ArchVariants(t *testing.T) {
 
 func TestAddReleaseEnvToProwJobSpec_ExistingEnvVar(t *testing.T) {
 	release := newRelease(true, "quay.io/openshift-release-dev/ocp-release")
-	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000"}
+	tag := &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true}
 	spec := prowjobv1.ProwJobSpec{
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{{

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -624,6 +624,18 @@ func IsReferenceRelease(release *Release) bool {
 		release.Config.ReferenceRelease != nil
 }
 
+// IsReferenceReleaseTag returns true when an individual existing tag was
+// created as a reference-based tag (its own Reference field is true) and
+// the release config includes a ReferenceRelease. This should be used when
+// processing already-tagged releases to avoid misclassifying legacy tags that
+// remain in a stream after it has been converted to reference-based.
+func IsReferenceReleaseTag(release *Release, tag *imagev1.TagReference) bool {
+	return tag != nil &&
+		tag.Reference &&
+		release.Config != nil &&
+		release.Config.ReferenceRelease != nil
+}
+
 // ResolveCLIImage determines the CLI image to use for job creation.
 // For reference-based releases the CLI image is taken from the mirror's spec
 // tag "cli"; for traditional releases it comes from the mirror's
@@ -648,17 +660,23 @@ func ResolveCLIImage(release *Release, mirror *imagev1.ImageStream) (string, err
 }
 
 // ReleasePullSpec returns the correct pull spec for a release payload tag.
-// For reference-based releases the payload lives in the external ReferenceRepository;
-// for traditional releases it lives in the Target imagestream.
-func ReleasePullSpec(release *Release, tagName string) string {
-	if IsReferenceRelease(release) {
+// For reference-based tags the payload lives in the external ReferenceRepository;
+// for traditional tags it lives in the Target imagestream.
+// Pass the actual tag reference so that legacy tags in a transitioning stream
+// are resolved against the local Target rather than the external repository.
+// Returns an empty string if tag is nil.
+func ReleasePullSpec(release *Release, tag *imagev1.TagReference) string {
+	if tag == nil {
+		return ""
+	}
+	if IsReferenceReleaseTag(release, tag) {
 		if release.Config.ReferenceRelease.PullRepository == "" {
 			return ""
 		}
-		return fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PullRepository, ReferencePayloadTag(tagName))
+		return fmt.Sprintf("%s:%s", release.Config.ReferenceRelease.PullRepository, ReferencePayloadTag(tag.Name))
 	}
 	if release.Target.Status.PublicDockerImageRepository == "" {
 		return ""
 	}
-	return release.Target.Status.PublicDockerImageRepository + ":" + tagName
+	return release.Target.Status.PublicDockerImageRepository + ":" + tag.Name
 }

--- a/pkg/release-controller/release_test.go
+++ b/pkg/release-controller/release_test.go
@@ -254,45 +254,113 @@ func TestResolveCLIImage(t *testing.T) {
 	}
 }
 
+func TestIsReferenceReleaseTag(t *testing.T) {
+	testCases := []struct {
+		name     string
+		release  *Release
+		tag      *imagev1.TagReference
+		expected bool
+	}{
+		{
+			name: "nil tag returns false",
+			release: &Release{
+				Config: &ReleaseConfig{
+					ReferenceRelease: &ReferenceRelease{PullRepository: "quay.io/openshift-release-dev/ocp-release"},
+				},
+			},
+			tag:      nil,
+			expected: false,
+		},
+		{
+			name: "tag with Reference false returns false even in reference stream",
+			release: &Release{
+				Source: &imagev1.ImageStream{
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{{Name: "cli", Reference: true}},
+					},
+				},
+				Config: &ReleaseConfig{
+					ReferenceRelease: &ReferenceRelease{PullRepository: "quay.io/openshift-release-dev/ocp-release"},
+				},
+			},
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: false},
+			expected: false,
+		},
+		{
+			name: "tag with Reference true but nil ReferenceRelease config returns false",
+			release: &Release{
+				Config: &ReleaseConfig{},
+			},
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true},
+			expected: false,
+		},
+		{
+			name: "tag with Reference true and valid ReferenceRelease returns true",
+			release: &Release{
+				Config: &ReleaseConfig{
+					ReferenceRelease: &ReferenceRelease{PullRepository: "quay.io/openshift-release-dev/ocp-release"},
+				},
+			},
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true},
+			expected: true,
+		},
+		{
+			name: "nil Config returns false",
+			release: &Release{
+				Config: nil,
+			},
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true},
+			expected: false,
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsReferenceReleaseTag(tc.release, tc.tag)
+			if actual != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
 func TestReleasePullSpec(t *testing.T) {
 	testCases := []struct {
 		name     string
 		release  *Release
-		tagName  string
+		tag      *imagev1.TagReference
 		expected string
 	}{
 		{
-			name: "non-reference release uses Target pull spec",
+			name: "nil tag returns empty string",
 			release: &Release{
-				Source: &imagev1.ImageStream{
-					Spec: imagev1.ImageStreamSpec{
-						Tags: []imagev1.TagReference{
-							{Name: "cli"},
-						},
-					},
-				},
 				Target: &imagev1.ImageStream{
 					Status: imagev1.ImageStreamStatus{
 						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
 					},
 				},
-				Config: &ReleaseConfig{
-					Name: "4.17.0-0.nightly",
-				},
+				Config: &ReleaseConfig{Name: "4.17.0-0.nightly"},
 			},
-			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			tag:      nil,
+			expected: "",
+		},
+		{
+			name: "tag with Reference false uses Target pull spec",
+			release: &Release{
+				Target: &imagev1.ImageStream{
+					Status: imagev1.ImageStreamStatus{
+						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
+					},
+				},
+				Config: &ReleaseConfig{Name: "4.17.0-0.nightly"},
+			},
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: false},
 			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
 		},
 		{
-			name: "reference release uses ReferenceRelease with payload tag prefix",
+			name: "tag with Reference true and ReferenceRelease uses external repo",
 			release: &Release{
-				Source: &imagev1.ImageStream{
-					Spec: imagev1.ImageStreamSpec{
-						Tags: []imagev1.TagReference{
-							{Name: "cli", Reference: true},
-						},
-					},
-				},
 				Target: &imagev1.ImageStream{
 					Status: imagev1.ImageStreamStatus{
 						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
@@ -306,41 +374,25 @@ func TestReleasePullSpec(t *testing.T) {
 					},
 				},
 			},
-			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true},
 			expected: "quay.io/openshift-release-dev/ocp-release:rc_payload__4.17.0-0.nightly-2025-01-01-000000",
 		},
 		{
-			name: "reference tags but nil ReferenceRelease falls back to Target",
+			name: "tag with Reference true but nil ReferenceRelease config falls back to Target",
 			release: &Release{
-				Source: &imagev1.ImageStream{
-					Spec: imagev1.ImageStreamSpec{
-						Tags: []imagev1.TagReference{
-							{Name: "cli", Reference: true},
-						},
-					},
-				},
 				Target: &imagev1.ImageStream{
 					Status: imagev1.ImageStreamStatus{
 						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
 					},
 				},
-				Config: &ReleaseConfig{
-					Name: "4.17.0-0.nightly",
-				},
+				Config: &ReleaseConfig{Name: "4.17.0-0.nightly"},
 			},
-			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true},
 			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
 		},
 		{
-			name: "reference release with empty PullRepository returns empty string",
+			name: "tag with Reference true and empty PullRepository returns empty string",
 			release: &Release{
-				Source: &imagev1.ImageStream{
-					Spec: imagev1.ImageStreamSpec{
-						Tags: []imagev1.TagReference{
-							{Name: "cli", Reference: true},
-						},
-					},
-				},
 				Target: &imagev1.ImageStream{
 					Status: imagev1.ImageStreamStatus{
 						PublicDockerImageRepository: "registry.ci.openshift.org/ocp/release",
@@ -354,36 +406,29 @@ func TestReleasePullSpec(t *testing.T) {
 					},
 				},
 			},
-			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: true},
 			expected: "",
 		},
 		{
-			name: "non-reference release with empty PublicDockerImageRepository returns empty string",
+			name: "tag with Reference false and empty PublicDockerImageRepository returns empty string",
 			release: &Release{
-				Source: &imagev1.ImageStream{
-					Spec: imagev1.ImageStreamSpec{
-						Tags: []imagev1.TagReference{
-							{Name: "cli"},
-						},
-					},
-				},
 				Target: &imagev1.ImageStream{
 					Status: imagev1.ImageStreamStatus{
 						PublicDockerImageRepository: "",
 					},
 				},
-				Config: &ReleaseConfig{
-					Name: "4.17.0-0.nightly",
-				},
+				Config: &ReleaseConfig{Name: "4.17.0-0.nightly"},
 			},
-			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: false},
 			expected: "",
 		},
 		{
-			name: "no spec tags means non-reference",
+			name: "transitional: reference source but legacy tag (Reference false) resolves to local Target",
 			release: &Release{
 				Source: &imagev1.ImageStream{
-					Spec: imagev1.ImageStreamSpec{},
+					Spec: imagev1.ImageStreamSpec{
+						Tags: []imagev1.TagReference{{Name: "cli", Reference: true}},
+					},
 				},
 				Target: &imagev1.ImageStream{
 					Status: imagev1.ImageStreamStatus{
@@ -398,7 +443,7 @@ func TestReleasePullSpec(t *testing.T) {
 					},
 				},
 			},
-			tagName:  "4.17.0-0.nightly-2025-01-01-000000",
+			tag:      &imagev1.TagReference{Name: "4.17.0-0.nightly-2025-01-01-000000", Reference: false},
 			expected: "registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2025-01-01-000000",
 		},
 	}
@@ -406,7 +451,7 @@ func TestReleasePullSpec(t *testing.T) {
 	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := ReleasePullSpec(tc.release, tc.tagName)
+			actual := ReleasePullSpec(tc.release, tc.tag)
 			if actual != tc.expected {
 				t.Errorf("expected %q, got %q", tc.expected, actual)
 			}


### PR DESCRIPTION
Add a new `IsReferenceReleaseTag` function that determines whether an existing release was created as a reference-based release. This fixes an issue where an imagestream with pre-existing locally pushed releases is updated to have `reference: true` spec tags and a corresponding config. In these situations, the controller was trying to use the reference
pull-spec instead of the correct local one. All locations where `IsReferenceRelease` was used after the release tag has been created have been updated.

This also updates parts of the code to use `IsReferenceRelease` instead of `HasReferenceSpecTags` where it makes sense. This helps prevent some potential inconsistencies (though situations where these inconsistencies could have happened should have been blocked before reaching these parts of the code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved precision in determining image sources for reference releases by evaluating each release tag individually rather than the entire release, ensuring images are pulled from the correct repository.
  * Enhanced internal logic for resolving image pull specifications to use complete tag information instead of just tag names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->