### PR TITLE
Update build root and run go fix

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,5 @@ build_root_image:
   use_build_cache: true
   namespace: openshift
   name: release
-  tag: rhel-9-release-golang-1.25-openshift-4.23
+  tag: rhel-9-release-golang-1.26-openshift-5.0
+

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -697,18 +697,14 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			"html": &renderHTML,
 			"json": &renderJSON,
 		} {
-			wg.Add(1)
 			format := k
 			result := v
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				c.changeLogWorker(result, tagInfo, format)
-			}()
+			})
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			streams, err := c.releaseInfo.ListMachineOSStreams(tagInfo.TagPullSpec)
 			if err != nil {
 				nodeImageErr = newHTTPError(http.StatusInternalServerError, "listing machine-OS streams for %s: %w", tagInfo.Tag, err)
@@ -765,7 +761,7 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				result = append(result, entry)
 			}
 			nodeImageStreams = result
-		}()
+		})
 
 		wg.Wait()
 
@@ -1851,40 +1847,40 @@ func (c *Controller) renderTeamApprovals(tag string, asList bool) string {
 	teamName := func(fullLabel string) string {
 		return strings.ToUpper(strings.Split(strings.TrimSuffix(fullLabel, "_state"), "/")[1])
 	}
-	var approvals string
+	var approvals strings.Builder
 	if asList {
-		approvals += "<ul>"
+		approvals.WriteString("<ul>")
 	}
 	if len(acceptedLabels) > 0 {
 		if asList {
-			approvals += "<li>"
+			approvals.WriteString("<li>")
 		}
-		approvals += "<span class=\"text-success\">Accepted</span><ul>"
+		approvals.WriteString("<span class=\"text-success\">Accepted</span><ul>")
 		for _, anno := range acceptedLabels {
-			approvals += "<li>" + teamName(anno) + "</li>"
+			approvals.WriteString("<li>" + teamName(anno) + "</li>")
 		}
-		approvals += "</ul>"
+		approvals.WriteString("</ul>")
 		if asList {
-			approvals += "</li>"
+			approvals.WriteString("</li>")
 		}
 	}
 	if len(rejectedLabels) > 0 {
 		if asList {
-			approvals += "<li>"
+			approvals.WriteString("<li>")
 		}
-		approvals += "<span class=\"text-danger\">Rejected</span><ul>"
+		approvals.WriteString("<span class=\"text-danger\">Rejected</span><ul>")
 		for _, anno := range rejectedLabels {
-			approvals += "<li>" + teamName(anno) + "</li>"
+			approvals.WriteString("<li>" + teamName(anno) + "</li>")
 		}
-		approvals += "</ul>"
+		approvals.WriteString("</ul>")
 		if asList {
-			approvals += "</li>"
+			approvals.WriteString("</li>")
 		}
 	}
 	if asList {
-		approvals += "</ul>"
+		approvals.WriteString("</ul>")
 	}
-	return approvals
+	return approvals.String()
 }
 
 func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Request) {

--- a/pkg/cmd/release-mirror-cleanup-controller/controller.go
+++ b/pkg/cmd/release-mirror-cleanup-controller/controller.go
@@ -66,11 +66,11 @@ func (c *MirrorCleanupController) sync(ctx context.Context) {
 	if err != nil {
 		klog.Errorf("Failed to list releases: %s", err)
 	}
-	isNames := ""
+	var isNames strings.Builder
 	for _, stream := range streams {
-		isNames += stream.Name + ", "
+		isNames.WriteString(stream.Name + ", ")
 	}
-	klog.V(3).Infof("List of imagestreams being checked: %s", strings.TrimSuffix(isNames, ", "))
+	klog.V(3).Infof("List of imagestreams being checked: %s", strings.TrimSuffix(isNames.String(), ", "))
 	klog.V(3).Infof("Identifying release tags and alternate repos")
 	alternateRepos := sets.New[string]()
 	validTags := sets.New[string]()

--- a/pkg/cmd/release-reimport-controller/controller.go
+++ b/pkg/cmd/release-reimport-controller/controller.go
@@ -52,11 +52,11 @@ func (c *ImageReimportController) sync() {
 	if err != nil {
 		klog.Errorf("Failed to list releases: %s", err)
 	}
-	isNames := ""
+	var isNames strings.Builder
 	for _, stream := range streams {
-		isNames += stream.Name + ", "
+		isNames.WriteString(stream.Name + ", ")
 	}
-	klog.V(3).Infof("List of imagestreams being checked: %s", strings.TrimSuffix(isNames, ", "))
+	klog.V(3).Infof("List of imagestreams being checked: %s", strings.TrimSuffix(isNames.String(), ", "))
 	for _, stream := range streams {
 		// only handle release imagestreams
 		if _, ok := stream.Annotations[releasecontroller.ReleaseAnnotationConfig]; !ok {

--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -13,7 +14,6 @@ import (
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/jira"
 	"sigs.k8s.io/prow/pkg/plugins"
@@ -96,12 +96,7 @@ func hasJiraLabel(issue *jiraBaseClient.Issue, labelName string) bool {
 	if issue.Fields == nil || issue.Fields.Labels == nil {
 		return false
 	}
-	for _, label := range issue.Fields.Labels {
-		if label == labelName {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(issue.Fields.Labels, labelName)
 }
 
 func (c *Verifier) commentOnPR(extPR pr, message string) (error, bool) {

--- a/pkg/jira/jira_test.go
+++ b/pkg/jira/jira_test.go
@@ -1241,13 +1241,10 @@ func TestSumMapValues(t *testing.T) {
 func TestSimpleBackoff(t *testing.T) {
 	retryWaitMin := 1 * time.Second
 	retryWaitMax := 30 * time.Second
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		t.Run(fmt.Sprintf("Attempt-%d", i), func(t *testing.T) {
 			got := simpleBackOff(retryWaitMin, retryWaitMax, i)
-			expect := time.Duration(math.Pow(2, float64(i)) * float64(retryWaitMin))
-			if expect >= retryWaitMax {
-				expect = retryWaitMax
-			}
+			expect := min(time.Duration(math.Pow(2, float64(i))*float64(retryWaitMin)), retryWaitMax)
 			if got != expect {
 				t.Errorf("expect: %s, but got: %s", expect, got)
 			}

--- a/pkg/release-controller/machine_os_tags.go
+++ b/pkg/release-controller/machine_os_tags.go
@@ -97,11 +97,11 @@ func machineOSDisplayNameFromAnnotations(annotations map[string]string) string {
 		return ""
 	}
 	// Typical: "machine-os=Red Hat Enterprise Linux CoreOS" (single pair).
-	for _, part := range strings.Split(v, ",") {
+	for part := range strings.SplitSeq(v, ",") {
 		part = strings.TrimSpace(part)
 		const prefix = "machine-os="
-		if strings.HasPrefix(part, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(part, prefix))
+		if after, ok := strings.CutPrefix(part, prefix); ok {
+			return strings.TrimSpace(after)
 		}
 	}
 	return ""

--- a/pkg/release-controller/prowjob.go
+++ b/pkg/release-controller/prowjob.go
@@ -49,8 +49,8 @@ func truncateProwJobResultsURL(url string) string {
 	if len(url) == 0 {
 		return url
 	}
-	if strings.HasPrefix(url, ProwJobResultsURLPrefix) {
-		return strings.TrimPrefix(url, ProwJobResultsURLPrefix)
+	if after, ok := strings.CutPrefix(url, ProwJobResultsURLPrefix); ok {
+		return after
 	}
 	klog.Warningf("Unknown prowjob result URL prefix: %s", url)
 	return url

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -53,7 +53,7 @@ type APIReleaseInfo struct {
 	//ChangeLog is the html representation of the changes included in this release tag
 	ChangeLog []byte `json:"changeLog,omitempty"`
 	//ChangeLogJson is the json representation of the changes included in this release tag
-	ChangeLogJson ChangeLog `json:"changeLogJson,omitempty"`
+	ChangeLogJson ChangeLog `json:"changeLogJson"`
 	// NodeImageStreams contains per-stream RPM diffs for each machine-OS image (e.g. rhel-coreos, rhel-coreos-10).
 	NodeImageStreams []APINodeImageStream `json:"nodeImageStreams,omitempty"`
 }


### PR DESCRIPTION
Update build root image to golang 1.26 and run the `go fix` command on the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal string-building and URL handling for better performance and clarity
  * Replaced some utility code with standard library calls for maintainability
  * Minor test simplifications for clearer assertions

* **Chores**
  * Updated build environment to Go 1.26 and OpenShift 5.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->