### PR TITLE
Bumping to the latest/greatest `oc`

### DIFF
--- a/images/release-controller-api/Dockerfile
+++ b/images/release-controller-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.23:tools
+FROM registry.ci.openshift.org/ocp/5.0:tools
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-controller-api /usr/bin/release-controller-api

--- a/images/release-controller/Dockerfile
+++ b/images/release-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.23:tools
+FROM registry.ci.openshift.org/ocp/5.0:tools
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-controller /usr/bin/release-controller

--- a/images/release-mirror-cleanup-controller/Dockerfile
+++ b/images/release-mirror-cleanup-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.23:cli
+FROM registry.ci.openshift.org/ocp/5.0:cli
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-mirror-cleanup-controller /usr/bin/release-mirror-cleanup-controller

--- a/images/release-reimport-controller/Dockerfile
+++ b/images/release-reimport-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.23:cli
+FROM registry.ci.openshift.org/ocp/5.0:cli
 LABEL maintainer="apavel@redhat.com"
 
 ADD release-reimport-controller /usr/bin/release-reimport-controller


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base images to OpenShift 5.0 version across multiple service containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->