### PR TITLE
Re-enabling GC processing

### DIFF
--- a/cmd/release-controller/controller.go
+++ b/cmd/release-controller/controller.go
@@ -439,8 +439,7 @@ func (c *Controller) run(workers int, stopCh <-chan struct{}) {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
 
-	// TODO: Turn GC back on...
-	// go wait.Until(c.gcWorker, time.Second, stopCh)
+	go wait.Until(c.gcWorker, time.Second, stopCh)
 
 	for range workers {
 		go wait.Until(c.auditWorker, time.Second, stopCh)

--- a/cmd/release-controller/sync_gc.go
+++ b/cmd/release-controller/sync_gc.go
@@ -24,6 +24,11 @@ func (c *Controller) garbageCollectSync() error {
 		}
 	}()
 
+	if c.auditStore != nil || c.signer != nil {
+		klog.V(2).Infof("Skipping garbage collection in audit mode")
+		return nil
+	}
+
 	imageStreams, err := c.releaseLister.List(labels.Everything())
 	if err != nil {
 		return err


### PR DESCRIPTION
Turning Garbage Collection back on.  I've also added a check to prevent running GC whenever running in audit/signing mode.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled automatic garbage collection processing that was previously inactive.

* **Features**
  * Garbage collection now respects audit mode, skipping cleanup operations when audit mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->