### PR TITLE
Omit Node Info rendering for 4.18 and earlier

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -706,6 +706,11 @@ func (c *Controller) apiReleaseInfo(w http.ResponseWriter, req *http.Request) {
 		}
 
 		wg.Go(func() {
+			// Skip node image info for 4.18 and earlier: rpmdb collection requires
+			// pulling the entire rhel-coreos image for those releases.
+			if !releasecontroller.ReleaseTagHasCheapRpmdb(tagInfo.Tag) {
+				return
+			}
 			streams, err := c.releaseInfo.ListMachineOSStreams(tagInfo.TagPullSpec)
 			if err != nil {
 				nodeImageErr = newHTTPError(http.StatusInternalServerError, "listing machine-OS streams for %s: %w", tagInfo.Tag, err)

--- a/cmd/release-controller-api/http_changelog.go
+++ b/cmd/release-controller-api/http_changelog.go
@@ -88,6 +88,13 @@ func (c *Controller) getChangeLog(ctx context.Context, ch chan renderResult, chN
 		return
 	}
 
+	// Skip node image info for 4.18 and earlier: rpmdb collection requires
+	// pulling the entire rhel-coreos image for those releases.
+	if !releasecontroller.ReleaseTagHasCheapRpmdb(toTag) {
+		chNodeInfo <- renderResult{}
+		return
+	}
+
 	toImagePullspec := toImage.GenerateDigestPullSpec()
 	fromImagePullspec := fromImage.GenerateDigestPullSpec()
 
@@ -197,6 +204,12 @@ func (c *Controller) renderChangeLog(w http.ResponseWriter, fromPull string, fro
 		}
 	}
 	if !needsNode {
+		return
+	}
+
+	// Skip node image info for 4.18 and earlier: rpmdb collection requires
+	// pulling the entire rhel-coreos image for those releases.
+	if !releasecontroller.ReleaseTagHasCheapRpmdb(toTag) {
 		return
 	}
 

--- a/pkg/release-controller/semver.go
+++ b/pkg/release-controller/semver.go
@@ -186,5 +186,5 @@ func ReleaseTagHasCheapRpmdb(toTag string) bool {
 	if err != nil {
 		return true
 	}
-	return !(v.Major == 4 && v.Minor <= 18)
+	return v.Major != 4 || v.Minor > 18
 }

--- a/pkg/release-controller/semver.go
+++ b/pkg/release-controller/semver.go
@@ -174,3 +174,17 @@ func ReleaseTagIsDualRHCOS(toTag string) bool {
 	}
 	return v.Major == 4 && v.Minor >= 21
 }
+
+// ReleaseTagHasCheapRpmdb reports whether the target release tag supports
+// rpmdb collection without pulling the entire rhel-coreos image.
+// Releases 4.19 and later store the rpmdb separately; 4.18 and earlier
+// require pulling the full image, so Node Info is omitted for those releases.
+// If the tag cannot be parsed as a semver version, it is assumed to support
+// cheap rpmdb (i.e., nightly or CI tags are not gated).
+func ReleaseTagHasCheapRpmdb(toTag string) bool {
+	v, err := SemverParseTolerant(toTag)
+	if err != nil {
+		return true
+	}
+	return !(v.Major == 4 && v.Minor <= 18)
+}


### PR DESCRIPTION
rpmdb collection on 4.18 and earlier requires pulling the entire `rhel-coreos` image. 4.19+ stores the rpmdb separately, making it significantly cheaper.

## Changes

Adds `ReleaseTagHasCheapRpmdb()` to `pkg/release-controller/semver.go`, which returns `false` for `4.x` tags where `x <= 18`. Unparseable tags (nightlies, CI builds) are not gated.

Uses the new function to skip Node Info in three places:
- `getChangeLog()` / `renderChangeLog()` — HTML page and compare page
- `apiReleaseInfo()` — API endpoint (`/api/v1/releasestream/{release}/release/{tag}`)

For gated releases the API response will have a null `nodeImageStreams` field, which is already a valid state. The `#node-image-info` anchor links that `oc` may emit in the changelog body for older releases are left as dead anchors for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog and release details for older releases by avoiding node image information when it isn’t available, preventing missing/partial sections.
  * Reduced unnecessary processing for unsupported release versions, improving responsiveness and eliminating confusing “loading” behavior related to node-image/RPM diff data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->