### PR TITLE
Adding Jira Bot's email address to prevent duplicate messages

### DIFF
--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -246,7 +246,7 @@ func (c *Verifier) commentIssue(errs *[]error, issue *jiraBaseClient.Issue, mess
 	for _, comment := range issue.Fields.Comments.Comments {
 		// if a ticket is on the verified state but does not contain a comment from the bot, it will add one
 		// if a manually verified ticket is already commented, we won't check the message body
-		if (comment.Body == message || strings.EqualFold(issue.Fields.Status.Name, jira.StatusVerified)) && (comment.Author.Name == "openshift-crt-jira-release-controller" || comment.Author.EmailAddress == "brawilli+openshift-crt-jira-release-controller@redhat.com" || comment.Author.EmailAddress == "brawilli@redhat.com") {
+		if (comment.Body == message || strings.EqualFold(issue.Fields.Status.Name, jira.StatusVerified)) && (comment.Author.Name == "openshift-crt-jira-release-controller" || comment.Author.EmailAddress == "brawilli+openshift-crt-jira-release-controller@redhat.com" || comment.Author.EmailAddress == "brawilli@redhat.com" || comment.Author.EmailAddress == "openshift-release-controller-jira-bot@redhat.com") {
 			return
 		}
 	}


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue causing duplicate JIRA comments when release automation updates issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->