### PR TITLE
Fix issue where payloads get stranded in a Ready state

### DIFF
--- a/pkg/cmd/release-payload-controller/payload_accepted_controller.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller.go
@@ -147,6 +147,18 @@ func computeReleasePayloadAcceptedCondition(payload *v1alpha1.ReleasePayload) me
 		return acceptedCondition
 	}
 
+	// When there are no blocking jobs, wait for all informing/upgrade jobs to
+	// finish before accepting. Informing job failures do not prevent acceptance.
+	if len(payload.Status.BlockingJobResults) == 0 {
+		allJobs := append(payload.Status.InformingJobResults, payload.Status.UpgradeJobResults...)
+		if jobstatus.ComputeJobState(allJobs) == v1alpha1.JobStatePending {
+			acceptedCondition.Status = metav1.ConditionUnknown
+		} else {
+			acceptedCondition.Status = metav1.ConditionTrue
+		}
+		return acceptedCondition
+	}
+
 	// Check that all Blocking jobs have completed successfully...
 	status := jobstatus.ComputeJobState(payload.Status.BlockingJobResults)
 	switch status {

--- a/pkg/cmd/release-payload-controller/payload_accepted_controller.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller.go
@@ -148,14 +148,20 @@ func computeReleasePayloadAcceptedCondition(payload *v1alpha1.ReleasePayload) me
 	}
 
 	// When there are no blocking jobs, wait for all informing/upgrade jobs to
-	// finish before accepting. Informing job failures do not prevent acceptance.
+	// finish before accepting. Failures do not prevent acceptance — only pending
+	// jobs delay it. We check for pending jobs directly rather than using
+	// ComputeJobState, because ComputeJobState prioritizes failure over pending
+	// (designed for blocking jobs where failure is terminal). Here, a failed job
+	// alongside a pending job must still wait for the pending job to complete.
 	if len(payload.Status.BlockingJobResults) == 0 {
 		allJobs := append(payload.Status.InformingJobResults, payload.Status.UpgradeJobResults...)
-		if jobstatus.ComputeJobState(allJobs) == v1alpha1.JobStatePending {
-			acceptedCondition.Status = metav1.ConditionUnknown
-		} else {
-			acceptedCondition.Status = metav1.ConditionTrue
+		for _, job := range allJobs {
+			if job.AggregateState == v1alpha1.JobStatePending {
+				acceptedCondition.Status = metav1.ConditionUnknown
+				return acceptedCondition
+			}
 		}
+		acceptedCondition.Status = metav1.ConditionTrue
 		return acceptedCondition
 	}
 

--- a/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
@@ -590,6 +590,27 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			},
 		},
 		{
+			// Verifies that a pending job is not masked by a failure in a sibling
+			// job. Acceptance must wait for all jobs to complete, regardless of
+			// whether other jobs have already failed.
+			name: "MixedInformingAndUpgradeJobsFailureAndPendingNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateFailure},
+					},
+					UpgradeJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStatePending},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionUnknown,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
 			name: "MixedInformingAndUpgradeJobsCompleteNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{

--- a/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
@@ -16,6 +16,611 @@ import (
 	"k8s.io/utils/clock"
 )
 
+func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		payload  *v1alpha1.ReleasePayload
+		expected metav1.Condition
+	}{
+		// === Empty / default state ===
+		{
+			name:    "EmptyPayload",
+			payload: &v1alpha1.ReleasePayload{},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		// === Release creation job failure (highest precedence) ===
+		{
+			name: "CreationJobFailed",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status:  v1alpha1.ReleaseCreationJobFailed,
+						Message: "BackoffLimitExceeded",
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  ReleasePayloadCreationJobFailedReason,
+				Message: "BackoffLimitExceeded",
+			},
+		},
+		{
+			name: "CreationJobFailedWithEmptyMessage",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status: v1alpha1.ReleaseCreationJobFailed,
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadCreationJobFailedReason,
+			},
+		},
+		{
+			name: "CreationJobFailedTakesPrecedenceOverAcceptedOverride",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Manually accepted per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status:  v1alpha1.ReleaseCreationJobFailed,
+						Message: "BackoffLimitExceeded",
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  ReleasePayloadCreationJobFailedReason,
+				Message: "BackoffLimitExceeded",
+			},
+		},
+		{
+			name: "CreationJobFailedTakesPrecedenceOverRejectedOverride",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Manually rejected per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status:  v1alpha1.ReleaseCreationJobFailed,
+						Message: "BackoffLimitExceeded",
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  ReleasePayloadCreationJobFailedReason,
+				Message: "BackoffLimitExceeded",
+			},
+		},
+		{
+			name: "CreationJobFailedTakesPrecedenceOverSuccessfulBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status:  v1alpha1.ReleaseCreationJobFailed,
+						Message: "BackoffLimitExceeded",
+					},
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  ReleasePayloadCreationJobFailedReason,
+				Message: "BackoffLimitExceeded",
+			},
+		},
+		{
+			name: "CreationJobSuccessDoesNotShortCircuit",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status: v1alpha1.ReleaseCreationJobSuccess,
+					},
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "CreationJobUnknownDoesNotShortCircuit",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status: v1alpha1.ReleaseCreationJobUnknown,
+					},
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		// === PayloadOverride (second precedence) ===
+		{
+			name: "OverrideAccepted",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Manually accepted per TRT",
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionTrue,
+				Reason:  ReleasePayloadManuallyAcceptedReason,
+				Message: "Manually accepted per TRT",
+			},
+		},
+		{
+			name: "OverrideRejected",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Manually rejected per TRT",
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  ReleasePayloadManuallyRejectedReason,
+				Message: "Manually rejected per TRT",
+			},
+		},
+		{
+			name: "OverrideAcceptedWithEmptyReason",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadManuallyAcceptedReason,
+			},
+		},
+		{
+			name: "OverrideRejectedWithEmptyReason",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadManuallyRejectedReason,
+			},
+		},
+		{
+			name: "OverrideAcceptedTakesPrecedenceOverFailedBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Force accept despite failures",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateFailure},
+						{AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionTrue,
+				Reason:  ReleasePayloadManuallyAcceptedReason,
+				Message: "Force accept despite failures",
+			},
+		},
+		{
+			name: "OverrideRejectedTakesPrecedenceOverSuccessfulBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Force reject despite success",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:    v1alpha1.ConditionPayloadAccepted,
+				Status:  metav1.ConditionFalse,
+				Reason:  ReleasePayloadManuallyRejectedReason,
+				Message: "Force reject despite success",
+			},
+		},
+		// === Blocking job results (lowest precedence) ===
+		{
+			name: "AllBlockingJobsSuccessful",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "job-a", AggregateState: v1alpha1.JobStateSuccess},
+						{CIConfigurationName: "job-b", AggregateState: v1alpha1.JobStateSuccess},
+						{CIConfigurationName: "job-c", AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "SingleBlockingJobSuccessful",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "SingleBlockingJobFailed",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "SingleBlockingJobPending",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStatePending},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "MixOfSuccessAndPendingBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+						{AggregateState: v1alpha1.JobStatePending},
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "MixOfSuccessAndFailedBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+						{AggregateState: v1alpha1.JobStateSuccess},
+						{AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "FailureTakesPrecedenceOverPendingInBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+						{AggregateState: v1alpha1.JobStateFailure},
+						{AggregateState: v1alpha1.JobStatePending},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "AllBlockingJobsPending",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStatePending},
+						{AggregateState: v1alpha1.JobStatePending},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "AllBlockingJobsFailed",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateFailure},
+						{AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionFalse,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "BlockingJobWithUnknownState",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+						{AggregateState: v1alpha1.JobStateUnknown},
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionUnknown,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "NoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		// === Informing/upgrade jobs should not affect acceptance ===
+		{
+			name: "InformingJobFailureDoesNotAffectAcceptance",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+					InformingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "UpgradeJobFailureDoesNotAffectAcceptance",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					BlockingJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateSuccess},
+					},
+					UpgradeJobResults: []v1alpha1.JobStatus{
+						{AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		// === No blocking jobs: wait for informing/upgrade jobs to complete, then accept ===
+		{
+			name: "OnlyInformingJobsSuccessfulNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
+						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "OnlyInformingJobsWithFailuresNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
+						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateFailure},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "OnlyInformingJobsPendingNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStatePending},
+						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionUnknown,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "OnlyUpgradeJobsSuccessfulNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					UpgradeJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "OnlyUpgradeJobsPendingNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					UpgradeJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStatePending},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionUnknown,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "MixedInformingAndUpgradeJobsPendingNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
+					},
+					UpgradeJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStatePending},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionUnknown,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
+			name: "MixedInformingAndUpgradeJobsCompleteNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
+						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateFailure},
+					},
+					UpgradeJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStateSuccess},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := computeReleasePayloadAcceptedCondition(tc.payload)
+			if diff := cmp.Diff(tc.expected, result, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")); diff != "" {
+				t.Errorf("unexpected condition (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+
 func TestPayloadAcceptedSync(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
Found an issue where release without any Blocking Jobs defined can get perpetually stuck in a `Ready` state.  The only saving grace was manual acceptance via imagestreamtags (which I'm currently trying to deprecate and how I found this issue).

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release payload acceptance condition logic when there are no blocking jobs, now deriving acceptance from informing and upgrade job results (pending → Unknown; otherwise → True).

* **Tests**
  * Added a comprehensive table-driven unit test covering precedence rules, manual accept/reject overrides, job failure dominance, and acceptance mapping across many payload permutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->