### PR TITLE
Disable Garbage Collection

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -439,7 +439,8 @@ func (c *Controller) run(workers int, stopCh <-chan struct{}) {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
 
-	go wait.Until(c.gcWorker, time.Second, stopCh)
+	// TODO: Turn GC back on...
+	// go wait.Until(c.gcWorker, time.Second, stopCh)
 
 	for range workers {
 		go wait.Until(c.auditWorker, time.Second, stopCh)


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the garbage collection worker in the release controller to reduce resource overhead during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->