### PR TITLE
Prevent premature acceptance/rejection

### DIFF
--- a/pkg/cmd/release-payload-controller/payload_accepted_controller.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller.go
@@ -124,11 +124,16 @@ func computeReleasePayloadAcceptedCondition(payload *v1alpha1.ReleasePayload) me
 		Reason: ReleasePayloadAcceptedReason,
 	}
 
-	// If the release creation job failed, then the payload will never be Accepted
+	// The release creation job must complete successfully before acceptance can
+	// be considered — including manual overrides, since there is no physical
+	// release to accept until the creation job succeeds.
 	if payload.Status.ReleaseCreationJobResult.Status == v1alpha1.ReleaseCreationJobFailed {
 		acceptedCondition.Status = metav1.ConditionFalse
 		acceptedCondition.Reason = ReleasePayloadCreationJobFailedReason
 		acceptedCondition.Message = payload.Status.ReleaseCreationJobResult.Message
+		return acceptedCondition
+	}
+	if payload.Status.ReleaseCreationJobResult.Status != v1alpha1.ReleaseCreationJobSuccess {
 		return acceptedCondition
 	}
 
@@ -140,7 +145,6 @@ func computeReleasePayloadAcceptedCondition(payload *v1alpha1.ReleasePayload) me
 		acceptedCondition.Reason = ReleasePayloadManuallyAcceptedReason
 		return acceptedCondition
 	case v1alpha1.ReleasePayloadOverrideRejected:
-		// If a payload has already been rejected, then we do not want to process it any further...
 		acceptedCondition.Status = metav1.ConditionFalse
 		acceptedCondition.Message = payload.Spec.PayloadOverride.Reason
 		acceptedCondition.Reason = ReleasePayloadManuallyRejectedReason

--- a/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_accepted_controller_test.go
@@ -29,7 +29,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			payload: &v1alpha1.ReleasePayload{},
 			expected: metav1.Condition{
 				Type:   v1alpha1.ConditionPayloadAccepted,
-				Status: metav1.ConditionTrue,
+				Status: metav1.ConditionUnknown,
 				Reason: ReleasePayloadAcceptedReason,
 			},
 		},
@@ -151,7 +151,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			},
 		},
 		{
-			name: "CreationJobUnknownDoesNotShortCircuit",
+			name: "CreationJobUnknownBlocksAcceptance",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
 					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
@@ -164,7 +164,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			},
 			expected: metav1.Condition{
 				Type:   v1alpha1.ConditionPayloadAccepted,
-				Status: metav1.ConditionTrue,
+				Status: metav1.ConditionUnknown,
 				Reason: ReleasePayloadAcceptedReason,
 			},
 		},
@@ -177,6 +177,9 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 						Override: v1alpha1.ReleasePayloadOverrideAccepted,
 						Reason:   "Manually accepted per TRT",
 					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 				},
 			},
 			expected: metav1.Condition{
@@ -195,6 +198,9 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 						Reason:   "Manually rejected per TRT",
 					},
 				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
+				},
 			},
 			expected: metav1.Condition{
 				Type:    v1alpha1.ConditionPayloadAccepted,
@@ -211,6 +217,9 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 						Override: v1alpha1.ReleasePayloadOverrideAccepted,
 					},
 				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
+				},
 			},
 			expected: metav1.Condition{
 				Type:   v1alpha1.ConditionPayloadAccepted,
@@ -225,6 +234,9 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 					PayloadOverride: v1alpha1.ReleasePayloadOverride{
 						Override: v1alpha1.ReleasePayloadOverrideRejected,
 					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 				},
 			},
 			expected: metav1.Condition{
@@ -243,6 +255,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateFailure},
 						{AggregateState: v1alpha1.JobStateFailure},
@@ -266,6 +279,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 						{AggregateState: v1alpha1.JobStateSuccess},
@@ -284,6 +298,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "AllBlockingJobsSuccessful",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "job-a", AggregateState: v1alpha1.JobStateSuccess},
 						{CIConfigurationName: "job-b", AggregateState: v1alpha1.JobStateSuccess},
@@ -301,6 +316,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "SingleBlockingJobSuccessful",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 					},
@@ -316,6 +332,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "SingleBlockingJobFailed",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateFailure},
 					},
@@ -331,6 +348,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "SingleBlockingJobPending",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStatePending},
 					},
@@ -346,6 +364,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "MixOfSuccessAndPendingBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 						{AggregateState: v1alpha1.JobStatePending},
@@ -363,6 +382,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "MixOfSuccessAndFailedBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 						{AggregateState: v1alpha1.JobStateSuccess},
@@ -380,6 +400,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "FailureTakesPrecedenceOverPendingInBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 						{AggregateState: v1alpha1.JobStateFailure},
@@ -397,6 +418,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "AllBlockingJobsPending",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStatePending},
 						{AggregateState: v1alpha1.JobStatePending},
@@ -413,6 +435,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "AllBlockingJobsFailed",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateFailure},
 						{AggregateState: v1alpha1.JobStateFailure},
@@ -429,6 +452,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "BlockingJobWithUnknownState",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 						{AggregateState: v1alpha1.JobStateUnknown},
@@ -446,6 +470,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "BlockingJobWithEmptyAggregateState",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 						{AggregateState: ""},
@@ -463,6 +488,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "NoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{},
 				},
 			},
@@ -477,6 +503,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "InformingJobFailureDoesNotAffectAcceptance",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 					},
@@ -495,6 +522,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "UpgradeJobFailureDoesNotAffectAcceptance",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{AggregateState: v1alpha1.JobStateSuccess},
 					},
@@ -514,6 +542,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "OnlyInformingJobsSuccessfulNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
 						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateSuccess},
@@ -530,6 +559,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "OnlyInformingJobsWithFailuresNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
 						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateFailure},
@@ -546,6 +576,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "OnlyInformingJobsPendingNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStatePending},
 						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateSuccess},
@@ -562,6 +593,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "InformingJobsWithUnsetStateNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a"},
 						{CIConfigurationName: "informing-b"},
@@ -578,6 +610,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "OnlyUpgradeJobsSuccessfulNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					UpgradeJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStateSuccess},
 					},
@@ -593,6 +626,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "OnlyUpgradeJobsPendingNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					UpgradeJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "upgrade-a", AggregateState: v1alpha1.JobStatePending},
 					},
@@ -608,6 +642,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "MixedInformingAndUpgradeJobsPendingNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
 					},
@@ -629,6 +664,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "MixedInformingAndUpgradeJobsFailureAndPendingNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateFailure},
 					},
@@ -647,6 +683,7 @@ func TestComputeReleasePayloadAcceptedCondition(t *testing.T) {
 			name: "MixedInformingAndUpgradeJobsCompleteNoBlockingJobs",
 			payload: &v1alpha1.ReleasePayload{
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					InformingJobResults: []v1alpha1.JobStatus{
 						{CIConfigurationName: "informing-a", AggregateState: v1alpha1.JobStateSuccess},
 						{CIConfigurationName: "informing-b", AggregateState: v1alpha1.JobStateFailure},
@@ -695,6 +732,9 @@ func TestPayloadAcceptedSync(t *testing.T) {
 						Reason:   "Manually accepted per TRT",
 					},
 				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
+				},
 			},
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -708,6 +748,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -733,6 +774,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadRejected,
@@ -755,6 +797,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -785,6 +828,9 @@ func TestPayloadAcceptedSync(t *testing.T) {
 						Reason:   "Manually rejected per TRT",
 					},
 				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
+				},
 			},
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -798,6 +844,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -823,6 +870,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadRejected,
@@ -845,6 +893,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -870,6 +919,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -889,6 +939,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -918,6 +969,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -937,6 +989,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -966,6 +1019,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -985,6 +1039,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -1014,6 +1069,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -1033,6 +1089,7 @@ func TestPayloadAcceptedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,

--- a/pkg/cmd/release-payload-controller/payload_rejected_controller.go
+++ b/pkg/cmd/release-payload-controller/payload_rejected_controller.go
@@ -141,10 +141,14 @@ func computeReleasePayloadRejectedCondition(payload *v1alpha1.ReleasePayload) me
 		rejectedCondition.Reason = ReleasePayloadManuallyRejectedReason
 		return rejectedCondition
 	case v1alpha1.ReleasePayloadOverrideAccepted:
-		// If a payload has already been accepted, then we do not want to process it any further...
 		rejectedCondition.Status = metav1.ConditionFalse
 		rejectedCondition.Message = payload.Spec.PayloadOverride.Reason
 		rejectedCondition.Reason = ReleasePayloadManuallyAcceptedReason
+		return rejectedCondition
+	}
+
+	// The release creation job must succeed before rejection can be evaluated
+	if payload.Status.ReleaseCreationJobResult.Status != v1alpha1.ReleaseCreationJobSuccess {
 		return rejectedCondition
 	}
 

--- a/pkg/cmd/release-payload-controller/payload_rejected_controller.go
+++ b/pkg/cmd/release-payload-controller/payload_rejected_controller.go
@@ -133,7 +133,14 @@ func computeReleasePayloadRejectedCondition(payload *v1alpha1.ReleasePayload) me
 		return rejectedCondition
 	}
 
-	// Check for "Accepted" PayloadOverride
+	// The release creation job must succeed before rejection can be evaluated,
+	// including manual overrides — there is no physical release to reject until
+	// the creation job completes.
+	if payload.Status.ReleaseCreationJobResult.Status != v1alpha1.ReleaseCreationJobSuccess {
+		return rejectedCondition
+	}
+
+	// Check for PayloadOverride
 	switch payload.Spec.PayloadOverride.Override {
 	case v1alpha1.ReleasePayloadOverrideRejected:
 		rejectedCondition.Status = metav1.ConditionTrue
@@ -144,11 +151,6 @@ func computeReleasePayloadRejectedCondition(payload *v1alpha1.ReleasePayload) me
 		rejectedCondition.Status = metav1.ConditionFalse
 		rejectedCondition.Message = payload.Spec.PayloadOverride.Reason
 		rejectedCondition.Reason = ReleasePayloadManuallyAcceptedReason
-		return rejectedCondition
-	}
-
-	// The release creation job must succeed before rejection can be evaluated
-	if payload.Status.ReleaseCreationJobResult.Status != v1alpha1.ReleaseCreationJobSuccess {
 		return rejectedCondition
 	}
 

--- a/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
@@ -177,6 +177,53 @@ func TestPayloadRejectedSync(t *testing.T) {
 			},
 		},
 		{
+			name: "CreationJobFailedTakesPrecedenceOverAcceptanceOverride",
+			input: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Manually accepted per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status:  v1alpha1.ReleaseCreationJobFailed,
+						Message: "BackoffLimitExceeded",
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Manually accepted per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{
+						Status:  v1alpha1.ReleaseCreationJobFailed,
+						Message: "BackoffLimitExceeded",
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:    v1alpha1.ConditionPayloadRejected,
+							Status:  metav1.ConditionTrue,
+							Reason:  ReleasePayloadCreationJobFailedReason,
+							Message: "BackoffLimitExceeded",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "TestPayloadOverrideRejectedAfterAccepted",
 			input: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
@@ -211,6 +211,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -230,6 +231,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -259,6 +261,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -278,6 +281,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -307,6 +311,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -326,6 +331,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -355,6 +361,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -374,6 +381,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -403,6 +411,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,
@@ -422,6 +431,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					Namespace: "ocp",
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					BlockingJobResults: []v1alpha1.JobStatus{
 						{
 							AggregateState: v1alpha1.JobStateSuccess,

--- a/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
@@ -65,6 +65,118 @@ func TestPayloadRejectedSync(t *testing.T) {
 			},
 		},
 		{
+			name: "CreationJobUnsetBlocksRejectionOverride",
+			input: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Manually rejected per TRT",
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Manually rejected per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   v1alpha1.ConditionPayloadRejected,
+							Status: metav1.ConditionUnknown,
+							Reason: ReleasePayloadRejectedReason,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CreationJobUnknownBlocksRejectionOverride",
+			input: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Manually rejected per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobUnknown},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideRejected,
+						Reason:   "Manually rejected per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobUnknown},
+					Conditions: []metav1.Condition{
+						{
+							Type:   v1alpha1.ConditionPayloadRejected,
+							Status: metav1.ConditionUnknown,
+							Reason: ReleasePayloadRejectedReason,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CreationJobUnsetBlocksAcceptanceOverride",
+			input: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Manually accepted per TRT",
+					},
+				},
+			},
+			expected: &v1alpha1.ReleasePayload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "4.11.0-0.nightly-2022-02-09-091559",
+					Namespace: "ocp",
+				},
+				Spec: v1alpha1.ReleasePayloadSpec{
+					PayloadOverride: v1alpha1.ReleasePayloadOverride{
+						Override: v1alpha1.ReleasePayloadOverrideAccepted,
+						Reason:   "Manually accepted per TRT",
+					},
+				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   v1alpha1.ConditionPayloadRejected,
+							Status: metav1.ConditionUnknown,
+							Reason: ReleasePayloadRejectedReason,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "TestPayloadOverrideRejectedAfterAccepted",
 			input: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
+++ b/pkg/cmd/release-payload-controller/payload_rejected_controller_test.go
@@ -36,6 +36,9 @@ func TestPayloadRejectedSync(t *testing.T) {
 						Reason:   "Manually rejected per TRT",
 					},
 				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
+				},
 			},
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -49,6 +52,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadRejected,
@@ -74,6 +78,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -96,6 +101,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -126,6 +132,9 @@ func TestPayloadRejectedSync(t *testing.T) {
 						Reason:   "Manually accepted per TRT",
 					},
 				},
+				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
+				},
 			},
 			expected: &v1alpha1.ReleasePayload{
 				ObjectMeta: metav1.ObjectMeta{
@@ -139,6 +148,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadRejected,
@@ -164,6 +174,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,
@@ -186,6 +197,7 @@ func TestPayloadRejectedSync(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.ReleasePayloadStatus{
+					ReleaseCreationJobResult: v1alpha1.ReleaseCreationJobResult{Status: v1alpha1.ReleaseCreationJobSuccess},
 					Conditions: []metav1.Condition{
 						{
 							Type:    v1alpha1.ConditionPayloadAccepted,


### PR DESCRIPTION
Prevent premature acceptance or rejection of releases before the creation job completes.

The `PayloadAcceptedController` and `PayloadRejectedController` evaluated job results and overrides without first confirming the release creation job had succeeded. This caused two problems:

1. Releases with only informing jobs (no blocking jobs) were accepted immediately because the informing-only path checked `job.AggregateState == JobStatePending,` which missed jobs with unset/null aggregate state. These were treated as "not pending" and the release was accepted before any verification ran.
2. Releases with no tests at all were accepted instantly — zero blocking + zero informing jobs meant the loop body never executed, falling through to `Accepted=True` before the release image even existed.

Changes

PayloadAcceptedController:
- Added a guard requiring `ReleaseCreationJobResult.Status == Success` before evaluating job results or overrides. A release cannot be accepted (even manually) until the creation job succeeds, since there is no physical release to point to.
- Creation job failure still takes highest precedence (`Accepted=False`).
- Fixed the informing-only check from `== JobStatePending` to `!= JobStateSuccess && != JobStateFailure`, correctly treating unset/Unknown/Pending states as "not done yet."

PayloadRejectedController:
- Same creation job success guard added, placed after the creation-job-failed check and before overrides/job evaluation.

Precedence order (both controllers):
1. Creation job failed → terminal (Accepted=False / Rejected=True)
2. Creation job not yet succeeded → Unknown (wait)
3. Manual override → accept/reject
4. Job results → normal evaluation

Tests:
- Updated `EmptyPayload` to expect `Unknown` instead of `True`
- Renamed `CreationJobUnknownDoesNotShortCircuit` to `CreationJobUnknownBlocksAcceptance`
- Added `InformingJobsWithUnsetStateNoBlockingJobs` test case
- All test fixtures with job results now include a successful creation job result

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release payload acceptance is now gated on the release creation job reaching **Success**; pending/unknown/unset results keep the acceptance outcome unresolved.
  - Release payload rejection is no longer evaluated (including manual overrides) unless the release creation job result is **Success**.
  - Manual acceptance overrides no longer fall through into subsequent rejection evaluation, while override reasons/messages are preserved.
  - Failed creation jobs continue to surface clear failure details.
- **Tests**
  - Updated and expanded controller unit tests for acceptance/rejection gating across unset/unknown/failed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->