### PR TITLE
New `format=short` option for the ReleaseInfo API

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -666,6 +666,12 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { klog.V(4).Infof("rendered in %s", time.Since(start)) }()
 
+	generateChangelog := false
+	format := req.URL.Query().Get("format")
+	if strings.ToLower(format) != "short" {
+		generateChangelog = true
+	}
+
 	tagInfo, err := c.getReleaseTagInfo(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
@@ -682,7 +688,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	var nodeImageStreams []releasecontroller.APINodeImageStream
 	var nodeImageErr *httpError
 
-	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 {
+	if tagInfo.Info.Previous != nil && len(tagInfo.PreviousTagPullSpec) > 0 && len(tagInfo.TagPullSpec) > 0 && generateChangelog {
 		var wg sync.WaitGroup
 		renderHTML := renderResult{}
 		renderJSON := renderResult{}
@@ -790,13 +796,13 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	summary := releasecontroller.APIReleaseInfo{
-		Name:            tagInfo.Tag,
-		Phase:           tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
-		Results:         verificationJobs,
-		UpgradesTo:      c.graph.UpgradesTo(tagInfo.Tag),
-		UpgradesFrom:    c.graph.UpgradesFrom(tagInfo.Tag),
-		ChangeLog:       changeLog,
-		ChangeLogJson:   changeLogJson,
+		Name:             tagInfo.Tag,
+		Phase:            tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationPhase],
+		Results:          verificationJobs,
+		UpgradesTo:       c.graph.UpgradesTo(tagInfo.Tag),
+		UpgradesFrom:     c.graph.UpgradesFrom(tagInfo.Tag),
+		ChangeLog:        changeLog,
+		ChangeLogJson:    changeLogJson,
 		NodeImageStreams: nodeImageStreams,
 	}
 


### PR DESCRIPTION
Option to generate the `ReleaseInfo` API without any of the Changelog logic getting invoked.

Can be accessed via:
`/api/v1/releasestream/{release}/release/{tag}?format=short`

Like:
https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/release/4.22.0?format=short

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `format=short` query parameter to the release API endpoint, allowing users to retrieve release information without changelog data for faster responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->