### PR TITLE
OCPCRT-522: Prevent verification names that end with digits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+/data/
 
 /release-controller
 /release-controller-api

--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -230,7 +230,7 @@ func validateVerifyNames(releaseConfigs []releasecontroller.ReleaseConfig) []err
 	for _, config := range releaseConfigs {
 		for name := range config.Verify {
 			if trailingDashDigitPattern.MatchString(name) {
-				errors = append(errors, fmt.Errorf("%s: verification job %q must not end with a dash followed by a number (e.g. %q)", config.Name, name, name))
+				errors = append(errors, fmt.Errorf("%s: verification job %q must not end with a dash followed by a number", config.Name, name))
 			}
 		}
 	}

--- a/cmd/release-controller/config_validate.go
+++ b/cmd/release-controller/config_validate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
@@ -53,6 +54,7 @@ func validateReleaseConfigs(configDir string) error {
 	errors = append(errors, findDuplicatePeriodics(releaseConfigs)...)
 	errors = append(errors, validateQualifiers(releaseConfigs)...)
 	errors = append(errors, validateOptionalAggregatedJobs(releaseConfigs)...)
+	errors = append(errors, validateVerifyNames(releaseConfigs)...)
 	return utilerrors.NewAggregate(errors)
 }
 
@@ -215,6 +217,20 @@ func validateOptionalAggregatedJobs(releaseConfigs []releasecontroller.ReleaseCo
 		for name, verify := range config.Verify {
 			if verify.Optional && verify.AggregatedProwJob != nil {
 				errors = append(errors, fmt.Errorf("%s: verification job %q cannot be both optional and an aggregatedProwJob", config.Name, name))
+			}
+		}
+	}
+	return errors
+}
+
+var trailingDashDigitPattern = regexp.MustCompile(`-\d+$`)
+
+func validateVerifyNames(releaseConfigs []releasecontroller.ReleaseConfig) []error {
+	var errors []error
+	for _, config := range releaseConfigs {
+		for name := range config.Verify {
+			if trailingDashDigitPattern.MatchString(name) {
+				errors = append(errors, fmt.Errorf("%s: verification job %q must not end with a dash followed by a number (e.g. %q)", config.Name, name, name))
 			}
 		}
 	}

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -809,7 +809,7 @@ func TestValidateVerifyNames(t *testing.T) {
 			configs: []releasecontroller.ReleaseConfig{{
 				Name: "4.19.0-0.nightly",
 				Verify: map[string]releasecontroller.ReleaseVerification{
-					"e2e": {},
+					"e2e4": {},
 				},
 			}},
 			expectedErr: false,

--- a/cmd/release-controller/config_validate_test.go
+++ b/cmd/release-controller/config_validate_test.go
@@ -758,6 +758,94 @@ func TestFindDuplicateQualifierIDs(t *testing.T) {
 	}
 }
 
+func TestValidateVerifyNames(t *testing.T) {
+	testCases := []struct {
+		name        string
+		configs     []releasecontroller.ReleaseConfig
+		expectedErr bool
+	}{
+		{
+			name: "valid name",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"aws-e2e": {},
+				},
+			}},
+			expectedErr: false,
+		},
+		{
+			name: "name ending with dash and single digit is invalid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"aws-e2e-1": {},
+				},
+			}},
+			expectedErr: true,
+		},
+		{
+			name: "name ending with dash and multiple digits is invalid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"aws-e2e-10": {},
+				},
+			}},
+			expectedErr: true,
+		},
+		{
+			name: "name with digits in the middle is valid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"aws-4x-e2e": {},
+				},
+			}},
+			expectedErr: false,
+		},
+		{
+			name: "name ending with digit but no dash is valid",
+			configs: []releasecontroller.ReleaseConfig{{
+				Name: "4.19.0-0.nightly",
+				Verify: map[string]releasecontroller.ReleaseVerification{
+					"e2e": {},
+				},
+			}},
+			expectedErr: false,
+		},
+		{
+			name: "multiple configs with one invalid name",
+			configs: []releasecontroller.ReleaseConfig{
+				{
+					Name: "4.18.0-0.nightly",
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"good-job": {},
+					},
+				},
+				{
+					Name: "4.19.0-0.nightly",
+					Verify: map[string]releasecontroller.ReleaseVerification{
+						"bad-job-3": {},
+					},
+				},
+			},
+			expectedErr: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			errs := validateVerifyNames(testCase.configs)
+			if len(errs) > 0 && !testCase.expectedErr {
+				t.Errorf("got error when error was not expected: %v", errs)
+			}
+			if len(errs) == 0 && testCase.expectedErr {
+				t.Errorf("did not get error when error was expected")
+			}
+		})
+	}
+}
+
 func TestValidateReleaseQualifiersConfig(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Validate that Verify job names do not end with a dash-digit suffix

Summary:

Adds a config validation check that rejects Verify map keys ending with a dash followed by digits (e.g. `my-job-1`, `aws-e2e-10`). These suffixes collide with the retry naming convention used by the release controller, which appends `-1`, `-2`, etc. to job names on retry.

Changes:
  - Added `validateVerifyNames()` to `config_validate.go` that matches Verify keys against the pattern `-\d+$`
  - Wired it into the `validateReleaseConfigs` pipeline
  - Added `TestValidateVerifyNames` with cases covering valid names, single/multi-digit suffixes, mid-name digits, and cross-config detection

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent verification job step names from ending with a dash followed by a digit.
  * Improved release configuration checks to report invalid verification names consistently across configurations.
* **Tests**
  * Added table-driven test coverage for valid and invalid verification name formats.
* **Chores**
  * Updated git ignore rules to additionally exclude the `/data/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->