### PR TITLE
pkg/release-controller: increase rpmdb semaphore to 32 slots

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -51,7 +51,7 @@ const coreosExtensionsMetadataPath = "usr/share/rpm-ostree/extensions.json"
 
 // MaxConcurrentRpmdbOCCalls limits parallel `oc adm release info` invocations that use
 // --rpmdb / --rpmdb-diff (heavy image pulls and RPM work). Additional callers get a clear error.
-const MaxConcurrentRpmdbOCCalls = 16
+const MaxConcurrentRpmdbOCCalls = 32
 
 var (
 	ocPath = ""

--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -404,6 +404,7 @@ func ocCmdRpmdb(args ...string) ([]byte, []byte, error) {
 	select {
 	case RpmdbOCSlots <- struct{}{}:
 	default:
+		klog.Infof("rpmdb semaphore exhausted (limit %d), rejecting: oc %s", MaxConcurrentRpmdbOCCalls, strings.Join(args, " "))
 		return nil, nil, fmt.Errorf(
 			"too many concurrent oc adm release info --rpmdb/--rpmdb-diff operations (limit %d)",
 			MaxConcurrentRpmdbOCCalls,


### PR DESCRIPTION
## Summary

- Increase `MaxConcurrentRpmdbOCCalls` from 16 → 32
- The 16-slot limit is exhausted under moderate concurrent changelog views because each `NodeImageSectionMarkdown` stream holds one slot for the full duration of sequential `oc adm release info --rpmdb`/`--rpmdb-diff` invocations per RHCOS stream (~18s each), so 16 concurrent views fully saturate the pool and new requests are immediately rejected

## Test plan

- [ ] Verify no regression in changelog rendering under normal load
- [ ] Confirm "too many concurrent oc adm release info --rpmdb/--rpmdb-diff operations" errors disappear under 16–32 concurrent changelog views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the number of concurrent release information checks that can run at once, reducing the chance of requests being rejected under load.
  * When the limit is reached, the system now logs which request was blocked, making it easier to understand intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->