### PR TITLE
Sync pending migration part 2

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -99,7 +99,7 @@ func (c *Controller) findReleaseStreamTags(includeStableTags bool, tags ...strin
 	}
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -147,7 +147,7 @@ func (c *Controller) endOfLifePrefixes() sets.Set[string] {
 	}
 	endOfLifePrefixes := sets.New[string]()
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -592,7 +592,7 @@ func (c *Controller) locateStream(streamName string, phases ...string) (*Release
 		return nil, err
 	}
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -1817,7 +1817,7 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 	endOfLifePrefixes := sets.New[string]()
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -2158,7 +2158,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 
 	var requestedStream *imagev1.ImageStream
 	for _, stream := range c.imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -2275,7 +2275,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 
 	endOfLifePrefixes := sets.New[string]()
 
-	r, ok, err := releasecontroller.ReleaseDefinition(requestedStream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+	r, ok, err := c.releaseDefinition(requestedStream)
 	if err != nil || !ok {
 		return
 	}
@@ -2416,7 +2416,7 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 	}
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -2547,7 +2547,7 @@ func (c *Controller) apiReleaseConfig(w http.ResponseWriter, req *http.Request) 
 	var release *releasecontroller.Release
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}
@@ -2790,7 +2790,7 @@ func (c *Controller) filteredStreams(phase string) ([]byte, error) {
 	releases := make(map[string][]string)
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -98,8 +98,9 @@ func (c *Controller) findReleaseStreamTags(includeStableTags bool, tags ...strin
 		stable = &releasecontroller.StableReferences{}
 	}
 
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -146,8 +147,9 @@ func (c *Controller) endOfLifePrefixes() sets.Set[string] {
 		return nil
 	}
 	endOfLifePrefixes := sets.New[string]()
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -591,8 +593,9 @@ func (c *Controller) locateStream(streamName string, phases ...string) (*Release
 	if err != nil {
 		return nil, err
 	}
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -1816,8 +1819,9 @@ func (c *Controller) httpReleases(w http.ResponseWriter, req *http.Request) {
 
 	endOfLifePrefixes := sets.New[string]()
 
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -2157,8 +2161,9 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 	}
 
 	var requestedStream *imagev1.ImageStream
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range c.imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -2275,7 +2280,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 
 	endOfLifePrefixes := sets.New[string]()
 
-	r, ok, err := c.releaseDefinition(requestedStream)
+	r, ok, err := c.releaseDefinition(requestedStream, nil)
 	if err != nil || !ok {
 		return
 	}
@@ -2415,8 +2420,9 @@ func (c *Controller) httpDashboardOverview(w http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -2545,9 +2551,10 @@ func (c *Controller) apiReleaseConfig(w http.ResponseWriter, req *http.Request) 
 	}
 
 	var release *releasecontroller.Release
+	payloadPhases := c.buildPayloadPhases()
 
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}
@@ -2788,9 +2795,10 @@ func (c *Controller) filteredStreams(phase string) ([]byte, error) {
 	}
 
 	releases := make(map[string][]string)
+	payloadPhases := c.buildPayloadPhases()
 
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http_candidate.go
+++ b/cmd/release-controller-api/http_candidate.go
@@ -296,7 +296,7 @@ func (c *Controller) findReleaseByName(includeStableTags bool, names ...string) 
 	}
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http_candidate.go
+++ b/cmd/release-controller-api/http_candidate.go
@@ -295,8 +295,9 @@ func (c *Controller) findReleaseByName(includeStableTags bool, names ...string) 
 		stable = &releasecontroller.StableReferences{}
 	}
 
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http_compare.go
+++ b/cmd/release-controller-api/http_compare.go
@@ -87,8 +87,9 @@ func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http_compare.go
+++ b/cmd/release-controller-api/http_compare.go
@@ -88,7 +88,7 @@ func (c *Controller) httpDashboardCompare(w http.ResponseWriter, req *http.Reque
 	}
 
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -29,6 +29,15 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
+func (c *Controller) releaseDefinition(stream *imagev1.ImageStream) (*releasecontroller.Release, bool, error) {
+	r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+	if err != nil || !ok {
+		return r, ok, err
+	}
+	releasecontroller.PopulatePayloadPhases(r, c.releasePayloadLister.ReleasePayloads(c.releasePayloadNamespace))
+	return r, ok, nil
+}
+
 var urlRegexp = regexp.MustCompile(`https?://[^\s<>"]*[^\s<>").,:;!?]`)
 
 // linkifyURLs HTML-escapes the input text, then converts any URLs into clickable links.

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -29,13 +29,21 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 )
 
-func (c *Controller) releaseDefinition(stream *imagev1.ImageStream) (*releasecontroller.Release, bool, error) {
+func (c *Controller) releaseDefinition(stream *imagev1.ImageStream, payloadPhases map[string]string) (*releasecontroller.Release, bool, error) {
 	r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
 	if err != nil || !ok {
 		return r, ok, err
 	}
-	releasecontroller.PopulatePayloadPhases(r, c.releasePayloadLister.ReleasePayloads(c.releasePayloadNamespace))
+	if payloadPhases != nil {
+		r.PayloadPhases = payloadPhases
+	} else {
+		releasecontroller.PopulatePayloadPhases(r, c.releasePayloadLister.ReleasePayloads(c.releasePayloadNamespace))
+	}
 	return r, ok, nil
+}
+
+func (c *Controller) buildPayloadPhases() map[string]string {
+	return releasecontroller.BuildPayloadPhases(c.releasePayloadLister.ReleasePayloads(c.releasePayloadNamespace))
 }
 
 var urlRegexp = regexp.MustCompile(`https?://[^\s<>"]*[^\s<>").,:;!?]`)

--- a/cmd/release-controller-api/http_upgrade_graph.go
+++ b/cmd/release-controller-api/http_upgrade_graph.go
@@ -34,8 +34,9 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 
 	var nodeCount int
 	var streams []ReleaseStream
+	payloadPhases := c.buildPayloadPhases()
 	for _, stream := range imageStreams {
-		r, ok, err := c.releaseDefinition(stream)
+		r, ok, err := c.releaseDefinition(stream, payloadPhases)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller-api/http_upgrade_graph.go
+++ b/cmd/release-controller-api/http_upgrade_graph.go
@@ -35,7 +35,7 @@ func (c *Controller) graphHandler(w http.ResponseWriter, req *http.Request) {
 	var nodeCount int
 	var streams []ReleaseStream
 	for _, stream := range imageStreams {
-		r, ok, err := releasecontroller.ReleaseDefinition(stream, c.parsedReleaseConfigCache, c.eventRecorder, *c.releaseLister)
+		r, ok, err := c.releaseDefinition(stream)
 		if err != nil || !ok {
 			continue
 		}

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -44,6 +44,7 @@ func (c *Controller) sync(key queueKey) error {
 	if err != nil || release == nil {
 		return err
 	}
+	c.populatePayloadPhases(release)
 
 	if release.Config.EndOfLife {
 		klog.V(6).Infof("release %s has reached the end of life", release.Config.Name)
@@ -183,7 +184,7 @@ func calculateSyncActions(release *releasecontroller.Release, now time.Time) (ad
 			hasNewImages = false
 		}
 
-		phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
+		phase := releasecontroller.GetTagPhase(release, tag)
 		switch phase {
 		case releasecontroller.ReleasePhasePending, "":
 			unreadyTagCount++
@@ -576,6 +577,10 @@ func (c *Controller) precacheChangelog(release *releasecontroller.Release, tag *
 			}
 		}()
 	}
+}
+
+func (c *Controller) populatePayloadPhases(release *releasecontroller.Release) {
+	releasecontroller.PopulatePayloadPhases(release, c.releasePayloadLister.ReleasePayloads(release.Target.Namespace))
 }
 
 func (c *Controller) loadReleaseForSync(namespace, name string) (*releasecontroller.Release, error) {

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -368,48 +368,27 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 			if err != nil || job == nil {
 				return err
 			}
-			success, complete := jobIsComplete(job)
-			switch {
-			case !complete:
-				return c.ensureRewriteJobImageRetrieved(release, job, mirror)
-			case !success:
-				// TODO: extract termination message from the job
-				if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
+			payload, err := c.releasePayloadLister.ReleasePayloads(release.Target.Namespace).Get(tag.Name)
+			if err != nil {
+				if !errors.IsNotFound(err) {
 					return err
 				}
-			default:
+				return c.ensureRewriteJobImageRetrieved(release, job, mirror)
+			}
+			phase := releasecontroller.GetReleasePhase(payload)
+			switch phase {
+			case releasecontroller.ReleasePhaseReady:
 				if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
 					return err
 				}
-				if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
-					go func() {
-						fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0])
-						if len(fromPullSpec) == 0 {
-							klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
-							return
-						}
-						fromImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, fromPullSpec)
-						if err != nil {
-							klog.Errorf("Unable to get from image info for release %s: %v", tags[0].Name, err)
-							return
-						}
-
-						toPullSpec := releasecontroller.ReleasePullSpec(release, tag)
-						if len(toPullSpec) == 0 {
-							klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
-							return
-						}
-						toImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, toPullSpec)
-						if err != nil {
-							klog.Errorf("Unable to get to image info for release %s: %v", tag.Name, err)
-							return
-						}
-
-						if _, err := c.releaseInfo.ChangeLog(fromImage.GenerateDigestPullSpec(), toImage.GenerateDigestPullSpec(), false); err != nil {
-							klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
-						}
-					}()
+				c.precacheChangelog(release, tag)
+			case releasecontroller.ReleasePhaseFailed:
+				log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "status.phase=Failed", "build", false)
+				if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
+					return err
 				}
+			default:
+				return c.ensureRewriteJobImageRetrieved(release, job, mirror)
 			}
 		}
 		return nil
@@ -444,50 +423,28 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 		if err != nil || job == nil {
 			return err
 		}
-		success, complete := jobIsComplete(job)
-		klog.V(4).Infof("Release creation for %s success: %v, complete: %v", tag.Name, success, complete)
-		switch {
-		case !complete:
+		payload, err := c.releasePayloadLister.ReleasePayloads(release.Target.Namespace).Get(tag.Name)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
 			return nil
-		case !success:
-			// try to get the last termination message
+		}
+		phase := releasecontroller.GetReleasePhase(payload)
+		klog.V(4).Infof("Release creation for %s phase: %s", tag.Name, phase)
+		switch phase {
+		case releasecontroller.ReleasePhaseReady:
+			if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
+				return err
+			}
+			c.precacheChangelog(release, tag)
+		case releasecontroller.ReleasePhaseFailed:
 			log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "status.phase=Failed", "build", false)
 			if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
 				return err
 			}
 		default:
-			if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
-				return err
-			}
-			if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
-				go func() {
-					fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0])
-					if len(fromPullSpec) == 0 {
-						klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
-						return
-					}
-					fromImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, fromPullSpec)
-					if err != nil {
-						klog.Errorf("Unable to get from image info for release %s: %v", tags[0].Name, err)
-						return
-					}
-
-					toPullSpec := releasecontroller.ReleasePullSpec(release, tag)
-					if len(toPullSpec) == 0 {
-						klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
-						return
-					}
-					toImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, toPullSpec)
-					if err != nil {
-						klog.Errorf("Unable to get to image info for release %s: %v", tag.Name, err)
-						return
-					}
-
-					if _, err := c.releaseInfo.ChangeLog(fromImage.GenerateDigestPullSpec(), toImage.GenerateDigestPullSpec(), false); err != nil {
-						klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
-					}
-				}()
-			}
+			return nil
 		}
 	}
 
@@ -587,6 +544,38 @@ func (c *Controller) syncAccepted(release *releasecontroller.Release) error {
 		return utilerrors.NewAggregate(errs)
 	}
 	return nil
+}
+
+func (c *Controller) precacheChangelog(release *releasecontroller.Release, tag *imagev1.TagReference) {
+	if tags := releasecontroller.SortedRawReleaseTags(release, releasecontroller.ReleasePhaseReady); len(tags) > 0 {
+		go func() {
+			fromPullSpec := releasecontroller.ReleasePullSpec(release, tags[0])
+			if len(fromPullSpec) == 0 {
+				klog.Errorf("Unable to determine pullspec for fromImage: %s", tags[0].Name)
+				return
+			}
+			fromImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, fromPullSpec)
+			if err != nil {
+				klog.Errorf("Unable to get from image info for release %s: %v", tags[0].Name, err)
+				return
+			}
+
+			toPullSpec := releasecontroller.ReleasePullSpec(release, tag)
+			if len(toPullSpec) == 0 {
+				klog.Errorf("Unable to determine pullspec for toImage: %s", tag.Name)
+				return
+			}
+			toImage, err := releasecontroller.GetImageInfo(c.releaseInfo, c.architecture, toPullSpec)
+			if err != nil {
+				klog.Errorf("Unable to get to image info for release %s: %v", tag.Name, err)
+				return
+			}
+
+			if _, err := c.releaseInfo.ChangeLog(fromImage.GenerateDigestPullSpec(), toImage.GenerateDigestPullSpec(), false); err != nil {
+				klog.V(4).Infof("Unable to pre-cache changelog for new ready release %s: %v", tag.Name, err)
+			}
+		}()
+	}
 }
 
 func (c *Controller) loadReleaseForSync(namespace, name string) (*releasecontroller.Release, error) {

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -381,7 +381,11 @@ func GetTagPhase(release *Release, tag *imagev1.TagReference) string {
 			return phase
 		}
 	}
-	return tag.Annotations[ReleaseAnnotationPhase]
+	phase := tag.Annotations[ReleaseAnnotationPhase]
+	if len(phase) > 0 {
+		klog.Warningf("GetTagPhase falling back to annotation for tag %s/%s:%s (phase=%s, PayloadPhases nil=%v)", release.Target.Namespace, release.Target.Name, tag.Name, phase, release.PayloadPhases == nil)
+	}
+	return phase
 }
 
 // does not sort the array. If phases is specified only tags in the provided phases

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -372,6 +372,18 @@ func FindPublicImagePullSpec(is *imagev1.ImageStream, name string) string {
 }
 
 // UnsortedSemanticReleaseTags returns the tags in the release as a sortable array, but
+// GetTagPhase returns the phase of a tag. It checks the pre-built PayloadPhases
+// map first (derived from ReleasePayload conditions), falling back to the
+// release.openshift.io/phase annotation on the ImageStream tag.
+func GetTagPhase(release *Release, tag *imagev1.TagReference) string {
+	if release.PayloadPhases != nil {
+		if phase, ok := release.PayloadPhases[tag.Name]; ok {
+			return phase
+		}
+	}
+	return tag.Annotations[ReleaseAnnotationPhase]
+}
+
 // does not sort the array. If phases is specified only tags in the provided phases
 // are returned.
 func UnsortedSemanticReleaseTags(release *Release, phases ...string) SemanticVersions {
@@ -388,7 +400,7 @@ func UnsortedSemanticReleaseTags(release *Release, phases ...string) SemanticVer
 		if tag.Annotations[ReleaseAnnotationName] != release.Config.Name {
 			continue
 		}
-		if len(phases) > 0 && !slices.Contains(phases, tag.Annotations[ReleaseAnnotationPhase]) {
+		if len(phases) > 0 && !slices.Contains(phases, GetTagPhase(release, tag)) {
 			continue
 		}
 
@@ -442,7 +454,7 @@ func SortedRawReleaseTags(release *Release, phases ...string) []*imagev1.TagRefe
 		if tag.Annotations[ReleaseAnnotationSource] != fmt.Sprintf("%s/%s", release.Source.Namespace, release.Source.Name) {
 			continue
 		}
-		if slices.Contains(phases, tag.Annotations[ReleaseAnnotationPhase]) {
+		if slices.Contains(phases, GetTagPhase(release, tag)) {
 			tags = append(tags, tag)
 		}
 	}
@@ -494,8 +506,7 @@ func CountUnreadyReleases(release *Release, tags []*imagev1.TagReference) int {
 			continue
 		}
 
-		phase := tag.Annotations[ReleaseAnnotationPhase]
-		switch phase {
+		switch GetTagPhase(release, tag) {
 		case ReleasePhaseFailed, ReleasePhaseRejected, ReleasePhaseAccepted:
 			// terminal don't count
 		default:

--- a/pkg/release-controller/release_payload.go
+++ b/pkg/release-controller/release_payload.go
@@ -38,17 +38,8 @@ func ApprovedReleases(lister v1alpha2.ReleasePayloadLister) ([]*v1alpha1.Release
 }
 
 func PopulatePayloadPhases(release *Release, lister v1alpha2.ReleasePayloadNamespaceLister) {
-	if lister == nil {
-		return
-	}
-	payloads, err := lister.List(labels.Everything())
-	if err != nil {
-		klog.V(4).Infof("Unable to list ReleasePayloads for %s: %v", release.Target.Namespace, err)
-		return
-	}
-	release.PayloadPhases = make(map[string]string, len(payloads))
-	for _, p := range payloads {
-		release.PayloadPhases[p.Name] = GetReleasePhase(p)
+	if phases := BuildPayloadPhases(lister); phases != nil {
+		release.PayloadPhases = phases
 	}
 }
 

--- a/pkg/release-controller/release_payload.go
+++ b/pkg/release-controller/release_payload.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog"
 
 	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
 	v1alpha2 "github.com/openshift/release-controller/pkg/client/listers/release/v1alpha1"
@@ -42,12 +43,29 @@ func PopulatePayloadPhases(release *Release, lister v1alpha2.ReleasePayloadNames
 	}
 	payloads, err := lister.List(labels.Everything())
 	if err != nil {
+		klog.V(4).Infof("Unable to list ReleasePayloads for %s: %v", release.Target.Namespace, err)
 		return
 	}
 	release.PayloadPhases = make(map[string]string, len(payloads))
 	for _, p := range payloads {
 		release.PayloadPhases[p.Name] = GetReleasePhase(p)
 	}
+}
+
+func BuildPayloadPhases(lister v1alpha2.ReleasePayloadNamespaceLister) map[string]string {
+	if lister == nil {
+		return nil
+	}
+	payloads, err := lister.List(labels.Everything())
+	if err != nil {
+		klog.V(4).Infof("Unable to list ReleasePayloads: %v", err)
+		return nil
+	}
+	phases := make(map[string]string, len(payloads))
+	for _, p := range payloads {
+		phases[p.Name] = GetReleasePhase(p)
+	}
+	return phases
 }
 
 func GetReleasePhase(payload *v1alpha1.ReleasePayload) string {

--- a/pkg/release-controller/release_payload.go
+++ b/pkg/release-controller/release_payload.go
@@ -2,11 +2,13 @@ package releasecontroller
 
 import (
 	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
 	v1alpha2 "github.com/openshift/release-controller/pkg/client/listers/release/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"strings"
 )
 
 func ApprovedReleasesByTeam(lister v1alpha2.ReleasePayloadLister, team string) ([]*v1alpha1.ReleasePayload, error) {
@@ -32,6 +34,20 @@ func ApprovedReleases(lister v1alpha2.ReleasePayloadLister) ([]*v1alpha1.Release
 		}
 	}
 	return approved, nil
+}
+
+func PopulatePayloadPhases(release *Release, lister v1alpha2.ReleasePayloadNamespaceLister) {
+	if lister == nil {
+		return
+	}
+	payloads, err := lister.List(labels.Everything())
+	if err != nil {
+		return
+	}
+	release.PayloadPhases = make(map[string]string, len(payloads))
+	for _, p := range payloads {
+		release.PayloadPhases[p.Name] = GetReleasePhase(p)
+	}
 }
 
 func GetReleasePhase(payload *v1alpha1.ReleasePayload) string {

--- a/pkg/release-controller/release_payload_test.go
+++ b/pkg/release-controller/release_payload_test.go
@@ -3,6 +3,7 @@ package releasecontroller
 import (
 	"testing"
 
+	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/release-controller/pkg/apis/release/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -87,6 +88,79 @@ func TestGetReleasePhase(t *testing.T) {
 			got := GetReleasePhase(payload)
 			if got != tt.expected {
 				t.Errorf("GetReleasePhase() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetTagPhase(t *testing.T) {
+	tests := []struct {
+		name          string
+		payloadPhases map[string]string
+		tagName       string
+		tagAnnotation string
+		want          string
+	}{
+		{
+			name:          "PayloadPhases hit returns map value",
+			payloadPhases: map[string]string{"4.17.0": ReleasePhaseAccepted},
+			tagName:       "4.17.0",
+			tagAnnotation: ReleasePhaseRejected,
+			want:          ReleasePhaseAccepted,
+		},
+		{
+			name:          "PayloadPhases miss falls back to annotation",
+			payloadPhases: map[string]string{"4.17.0": ReleasePhaseAccepted},
+			tagName:       "4.18.0",
+			tagAnnotation: ReleasePhaseReady,
+			want:          ReleasePhaseReady,
+		},
+		{
+			name:          "nil PayloadPhases falls back to annotation",
+			payloadPhases: nil,
+			tagName:       "4.17.0",
+			tagAnnotation: ReleasePhasePending,
+			want:          ReleasePhasePending,
+		},
+		{
+			name:          "empty PayloadPhases falls back to annotation",
+			payloadPhases: map[string]string{},
+			tagName:       "4.17.0",
+			tagAnnotation: ReleasePhaseFailed,
+			want:          ReleasePhaseFailed,
+		},
+		{
+			name:          "no annotation and no PayloadPhases returns empty string",
+			payloadPhases: nil,
+			tagName:       "4.17.0",
+			tagAnnotation: "",
+			want:          "",
+		},
+		{
+			name:          "PayloadPhases overrides empty annotation",
+			payloadPhases: map[string]string{"4.17.0": ReleasePhaseReady},
+			tagName:       "4.17.0",
+			tagAnnotation: "",
+			want:          ReleasePhaseReady,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			release := &Release{
+				Target: &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "release"},
+				},
+				PayloadPhases: tt.payloadPhases,
+			}
+			tag := &imagev1.TagReference{
+				Name: tt.tagName,
+				Annotations: map[string]string{
+					ReleaseAnnotationPhase: tt.tagAnnotation,
+				},
+			}
+			got := GetTagPhase(release, tag)
+			if got != tt.want {
+				t.Errorf("GetTagPhase() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/release-controller/types.go
+++ b/pkg/release-controller/types.go
@@ -78,6 +78,10 @@ type Release struct {
 	Target *imagev1.ImageStream
 	// Config holds the release configuration parsed off of Source.
 	Config *ReleaseConfig
+	// PayloadPhases maps tag names to their phase derived from the corresponding
+	// ReleasePayload conditions. When nil, callers fall back to reading the
+	// release.openshift.io/phase annotation from the ImageStream tag.
+	PayloadPhases map[string]string
 }
 
 // ReleaseConfig is serialized in JSON as the release.openshift.io/config annotation


### PR DESCRIPTION
Summary

  Migrate the sync loop's phase-annotation readers to use ReleasePayload conditions as the source of truth.

  Previously, `calculateSyncActions`, `SortedRawReleaseTags`, `SortedReleaseTags`, `UnsortedSemanticReleaseTags`, and `CountUnreadyReleases` all read the `release.openshift.io/phase `annotation directly from ImageStream
  tags to filter and classify releases. This created inconsistencies with the API endpoints (which already read from ReleasePayload via `resolvePhase`), most visibly in the `/latest `endpoint returning stale results
  when the annotation and ReleasePayload disagreed.

  Changes

  - Added `PayloadPhases map[string]string `to the `Release` struct, populated once per sync cycle by listing all ReleasePayloads and calling `GetReleasePhase() `on each
  - Added `GetTagPhase(release, tag) `helper that checks the map first, falling back to the annotation when the map is nil or the tag has no entry (e.g., adoption candidates with no ReleasePayload yet)
  - Added `PopulatePayloadPhases` as a shared function in `pkg/release-controller` so both binaries use the same logic
  - Updated `calculateSyncActions` to use `GetTagPhase` for phase bucketing
  - Updated `SortedRawReleaseTags`, `UnsortedSemanticReleaseTags`, and `CountUnreadyReleases` to use `GetTagPhase`
  - Updated the API binary to populate `PayloadPhases` via a `c.releaseDefinition(stream) `wrapper, replacing all 13 direct `ReleaseDefinition` call sites

  What doesn't change

  - The phase annotation is still written as a mirror by `markReleaseReady`, `markReleaseAccepted`, and `transitionReleasePhaseFailure`
  - Precondition checks in `ensureReleaseTagPhase` and `transitionReleasePhaseFailure` still read the annotation (they guard the annotation before overwriting it)
  - Tag adoption detection still works — unadopted tags have no ReleasePayload, so `GetTagPhase` falls back to the annotation (empty string), matching the existing case ReleasePhasePending, "" logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release dashboards, graphs, and API responses now derive phase information from release payloads for more consistent status display.

* **Bug Fixes**
  * Improved release readiness and failure determination by basing sync transitions on release payload phase state rather than job-completion heuristics.
  * Tag and stream phase filtering/counting now uses computed payload phases, with a fallback to existing tag phase annotations when payload data isn’t available.
  * Changelog pre-caching runs more reliably when releases become ready.

* **Tests**
  * Added coverage for tag phase resolution behavior (payload vs annotation fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->