### PR TITLE
Make BigQuery optional for local development

### DIFF
--- a/pkg/cmd/release-payload-controller/cmd.go
+++ b/pkg/cmd/release-payload-controller/cmd.go
@@ -2,7 +2,6 @@ package release_payload_controller
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -83,12 +82,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *Options) Validate(_ context.Context) error {
-	if len(o.GoogleProjectID) == 0 {
-		return errors.New("--google-project-id flag must be set")
-	}
-	if len(o.GoogleServiceAccountCredentialFile) == 0 {
-		return errors.New("--google-service-account-credential-file flag must be set")
-	}
 	if err := o.jira.Validate(false); err != nil {
 		return fmt.Errorf("invalid jira options: %w", err)
 	}
@@ -151,17 +144,22 @@ func (o *Options) Run(ctx context.Context) error {
 		}
 	}
 
-	// BigQuery Client
-	bqc, err := bigquery.NewBigQueryClient(o.GoogleProjectID, o.GoogleServiceAccountCredentialFile)
-	if err != nil {
-		klog.Fatalf("Unable to configure bigquery client: %v", err)
-	}
-	defer bqc.Close()
-
-	var bqClient bigquery.ClientInterface = bqc
-	if o.BigQueryCacheTTL > 0 {
-		bqClient = bigquery.NewCachedClient(bqc, o.BigQueryCacheTTL)
-		klog.Infof("BigQuery caching enabled with TTL: %s", o.BigQueryCacheTTL)
+	// BigQuery Client (optional)
+	var bqClient bigquery.ClientInterface
+	if o.GoogleProjectID != "" && o.GoogleServiceAccountCredentialFile != "" {
+		bqc, err := bigquery.NewBigQueryClient(o.GoogleProjectID, o.GoogleServiceAccountCredentialFile)
+		if err != nil {
+			klog.Infof("BigQuery client not configured, job history lookups will be unavailable: %v", err)
+		} else {
+			defer bqc.Close()
+			bqClient = bqc
+			if o.BigQueryCacheTTL > 0 {
+				bqClient = bigquery.NewCachedClient(bqc, o.BigQueryCacheTTL)
+				klog.Infof("BigQuery caching enabled with TTL: %s", o.BigQueryCacheTTL)
+			}
+		}
+	} else {
+		klog.Infof("BigQuery client not configured, job history lookups will be unavailable")
 	}
 
 	// Jira Client (optional)

--- a/pkg/cmd/release-payload-controller/jira_escalations_controller_test.go
+++ b/pkg/cmd/release-payload-controller/jira_escalations_controller_test.go
@@ -69,6 +69,35 @@ func TestNewJiraEscalationsController(t *testing.T) {
 	}
 }
 
+func TestNewJiraEscalationsControllerWithNilBigQueryClient(t *testing.T) {
+	t.Parallel()
+
+	objs := []runtime.Object{}
+	client := releasepayloadclient.NewSimpleClientset(objs...)
+	informerFactory := releasepayloadinformers.NewSharedInformerFactory(client, 0)
+	releasePayloadInformer := informerFactory.Release().V1alpha1().ReleasePayloads()
+
+	eventRecorder := events.NewInMemoryRecorder("test", clock.RealClock{})
+	configAccessor := &mockConfigAccessor{}
+
+	controller, err := NewJiraEscalationsController(
+		releasePayloadInformer,
+		client.ReleaseV1alpha1(),
+		eventRecorder,
+		configAccessor,
+		nil,
+		nil,
+	)
+
+	if err != nil {
+		t.Fatalf("Failed to create controller: %v", err)
+	}
+
+	if controller == nil {
+		t.Fatal("Expected non-nil controller")
+	}
+}
+
 func TestGetWindowSize(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The bigquery requirement was added recently and makes local development of the majority of release payload controller difficult (since I'd have to set up a bigquery).

As far as I can tell the bigquery stuff is only used in one of the controllers. This PR makes the bigquery client optional (to match the jira client) for local dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* The release payload controller can now start without BigQuery credentials.
* BigQuery initialization is optional when credentials are unavailable, and initialization failures no longer prevent startup.
* Caching remains enabled only when a positive cache duration is configured.
* Jira escalation handling now supports operation when BigQuery is unavailable, reducing avoidable startup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->