### PR TITLE
Retryable jobs not launching fix

### DIFF
--- a/pkg/releasepayload/utils.go
+++ b/pkg/releasepayload/utils.go
@@ -41,6 +41,22 @@ func convertToVerificationStatusMapResult(job v1alpha1.JobStatus) (*releasecontr
 	if state == releasecontroller.ReleaseVerificationStateSucceeded && url == "" {
 		state = releasecontroller.ReleaseVerificationStatePending
 	}
+	// The ReleasePayload controller sets AggregateState=Pending for retryable jobs
+	// that have failed but haven't exhausted their retries. The release-controller's
+	// retry logic needs to see Failed (not Pending) to trigger a retry with backoff.
+	// Detect this by checking whether all results are failures while aggregate is Pending.
+	if state == releasecontroller.ReleaseVerificationStatePending && job.MaxRetries > 0 && len(job.JobRunResults) > 0 {
+		allFailed := true
+		for _, r := range job.JobRunResults {
+			if r.State != v1alpha1.JobRunStateFailure && r.State != v1alpha1.JobRunStateAborted && r.State != v1alpha1.JobRunStateError {
+				allFailed = false
+				break
+			}
+		}
+		if allFailed {
+			state = releasecontroller.ReleaseVerificationStateFailed
+		}
+	}
 	status := &releasecontroller.VerificationStatus{
 		Retries:             getVerificationStatusRetries(job),
 		PreviousAttemptURLs: getVerificationStatusPreviousAttemptURLs(job.JobRunResults, url),


### PR DESCRIPTION
The release-controller is not launching retries for jobs that have them defined.   This PR should fix that!

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification status handling so jobs that remain pending after all attempts fail are now shown as failed when retries are still available.
  * This helps retryable failures surface correctly, making job outcomes easier to understand and act on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->