### PR TITLE
Prevent aggregated, informing jobs

### DIFF
--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -52,6 +52,7 @@ func validateReleaseConfigs(configDir string) error {
 	errors = append(errors, verifyPeriodicFields(releaseConfigs)...)
 	errors = append(errors, findDuplicatePeriodics(releaseConfigs)...)
 	errors = append(errors, validateQualifiers(releaseConfigs)...)
+	errors = append(errors, validateOptionalAggregatedJobs(releaseConfigs)...)
 	return utilerrors.NewAggregate(errors)
 }
 
@@ -206,4 +207,16 @@ func validateQualifier(name releasequalifiers.QualifierId, qualifier releasequal
 		return fmt.Errorf("unable to validate qualifier %s: %v", name, err)
 	}
 	return nil
+}
+
+func validateOptionalAggregatedJobs(releaseConfigs []releasecontroller.ReleaseConfig) []error {
+	var errors []error
+	for _, config := range releaseConfigs {
+		for name, verify := range config.Verify {
+			if verify.Optional && verify.AggregatedProwJob != nil {
+				errors = append(errors, fmt.Errorf("%s: verification job %q cannot be both optional and an aggregatedProwJob", config.Name, name))
+			}
+		}
+	}
+	return errors
 }

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -420,6 +420,179 @@ func TestValidateUpgradeJobs(t *testing.T) {
 	}
 }
 
+func TestValidateOptionalAggregatedJobs(t *testing.T) {
+	testCases := []struct {
+		name        string
+		configs     []releasecontroller.ReleaseConfig
+		expectedErr bool
+	}{
+		{
+			name: "optional with aggregatedProwJob is invalid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"analysis-job": {
+						Optional: true,
+						AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+							AnalysisJobCount: 10,
+						},
+					},
+				},
+			}},
+			expectedErr: true,
+		},
+		{
+			name: "non-optional with aggregatedProwJob is valid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"analysis-job": {
+						Optional: false,
+						AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+							AnalysisJobCount: 10,
+						},
+					},
+				},
+			}},
+			expectedErr: false,
+		},
+		{
+			name: "optional without aggregatedProwJob is valid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"my-optional-job": {
+						Optional: true,
+						ProwJob:  &releasecontroller.ProwJobVerification{Name: "some-job"},
+					},
+				},
+			}},
+			expectedErr: false,
+		},
+		{
+			name: "non-optional without aggregatedProwJob is valid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"my-blocking-job": {
+						Optional: false,
+						ProwJob:  &releasecontroller.ProwJobVerification{Name: "some-job"},
+					},
+				},
+			}},
+			expectedErr: false,
+		},
+		{
+			name: "multiple jobs with one invalid combination",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"good-job": {
+						Optional: false,
+						AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+							AnalysisJobCount: 10,
+						},
+					},
+					"bad-job": {
+						Optional: true,
+						AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+							AnalysisJobCount: 5,
+						},
+					},
+				},
+			}},
+			expectedErr: true,
+		},
+		{
+			name: "invalid combination across multiple configs",
+			configs: []releasecontroller.ReleaseConfig{
+				{
+					Name: "4.18.0-0.nightly",
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"good-job": {
+							Optional: false,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								AnalysisJobCount: 10,
+							},
+						},
+					},
+				},
+				{
+					Name: "4.19.0-0.nightly",
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"bad-job": {
+							Optional: true,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								AnalysisJobCount: 5,
+							},
+						},
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "optional with aggregatedProwJob containing custom prowJob is invalid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"analysis-job": {
+						Optional: true,
+						AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+							ProwJob: &releasecontroller.ProwJobVerification{
+								Name: "custom-aggregator",
+							},
+							AnalysisJobCount: 10,
+						},
+					},
+				},
+			}},
+			expectedErr: true,
+		},
+		{
+			name: "all valid jobs across multiple configs",
+			configs: []releasecontroller.ReleaseConfig{
+				{
+					Name: "4.18.0-0.nightly",
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"blocking-aggregated": {
+							Optional: false,
+							AggregatedProwJob: &releasecontroller.AggregatedProwJobVerification{
+								AnalysisJobCount: 10,
+							},
+						},
+						"optional-regular": {
+							Optional: true,
+							ProwJob:  &releasecontroller.ProwJobVerification{Name: "some-job"},
+						},
+					},
+				},
+				{
+					Name: "4.19.0-0.nightly",
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"blocking-regular": {
+							Optional: false,
+							ProwJob:  &releasecontroller.ProwJobVerification{Name: "another-job"},
+						},
+					},
+				},
+			},
+			expectedErr: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			errs := validateOptionalAggregatedJobs(testCase.configs)
+			if len(errs) > 0 && !testCase.expectedErr {
+				t.Errorf("got error when error was not expected: %v", errs)
+			}
+			if len(errs) == 0 && testCase.expectedErr {
+				t.Errorf("did not get error when error was expected")
+			}
+		})
+	}
+}
+
 func TestValidateQualifiersConfiguration(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Due to the inherent cost of "Aggregated Prow Jobs", the implementation expects that any `aggregatedProwJob` must be defined as a `Blocking Job` to be properly tracked by  release-payload-controller. 

This PR adds a validation check to ensure that any `aggregatedProwJob` does not also specify `optional: true`.  These checks run automatically on any PR's, in the `openshift/release` repo, to ensure compliance before merging.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release configuration validation to flag contradictory settings where a verification job is marked *Optional* while also configured as an *Aggregated* job.
  - Validation now aggregates and reports these issues more reliably to prevent misconfigured releases.
- **Tests**
  - Added coverage for the new validation rule, including multiple success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->