### PR TITLE
Add releasestreams/ready API endpoint

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -190,6 +190,7 @@ func (c *Controller) userInterfaceHandler() http.Handler {
 	mux.HandleFunc("/api/v1/releasestreams/accepted", c.apiAcceptedStreams)
 	mux.HandleFunc("/api/v1/releasestreams/rejected", c.apiRejectedStreams)
 	mux.HandleFunc("/api/v1/releasestreams/all", c.apiAllStreams)
+	mux.HandleFunc("/api/v1/releasestreams/ready", c.apiReadyStreams)
 	mux.HandleFunc("/api/v1/releasestreams/approvals", c.apiReleaseApprovals)
 
 	//mux.HandleFunc("/api/v1/features/{tag}", c.apiFeatureInfo)
@@ -2376,6 +2377,19 @@ func (c *Controller) apiAcceptedStreams(w http.ResponseWriter, req *http.Request
 
 func (c *Controller) apiRejectedStreams(w http.ResponseWriter, req *http.Request) {
 	data, err := c.filteredStreams(releasecontroller.ReleasePhaseRejected)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	fmt.Fprintln(w)
+}
+
+func (c *Controller) apiReadyStreams(w http.ResponseWriter, req *http.Request) {
+	data, err := c.filteredStreams(releasecontroller.ReleasePhaseReady)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Adds a new API endpoint that returns release streams and their payloads currently in the Ready phase (awaiting verification).

Changes (`cmd/release-controller-api/http.go`):
- Register GET /`api/v1/releasestreams/ready` route
- Add `apiReadyStreams` handler using the existing `filteredStreams` helper with `ReleasePhaseReady`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to list release streams that are ready.
  * Responses are returned in JSON format for easier consumption by clients.
* **Bug Fixes**
  * Added error handling so the endpoint returns a server error if the ready-stream lookup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->