### PR TITLE
Adding display elements for `ReleasePayloads` that have been Manually approved/rejected

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1282,6 +1282,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			h2 { font-size: 1.5rem; margin-top: 2rem; margin-bottom: 1rem  }
 			h3 { font-size: 1.35rem; margin-top: 2rem; margin-bottom: 1rem  }
 			h4 { font-size: 1.2rem; margin-top: 2rem; margin-bottom: 1rem  }
+			.alert h4.alert-heading { margin-top: 0; }
 			h3 a { text-transform: uppercase; font-size: 1rem; }
 			.mb-custom {
 			  margin-bottom: 0.5rem !important; /* use !important to override other margin-bottom styles */
@@ -1303,6 +1304,17 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		"</div>"+
 		"</div>"+
 		"</div>", template.HTMLEscapeString(tagInfo.Tag))
+
+	if payload := c.GetReleasePayload(tagInfo.Tag); payload != nil && payload.Spec.PayloadOverride.Reason != "" {
+		override := payload.Spec.PayloadOverride
+		fmt.Fprintf(w, `<div class="alert alert-warning">`+
+			`<h4 class="alert-heading"><i class="bi bi-exclamation-triangle-fill"></i> Manual Override Applied</h4>`+
+			`<p>This release was manually <strong>%s</strong>.</p>`+
+			`<hr><p class="mb-0"><strong>Reason:</strong> %s</p>`+
+			`</div>`,
+			template.HTMLEscapeString(string(override.Override)),
+			linkifyURLs(override.Reason))
+	}
 
 	switch tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase] {
 	case releasecontroller.ReleasePhaseFailed:
@@ -1647,7 +1659,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 			"tableLink":               c.tableLink,
 			"versionGrouping":         versionGrouping,
 			"streamNames":             streamNames,
-			"phaseCell":               phaseCell,
+			"phaseCell":               c.phaseCell,
 			"phaseAlert":              phaseAlert,
 			"alerts":                  renderAlerts,
 			"links":                   c.links,
@@ -1887,7 +1899,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 			"tableLink":               c.tableLink,
 			"versionGrouping":         versionGrouping,
 			"streamNames":             streamNames,
-			"phaseCell":               phaseCell,
+			"phaseCell":               c.phaseCell,
 			"phaseAlert":              phaseAlert,
 			"alerts":                  renderAlerts,
 			"links":                   c.links,
@@ -2035,7 +2047,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 				return ""
 			},
 			"tableLink":      c.tableLink,
-			"phaseCell":      phaseCell,
+			"phaseCell":      c.phaseCell,
 			"phaseAlert":     phaseAlert,
 			"inc":            func(i int) int { return i + 1 },
 			"upgradeJobs":    upgradeJobs,

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -25,6 +26,16 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 )
+
+var urlRegexp = regexp.MustCompile(`https?://[^\s<>"]*[^\s<>").,:;!?]`)
+
+// linkifyURLs HTML-escapes the input text, then converts any URLs into clickable links.
+func linkifyURLs(s string) string {
+	escaped := template.HTMLEscapeString(s)
+	return urlRegexp.ReplaceAllStringFunc(escaped, func(u string) string {
+		return fmt.Sprintf(`<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>`, u, u)
+	})
+}
 
 type ReleasePage struct {
 	BaseURL      string
@@ -118,17 +129,32 @@ func resolveReleasePullSpec(release *releasecontroller.Release, tagName string) 
 	return releasecontroller.FindPublicImagePullSpec(release.Target, tagName)
 }
 
-func phaseCell(tag imagev1.TagReference) string {
+func (c *Controller) phaseCell(tag imagev1.TagReference) string {
 	phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
-	switch phase {
-	case releasecontroller.ReleasePhaseRejected:
+	alert := phaseAlert(tag)
+
+	var title string
+	var overridden bool
+	if payload := c.GetReleasePayload(tag.Name); payload != nil && payload.Spec.PayloadOverride.Reason != "" {
+		title = payload.Spec.PayloadOverride.Reason
+		overridden = true
+	} else if phase == releasecontroller.ReleasePhaseRejected {
+		title = tag.Annotations[releasecontroller.ReleaseAnnotationMessage]
+	}
+
+	display := template.HTMLEscapeString(phase)
+	if overridden {
+		display += "*"
+	}
+
+	if title != "" {
 		return fmt.Sprintf("<td class=\"%s\" title=\"%s\">%s</td>",
-			phaseAlert(tag),
-			template.HTMLEscapeString(tag.Annotations[releasecontroller.ReleaseAnnotationMessage]),
-			template.HTMLEscapeString(phase),
+			alert,
+			template.HTMLEscapeString(title),
+			display,
 		)
 	}
-	return fmt.Sprintf("<td class=\"%s\">", phaseAlert(tag)) + template.HTMLEscapeString(phase) + "</td>"
+	return fmt.Sprintf("<td class=\"%s\">%s</td>", alert, display)
 }
 
 func phaseAlert(tag imagev1.TagReference) string {


### PR DESCRIPTION
Releases that have been manually overridden will now show with an asterisk, and a tooltip of the reason, on the release listing page:
<img width="1246" height="522" alt="Screenshot From 2026-05-21 14-39-13" src="https://github.com/user-attachments/assets/1a74e5fd-ebc5-411a-9629-31c4a5d3c2ef" />


On the release summary page, a new informational block will be displayed showing that this release was manually overridden and any reason associated with the override:

* Manually `Accepted` release
<img width="1195" height="397" alt="Screenshot From 2026-05-21 14-56-05" src="https://github.com/user-attachments/assets/324c1791-7f05-4b67-a946-1c2424772a57" />

* Manually `Rejected` release
<img width="1195" height="397" alt="Screenshot From 2026-05-21 14-57-27" src="https://github.com/user-attachments/assets/87f39b41-74aa-418c-96e9-6fc50d66c866" />

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URLs in release info are now clickable links.
  * Manual overrides show a warning banner and an asterisk marking overridden payloads.
  * Hoverable tooltips added for rejection messages and override details.

* **Style**
  * Improved spacing for alert headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->