### PR TITLE
Latest api fix

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -2280,7 +2280,7 @@ func (c *Controller) httpReleaseStreamTable(w http.ResponseWriter, req *http.Req
 
 	endOfLifePrefixes := sets.New[string]()
 
-	r, ok, err := c.releaseDefinition(requestedStream, nil)
+	r, ok, err := c.releaseDefinition(requestedStream, payloadPhases)
 	if err != nil || !ok {
 		return
 	}

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -532,7 +532,7 @@ func (c *Controller) locateLatest(w http.ResponseWriter, req *http.Request) (*re
 		releasePrefix = inString
 	}
 
-	r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, streamName, constraint, relativeIndex, releasePrefix)
+	r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister, streamName, constraint, relativeIndex, releasePrefix)
 	if err != nil {
 		code := http.StatusInternalServerError
 		if errors.Is(err, releasecontroller.ErrStreamNotFound) || errors.Is(err, releasecontroller.ErrStreamTagNotFound) {

--- a/cmd/release-controller-api/http_candidate.go
+++ b/cmd/release-controller-api/http_candidate.go
@@ -202,7 +202,7 @@ func (c *Controller) findReleaseCandidates(upgradeSuccessPercent float64, releas
 
 	stableReleases := make([]imagev1.TagReference, 0)
 
-	stable, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister)
+	stable, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister)
 	if err != nil {
 		return releaseCandidates, err
 	}

--- a/cmd/release-controller-api/http_helper.go
+++ b/cmd/release-controller-api/http_helper.go
@@ -37,7 +37,7 @@ func (c *Controller) releaseDefinition(stream *imagev1.ImageStream, payloadPhase
 	if payloadPhases != nil {
 		r.PayloadPhases = payloadPhases
 	} else {
-		releasecontroller.PopulatePayloadPhases(r, c.releasePayloadLister.ReleasePayloads(c.releasePayloadNamespace))
+		releasecontroller.PopulatePayloadPhases(r, c.releasePayloadLister.ReleasePayloads(r.Target.Namespace))
 	}
 	return r, ok, nil
 }

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -83,7 +83,7 @@ func getNonVerifiedTagsJira(acceptedTags []*v1.TagReference) (current, previous 
 // If a major version transition requires a specific previous release mapping, follow this pattern.
 func (c *Controller) calculatePreviousReleaseTagForNightly(currentVersion semver.Version) (*releasecontroller.VerifyIssuesTagInfo, error) {
 	// Get all stable releases (includes 4-stable, 4-dev-preview, 5-stable, and 5-dev-preview streams)
-	stableReleases, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister)
+	stableReleases, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get stable releases: %w", err)
 	}
@@ -365,7 +365,7 @@ func (c *Controller) syncJira(key queueKey) error {
 	// figure out what fix version should be applied
 	tagSemver := semver.MustParse(tag.Name)
 	fixVersion := fmt.Sprintf("%d.%d.0", tagSemver.Major, tagSemver.Minor)
-	stableReleases, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister)
+	stableReleases, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister)
 	if err != nil {
 		klog.V(4).Infof("Jira: Error getting stable releases: %v", err)
 		c.jiraErrorMetrics.WithLabelValues(jiraStableReleases).Inc()

--- a/cmd/release-controller/jira.go
+++ b/cmd/release-controller/jira.go
@@ -163,6 +163,7 @@ func (c *Controller) syncJira(key queueKey) error {
 		klog.V(6).Infof("jira: could not load release for sync for %s/%s", key.namespace, key.name)
 		return err
 	}
+	c.populatePayloadPhases(release)
 
 	klog.V(6).Infof("checking if %v (%s) has verifyIssues set", key, release.Config.Name)
 

--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -139,13 +139,13 @@ func (c *Controller) getUpgradeTagAndPullSpec(release *releasecontroller.Release
 	case releasecontroller.ReleaseUpgradeFromPreviousMinor:
 		if version, err := semver.Parse(releaseTag.Name); err == nil && version.Minor > 0 {
 			version.Minor--
-			if ref, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister); err == nil {
+			if ref, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister); err == nil {
 				previousTag, previousReleasePullSpec = findLatestStableForVersion(ref, version)
 			}
 		}
 	case releasecontroller.ReleaseUpgradeFromPreviousPatch:
 		if version, err := semver.Parse(releaseTag.Name); err == nil {
-			if ref, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister); err == nil {
+			if ref, err := releasecontroller.GetStableReleases(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister); err == nil {
 				previousTag, previousReleasePullSpec = findLatestStableForVersion(ref, version)
 			}
 		}
@@ -179,7 +179,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 			return "", "", fmt.Errorf("invalid semver range `%s`: %w", upgradeRelease.Prerelease.VersionBounds.Query(), err)
 		}
 		//TODO: Right now, nothing relies on the "prerelease" stanza that would trigger this logic.  If it is ever used, we are going to need to handle "4-stable" and "5-stable"...
-		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, "4-stable", semverRange, 0, "")
+		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister, "4-stable", semverRange, 0, "")
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get latest tag in 4-stable stream: %w", err)
 		}
@@ -190,7 +190,7 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 		// create blank semver.Range
 		var constraint semver.Range
 		stream := fmt.Sprintf("%s.0-0.%s%s", upgradeRelease.Candidate.Version, upgradeRelease.Candidate.Stream, TrimPrefixes(release.Config.To, "release-5", "release"))
-		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, stream, constraint, upgradeRelease.Candidate.Relative, "")
+		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister, stream, constraint, upgradeRelease.Candidate.Relative, "")
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get latest tag for stream %s: %w", stream, err)
 		}

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -540,11 +540,11 @@ func GetStableReleases(rcCache *lru.Cache, eventRecorder record.EventRecorder, l
 		if err != nil || !ok {
 			continue
 		}
-		if rpLister != nil {
-			PopulatePayloadPhases(r, rpLister.ReleasePayloads(r.Target.Namespace))
-		}
 
 		if r.Config.As == ReleaseConfigModeStable {
+			if rpLister != nil {
+				PopulatePayloadPhases(r, rpLister.ReleasePayloads(r.Target.Namespace))
+			}
 			version, _ := SemverParseTolerant(r.Source.Name)
 			stable.Releases = append(stable.Releases, StableRelease{
 				Release: r,
@@ -567,11 +567,11 @@ func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lis
 		if err != nil || !ok {
 			continue
 		}
-		if rpLister != nil {
-			PopulatePayloadPhases(r, rpLister.ReleasePayloads(r.Target.Namespace))
-		}
 		if r.Config.Name != streamName {
 			continue
+		}
+		if rpLister != nil {
+			PopulatePayloadPhases(r, rpLister.ReleasePayloads(r.Target.Namespace))
 		}
 		// find all accepted tags, then sort by semantic version
 		tags := UnsortedSemanticReleaseTags(r, ReleasePhaseAccepted)

--- a/pkg/release-controller/release.go
+++ b/pkg/release-controller/release.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 
 	imagev1 "github.com/openshift/api/image/v1"
+	releasepayloadlisters "github.com/openshift/release-controller/pkg/client/listers/release/v1alpha1"
 )
 
 var (
@@ -520,7 +521,13 @@ func CountUnreadyReleases(release *Release, tags []*imagev1.TagReference) int {
 	return unreadyTagCount
 }
 
-func GetStableReleases(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister) (*StableReferences, error) {
+// ReleasePayloadLister provides access to namespace-scoped ReleasePayload listers.
+// Both MultiReleasePayloadLister and the generated ReleasePayloadLister satisfy this interface.
+type ReleasePayloadLister interface {
+	ReleasePayloads(namespace string) releasepayloadlisters.ReleasePayloadNamespaceLister
+}
+
+func GetStableReleases(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, rpLister ReleasePayloadLister) (*StableReferences, error) {
 	imageStreams, err := lister.List(labels.Everything())
 	if err != nil {
 		return nil, err
@@ -532,6 +539,9 @@ func GetStableReleases(rcCache *lru.Cache, eventRecorder record.EventRecorder, l
 		r, ok, err := ReleaseDefinition(stream, rcCache, eventRecorder, *lister)
 		if err != nil || !ok {
 			continue
+		}
+		if rpLister != nil {
+			PopulatePayloadPhases(r, rpLister.ReleasePayloads(r.Target.Namespace))
 		}
 
 		if r.Config.As == ReleaseConfigModeStable {
@@ -547,7 +557,7 @@ func GetStableReleases(rcCache *lru.Cache, eventRecorder record.EventRecorder, l
 	return stable, nil
 }
 
-func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, streamName string, constraint semver.Range, relativeIndex int, versionPrefix string) (*Release, *imagev1.TagReference, error) {
+func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lister *MultiImageStreamLister, rpLister ReleasePayloadLister, streamName string, constraint semver.Range, relativeIndex int, versionPrefix string) (*Release, *imagev1.TagReference, error) {
 	imageStreams, err := lister.List(labels.Everything())
 	if err != nil {
 		return nil, nil, err
@@ -556,6 +566,9 @@ func LatestForStream(rcCache *lru.Cache, eventRecorder record.EventRecorder, lis
 		r, ok, err := ReleaseDefinition(stream, rcCache, eventRecorder, *lister)
 		if err != nil || !ok {
 			continue
+		}
+		if rpLister != nil {
+			PopulatePayloadPhases(r, rpLister.ReleasePayloads(r.Target.Namespace))
 		}
 		if r.Config.Name != streamName {
 			continue


### PR DESCRIPTION
Fix the `/latest` API endpoint and upgrade source resolution to use ReleasePayload conditions instead of the phase annotation when determining accepted releases.

`LatestForStream` and `GetStableReleases` create their own `Release` objects internally via `ReleaseDefinition`, which left `PayloadPhases` unpopulated. `UnsortedSemanticReleaseTags` (which filters by phase) fell back to the annotation, returning stale results when the annotation and ReleasePayload disagreed — for example, a release whose ReleasePayload says Accepted but whose annotation was set to Rejected by the old pre-migration code.

Changes

- Defined a `ReleasePayloadLister` interface in `pkg/release-controller/release.go` with a `ReleasePayloads(namespace)` method, satisfied by both `MultiReleasePayloadLister` (sync loop) and the generated `ReleasePayloadLister` (API binary)
- Added an `rpLister ReleasePayloadLister` parameter to `GetStableReleases` and `LatestForStream`; both now call `PopulatePayloadPhases` on each `Release` they create
- Updated all 8 callers across both binaries to pass the lister

Impact

  - `/api/v1/releasestream/{stream}/latest` now returns the correct most-recently-accepted release based on ReleasePayload conditions
  - Upgrade source resolution in `sync_verify.go `picks the correct "from" release for upgrade tests
  - Jira and candidate handlers also benefit from consistent phase resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release selection now uses more complete release metadata, improving how stable, latest, and upgrade targets are determined.
  * Tag phase handling is more reliable, with fallback support when the primary phase data is unavailable.

* **Bug Fixes**
  * Improved accuracy for release lookups across stable, candidate, nightly, and upgrade flows.
  * Fixed cases where issue sync and version derivation could use incomplete phase information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->