### PR TITLE
Addressing a couple issues impacting 4.23 nightly releases

### DIFF
--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -351,8 +351,8 @@ func (a *AuditTracker) Sync(release *releasecontroller.Release) {
 		if len(tag.Name) == 0 {
 			continue
 		}
-		phase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
-		if phase != "Accepted" && phase != "Ready" && phase != "Rejected" {
+		phase := releasecontroller.GetTagPhase(release, &tag)
+		if phase != releasecontroller.ReleasePhaseAccepted && phase != releasecontroller.ReleasePhaseReady && phase != releasecontroller.ReleasePhaseRejected {
 			continue
 		}
 

--- a/pkg/cmd/release-payload-controller/payload_accepted_controller.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller.go
@@ -148,15 +148,13 @@ func computeReleasePayloadAcceptedCondition(payload *v1alpha1.ReleasePayload) me
 	}
 
 	// When there are no blocking jobs, wait for all informing/upgrade jobs to
-	// finish before accepting. Failures do not prevent acceptance — only pending
-	// jobs delay it. We check for pending jobs directly rather than using
-	// ComputeJobState, because ComputeJobState prioritizes failure over pending
-	// (designed for blocking jobs where failure is terminal). Here, a failed job
-	// alongside a pending job must still wait for the pending job to complete.
+	// reach a terminal state before accepting. A job is terminal when its
+	// aggregate state is Success or Failure. Any other state (Pending, Unknown,
+	// or unset) means the job has not finished and acceptance must wait.
 	if len(payload.Status.BlockingJobResults) == 0 {
 		allJobs := append(payload.Status.InformingJobResults, payload.Status.UpgradeJobResults...)
 		for _, job := range allJobs {
-			if job.AggregateState == v1alpha1.JobStatePending {
+			if job.AggregateState != v1alpha1.JobStateSuccess && job.AggregateState != v1alpha1.JobStateFailure {
 				acceptedCondition.Status = metav1.ConditionUnknown
 				return acceptedCondition
 			}

--- a/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
@@ -559,6 +559,22 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			},
 		},
 		{
+			name: "InformingJobsWithUnsetStateNoBlockingJobs",
+			payload: &v1alpha1.ReleasePayload{
+				Status: v1alpha1.ReleasePayloadStatus{
+					InformingJobResults: []v1alpha1.JobStatus{
+						{CIConfigurationName: "informing-a"},
+						{CIConfigurationName: "informing-b"},
+					},
+				},
+			},
+			expected: metav1.Condition{
+				Type:   v1alpha1.ConditionPayloadAccepted,
+				Status: metav1.ConditionUnknown,
+				Reason: ReleasePayloadAcceptedReason,
+			},
+		},
+		{
 			name: "OnlyUpgradeJobsSuccessfulNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{


### PR DESCRIPTION
Fix premature acceptance of releases that have only informing jobs and no blocking jobs.

The PayloadAcceptedController checked for pending informing jobs using job.AggregateState == JobStatePending, but newly initialized jobs have an unset (null/empty) aggregate state — not "Pending".  The check missed these jobs entirely, causing the controller to accept the release immediately before any verification jobs ran.

This affected release configs with only informing jobs (no blocking jobs), such as 4.23.0-0.nightly, where releases were accepted with zero job results.

Changes

- Changed the informing-only acceptance check from matching == JobStatePending to rejecting anything that isn't a terminal state (!= JobStateSuccess && != JobStateFailure). This correctly treats unset, Unknown, and Pending states as "not done yet."
- Added test case InformingJobsWithUnsetStateNoBlockingJobs to cover the null aggregate state scenario.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release audit tracking by using the correct computed phase for release tags.
  * Updated release payload acceptance to wait for all jobs that have not reached a terminal success or failure state.
  * Ensured payload acceptance remains unknown when informing jobs have no reported status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->