### PR TITLE
OCPCRT-458: Add node image RPM diff to release info API response

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -668,7 +668,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	var changeLog []byte
 	var changeLogJson releasecontroller.ChangeLog
-	var rpmDiff *releasecontroller.RpmDiff
+	var nodeImageStreams []releasecontroller.APINodeImageStream
 
 	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 {
 		var wg sync.WaitGroup
@@ -691,12 +691,42 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
+			streams, err := c.releaseInfo.ListMachineOSStreams(tagInfo.TagPullSpec)
 			if err != nil {
-				klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+				klog.V(4).Infof("Unable to list machine-OS streams for %s: %v", tagInfo.Tag, err)
+			}
+
+			if len(streams) == 0 {
+				diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
+				if err != nil {
+					klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+					return
+				}
+				nodeImageStreams = []releasecontroller.APINodeImageStream{{
+					Name:    "Red Hat Enterprise Linux CoreOS",
+					Tag:     "rhel-coreos",
+					RpmDiff: &diff,
+				}}
 				return
 			}
-			rpmDiff = &diff
+
+			result := make([]releasecontroller.APINodeImageStream, 0, len(streams))
+			for _, stream := range streams {
+				entry := releasecontroller.APINodeImageStream{
+					Name: stream.DisplayName,
+					Tag:  stream.Tag,
+				}
+				if _, errFrom := c.releaseInfo.ImageReferenceForComponent(tagInfo.PreviousTagPullSpec, stream.Tag); errFrom == nil {
+					diff, err := c.releaseInfo.RpmDiffForStream(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec, stream.Tag)
+					if err != nil {
+						klog.V(4).Infof("Unable to retrieve RPM diff for stream %s in %s: %v", stream.Tag, tagInfo.Tag, err)
+					} else {
+						entry.RpmDiff = &diff
+					}
+				}
+				result = append(result, entry)
+			}
+			nodeImageStreams = result
 		}()
 
 		wg.Wait()
@@ -719,14 +749,14 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	summary := releasecontroller.APIReleaseInfo{
-		Name:             tagInfo.Tag,
-		Phase:            tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
-		Results:          verificationJobs,
-		UpgradesTo:       c.graph.UpgradesTo(tagInfo.Tag),
-		UpgradesFrom:     c.graph.UpgradesFrom(tagInfo.Tag),
-		ChangeLog:        changeLog,
-		ChangeLogJson:    changeLogJson,
-		NodeImageRpmDiff: rpmDiff,
+		Name:            tagInfo.Tag,
+		Phase:           tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
+		Results:         verificationJobs,
+		UpgradesTo:      c.graph.UpgradesTo(tagInfo.Tag),
+		UpgradesFrom:    c.graph.UpgradesFrom(tagInfo.Tag),
+		ChangeLog:       changeLog,
+		ChangeLogJson:   changeLogJson,
+		NodeImageStreams: nodeImageStreams,
 	}
 
 	data, err := json.MarshalIndent(&summary, "", "  ")

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -668,6 +668,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 
 	var changeLog []byte
 	var changeLogJson releasecontroller.ChangeLog
+	var rpmDiff *releasecontroller.RpmDiff
 
 	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 {
 		var wg sync.WaitGroup
@@ -686,6 +687,18 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				c.changeLogWorker(result, tagInfo, format)
 			}()
 		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
+			if err != nil {
+				klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+				return
+			}
+			rpmDiff = &diff
+		}()
+
 		wg.Wait()
 
 		if renderHTML.err == nil {
@@ -706,13 +719,14 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	summary := releasecontroller.APIReleaseInfo{
-		Name:          tagInfo.Tag,
-		Phase:         tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
-		Results:       verificationJobs,
-		UpgradesTo:    c.graph.UpgradesTo(tagInfo.Tag),
-		UpgradesFrom:  c.graph.UpgradesFrom(tagInfo.Tag),
-		ChangeLog:     changeLog,
-		ChangeLogJson: changeLogJson,
+		Name:             tagInfo.Tag,
+		Phase:            tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
+		Results:          verificationJobs,
+		UpgradesTo:       c.graph.UpgradesTo(tagInfo.Tag),
+		UpgradesFrom:     c.graph.UpgradesFrom(tagInfo.Tag),
+		ChangeLog:        changeLog,
+		ChangeLogJson:    changeLogJson,
+		NodeImageRpmDiff: rpmDiff,
 	}
 
 	data, err := json.MarshalIndent(&summary, "", "  ")

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -460,6 +460,17 @@ func (c *Controller) userInterfaceHandler() http.Handler {
 //	return status
 //}
 
+type httpError struct {
+	status int
+	err    error
+}
+
+func (e *httpError) Error() string { return e.err.Error() }
+
+func newHTTPError(status int, format string, args ...any) *httpError {
+	return &httpError{status: status, err: fmt.Errorf(format, args...)}
+}
+
 type FeatureTree struct {
 	IssueKey        string         `json:"key"`
 	Summary         string         `json:"summary"`
@@ -669,6 +680,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	var changeLog []byte
 	var changeLogJson releasecontroller.ChangeLog
 	var nodeImageStreams []releasecontroller.APINodeImageStream
+	var nodeImageErr *httpError
 
 	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 {
 		var wg sync.WaitGroup
@@ -693,13 +705,14 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			defer wg.Done()
 			streams, err := c.releaseInfo.ListMachineOSStreams(tagInfo.TagPullSpec)
 			if err != nil {
-				klog.V(4).Infof("Unable to list machine-OS streams for %s: %v", tagInfo.Tag, err)
+				nodeImageErr = newHTTPError(http.StatusInternalServerError, "listing machine-OS streams for %s: %w", tagInfo.Tag, err)
+				return
 			}
 
 			if len(streams) == 0 {
 				diff, err := c.releaseInfo.RpmDiff(tagInfo.PreviousTagPullSpec, tagInfo.TagPullSpec)
 				if err != nil {
-					klog.V(4).Infof("Unable to retrieve RPM diff for %s: %v", tagInfo.Tag, err)
+					nodeImageErr = newHTTPError(http.StatusInternalServerError, "RPM diff for %s: %w", tagInfo.Tag, err)
 					return
 				}
 				nodeImageStreams = []releasecontroller.APINodeImageStream{{
@@ -710,8 +723,27 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				return
 			}
 
+			// Acquire a single semaphore slot for all stream operations,
+			// matching the HTML path (pkg/rhcos/node_image.go).
+			// RpmDiffForStream with a non-empty tag uses ocCmd (no
+			// semaphore), so without this guard concurrent API requests
+			// could spawn unbounded oc processes.
+			select {
+			case releasecontroller.RpmdbOCSlots <- struct{}{}:
+			default:
+				nodeImageErr = newHTTPError(http.StatusTooManyRequests,
+					"too many concurrent rpmdb operations (limit %d)",
+					releasecontroller.MaxConcurrentRpmdbOCCalls,
+				)
+				return
+			}
+			defer func() { <-releasecontroller.RpmdbOCSlots }()
+
 			result := make([]releasecontroller.APINodeImageStream, 0, len(streams))
 			for _, stream := range streams {
+				if req.Context().Err() != nil {
+					return
+				}
 				entry := releasecontroller.APINodeImageStream{
 					Name: stream.DisplayName,
 					Tag:  stream.Tag,
@@ -730,6 +762,15 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		}()
 
 		wg.Wait()
+
+		if nodeImageErr != nil {
+			klog.V(2).Infof("Node image RPM diff failed: %v", nodeImageErr)
+			if nodeImageErr.status == http.StatusTooManyRequests {
+				w.Header().Set("Retry-After", "60")
+			}
+			http.Error(w, nodeImageErr.Error(), nodeImageErr.status)
+			return
+		}
 
 		if renderHTML.err == nil {
 			result := blackfriday.Run([]byte(renderHTML.out))

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -54,8 +54,18 @@ type APIReleaseInfo struct {
 	ChangeLog []byte `json:"changeLog,omitempty"`
 	//ChangeLogJson is the json representation of the changes included in this release tag
 	ChangeLogJson ChangeLog `json:"changeLogJson,omitempty"`
-	// NodeImageRpmDiff is the RPM package diff between the previous and current node images
-	NodeImageRpmDiff *RpmDiff `json:"nodeImageRpmDiff,omitempty"`
+	// NodeImageStreams contains per-stream RPM diffs for each machine-OS image (e.g. rhel-coreos, rhel-coreos-10).
+	NodeImageStreams []APINodeImageStream `json:"nodeImageStreams,omitempty"`
+}
+
+// APINodeImageStream holds RPM diff information for a single machine-OS stream in a release payload.
+type APINodeImageStream struct {
+	// Name is the human-readable display name (e.g. "Red Hat Enterprise Linux CoreOS").
+	Name string `json:"name"`
+	// Tag is the payload component tag (e.g. "rhel-coreos", "rhel-coreos-10").
+	Tag string `json:"tag"`
+	// RpmDiff is the RPM package diff between previous and current releases for this stream.
+	RpmDiff *RpmDiff `json:"rpmDiff,omitempty"`
 }
 
 // Release holds information about the release used during processing.

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -54,6 +54,8 @@ type APIReleaseInfo struct {
 	ChangeLog []byte `json:"changeLog,omitempty"`
 	//ChangeLogJson is the json representation of the changes included in this release tag
 	ChangeLogJson ChangeLog `json:"changeLogJson,omitempty"`
+	// NodeImageRpmDiff is the RPM package diff between the previous and current node images
+	NodeImageRpmDiff *RpmDiff `json:"nodeImageRpmDiff,omitempty"`
 }
 
 // Release holds information about the release used during processing.


### PR DESCRIPTION
## Summary

- Adds `nodeImageStreams` field to the `APIReleaseInfo` struct, exposing per-stream RPM diffs (changed/added/removed packages) in the JSON API response
- This data was previously only available on the HTML page but missing from the API
- The RPM diff is fetched concurrently alongside the existing changelog generation, so it adds no additional latency
- For payloads with multiple machine-OS streams (e.g. rhel-coreos + rhel-coreos-10), each stream gets its own entry with an optional RPM diff
- For payloads without multiple streams, falls back to a single RPM diff wrapped in one entry

### Semaphore protection

Adds the same semaphore guard that the HTML path (`pkg/rhcos/node_image.go`) uses to the API's multi-stream RPM diff logic:

- `RpmDiffForStream` with a non-empty tag calls `ocCmd` directly (bypassing `ocCmdRpmdb` and its semaphore), so without an explicit guard concurrent API requests during cache-miss windows could spawn unbounded `oc` processes — the same class of issue that caused the production incident after #749
- When all semaphore slots are busy, the API returns **429 Too Many Requests** with a `Retry-After: 60` header so clients can back off
- The zero-streams fallback path (`RpmDiff`) already uses `ocCmdRpmdb` internally, so it's already protected

Supersedes #750.

Sample output:

```json
  "nodeImageStreams": [
    {
      "name": "Red Hat Enterprise Linux CoreOS",
      "tag": "rhel-coreos",
      "rpmDiff": {
        "changed": {
          "kernel": {
            "old": "6.12.0-211.5.1.el10_2",
            "new": "6.12.0-211.6.1.el10_2"
          }
        }
      }
    }
  ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release API now includes per-node image RPM diffs for machine OS streams in release info responses, showing per-stream diff results where available.

* **Updates**
  * When concurrency limits are hit while computing node-image diffs, the API returns HTTP 429 Too Many Requests with a Retry-After: 60 header to signal backoff and protect system resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->