### PR TITLE
Ensure accepted releases are mirrored to alternate image repository

### DIFF
--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -515,11 +515,27 @@ func (c *Controller) syncAccepted(release *releasecontroller.Release) error {
 		klog.Infof("release=%s accepted=%v", release.Config.Name, releasecontroller.TagNames(acceptedTags))
 	}
 
-	if len(release.Config.Publish) == 0 || len(acceptedTags) == 0 {
+	if len(acceptedTags) == 0 {
+		return nil
+	}
+
+	// Mirror the newest accepted release to the alternate image repository
+	// (e.g. quay.io). This is normally done in syncReady, but if a release
+	// transitions directly to Accepted before syncReady processes it, the
+	// mirror job is never created. Only the newest accepted release is
+	// mirrored here to avoid recreating pruned jobs for old releases.
+	newestAccepted := acceptedTags[0]
+	mirror, err := releasecontroller.GetMirror(release, newestAccepted.Name, c.releaseLister)
+	if err != nil {
+		klog.Errorf("Failed to identify `from` mirror for creation of release mirror job: %v", err)
+	} else if _, err := c.ensureReleaseMirrorJob(release, newestAccepted.Name, mirror); err != nil {
+		klog.Errorf("Failed to create release mirror job: %v", err)
+	}
+
+	if len(release.Config.Publish) == 0 {
 		return nil
 	}
 	var errs []error
-	newestAccepted := acceptedTags[0]
 	for name, publishType := range release.Config.Publish {
 		if publishType.Disabled {
 			continue


### PR DESCRIPTION
## Summary

The mirror job (`ensureReleaseMirrorJob`) that copies releases to the alternate image repository (e.g. quay.io) was only called during `syncReady`. If a release transitions to `Accepted` before `syncReady` processes it, the mirror job is never created and the image never appears on quay.io.

This is a race between the release-payload-controller (which updates the CRD to `Accepted`) and the release-controller (which runs `syncReady`). When the CRD wins, the release skips `readyTags` entirely and the mirror is permanently missed.

This change calls `ensureReleaseMirrorJob` for the newest accepted release in `syncAccepted`. Only the newest release is mirrored to avoid recreating pruned jobs for old releases that may no longer have source images in the internal registry. The function is idempotent (`ensureJob` checks for existing jobs), so releases already mirrored during `syncReady` are not affected.

Older missed releases (e.g. the 4.23 multi nightlies from July 9-13) will need to be mirrored manually.