### PR TITLE
Fix ConfigMap file watcher failing to detect config updates

### DIFF
--- a/pkg/releasequalifiers/config_loader.go
+++ b/pkg/releasequalifiers/config_loader.go
@@ -79,16 +79,10 @@ func (cl *ConfigLoader) StartWatching(ctx context.Context) error {
 	}
 	cl.watcher = watcher
 
-	// Determine which directory to watch
-	// For ConfigMap support, if the path contains ..data, watch the grandparent directory
-	// to detect when the ..data symlink is replaced
+	// Watch the parent directory of the config file. For ConfigMap mounts this is
+	// the mount root where the ..data symlink lives, so we receive CREATE events
+	// when Kubernetes atomically swaps it during ConfigMap updates.
 	dir := filepath.Dir(cl.configPath)
-
-	// Check if we're in a ConfigMap mount scenario (path contains ..data)
-	if filepath.Base(dir) == "..data" {
-		// Watch the grandparent directory to detect ..data symlink changes
-		dir = filepath.Dir(dir)
-	}
 
 	if err := watcher.Add(dir); err != nil {
 		watcher.Close()
@@ -133,16 +127,8 @@ func (cl *ConfigLoader) watch(ctx context.Context) {
 			if event.Op&fsnotify.Write == fsnotify.Write && event.Name == cl.configPath {
 				// Direct write to config file
 				shouldReload = true
-			} else if event.Op&fsnotify.Create == fsnotify.Create {
-				// ConfigMap scenario: ..data symlink was recreated
-				// Check if the event is for a ..data symlink in our config path
-				dir := filepath.Dir(cl.configPath)
-				if filepath.Base(dir) == "..data" {
-					// We're using a ConfigMap mount, check if ..data was recreated
-					if event.Name == dir {
-						shouldReload = true
-					}
-				}
+			} else if event.Op&fsnotify.Create == fsnotify.Create && filepath.Base(event.Name) == "..data" {
+				shouldReload = true
 			}
 
 			if shouldReload {

--- a/pkg/releasequalifiers/config_loader_test.go
+++ b/pkg/releasequalifiers/config_loader_test.go
@@ -348,41 +348,48 @@ func TestConfigLoaderConfigMapSimulation(t *testing.T) {
 
 	t.Parallel()
 
-	// Simulate ConfigMap structure
+	// Simulate a real Kubernetes ConfigMap mount structure:
+	//   mountRoot/
+	//   ├── ..data -> ..2026_01_01_v1/
+	//   ├── ..2026_01_01_v1/
+	//   │   └── release-qualifiers.yaml
+	//   └── release-qualifiers.yaml -> ..data/release-qualifiers.yaml
+	//
+	// The config path is the top-level symlink (release-qualifiers.yaml),
+	// NOT a path through ..data.
 	tmpDir := t.TempDir()
 
-	// Create ..data_v1 directory with config file
-	dataDir1 := filepath.Join(tmpDir, "..data_v1")
+	// Create timestamped data directory v1
+	dataDir1 := filepath.Join(tmpDir, "..2026_01_01_v1")
 	if err := os.Mkdir(dataDir1, 0755); err != nil {
 		t.Fatalf("Failed to create data directory: %v", err)
 	}
-	configFile1 := filepath.Join(dataDir1, "config.yaml")
-	initialContent := `qualifiers:
+	if err := os.WriteFile(filepath.Join(dataDir1, "release-qualifiers.yaml"), []byte(`qualifiers:
   test-qualifier:
     enabled: true
     badgeName: Version1
-`
-	if err := os.WriteFile(configFile1, []byte(initialContent), 0644); err != nil {
+`), 0644); err != nil {
 		t.Fatalf("Failed to write initial config file: %v", err)
 	}
 
-	// Create ..data symlink pointing to ..data_v1
-	symlinkPath := filepath.Join(tmpDir, "..data")
-	if err := os.Symlink(dataDir1, symlinkPath); err != nil {
-		t.Fatalf("Failed to create symlink: %v", err)
+	// Create ..data symlink pointing to v1
+	dataSym := filepath.Join(tmpDir, "..data")
+	if err := os.Symlink(dataDir1, dataSym); err != nil {
+		t.Fatalf("Failed to create ..data symlink: %v", err)
 	}
 
-	// Config path points through the symlink
-	configPath := filepath.Join(symlinkPath, "config.yaml")
+	// Create top-level file symlink (this is what the controller uses as configPath)
+	configSym := filepath.Join(tmpDir, "release-qualifiers.yaml")
+	if err := os.Symlink(filepath.Join("..data", "release-qualifiers.yaml"), configSym); err != nil {
+		t.Fatalf("Failed to create config symlink: %v", err)
+	}
 
-	loader, err := NewConfigLoader(configPath)
+	loader, err := NewConfigLoader(configSym)
 	if err != nil {
 		t.Fatalf("NewConfigLoader() error = %v", err)
 	}
 
 	ctx := t.Context()
-
-	// Start watching
 	if err := loader.StartWatching(ctx); err != nil {
 		t.Fatalf("StartWatching() error = %v", err)
 	}
@@ -393,33 +400,31 @@ func TestConfigLoaderConfigMapSimulation(t *testing.T) {
 		t.Errorf("Expected BadgeName 'Version1', got '%s'", config["test-qualifier"].BadgeName)
 	}
 
-	// Simulate ConfigMap update: create new version directory
-	dataDir2 := filepath.Join(tmpDir, "..data_v2")
+	// Simulate ConfigMap update: Kubernetes creates a new timestamped dir,
+	// then atomically replaces the ..data symlink.
+	dataDir2 := filepath.Join(tmpDir, "..2026_01_01_v2")
 	if err := os.Mkdir(dataDir2, 0755); err != nil {
 		t.Fatalf("Failed to create new data directory: %v", err)
 	}
-	configFile2 := filepath.Join(dataDir2, "config.yaml")
-	updatedContent := `qualifiers:
+	if err := os.WriteFile(filepath.Join(dataDir2, "release-qualifiers.yaml"), []byte(`qualifiers:
   test-qualifier:
     enabled: true
     badgeName: Version2
-`
-	if err := os.WriteFile(configFile2, []byte(updatedContent), 0644); err != nil {
+`), 0644); err != nil {
 		t.Fatalf("Failed to write updated config file: %v", err)
 	}
 
-	// Remove old symlink and create new one (atomic update)
-	if err := os.Remove(symlinkPath); err != nil {
-		t.Fatalf("Failed to remove old symlink: %v", err)
+	// Atomic symlink swap (remove + create)
+	if err := os.Remove(dataSym); err != nil {
+		t.Fatalf("Failed to remove old ..data symlink: %v", err)
 	}
-	if err := os.Symlink(dataDir2, symlinkPath); err != nil {
-		t.Fatalf("Failed to create new symlink: %v", err)
+	if err := os.Symlink(dataDir2, dataSym); err != nil {
+		t.Fatalf("Failed to create new ..data symlink: %v", err)
 	}
 
 	// Wait for file watcher to detect change
 	time.Sleep(500 * time.Millisecond)
 
-	// Verify updated config
 	config = loader.Get()
 	if config["test-qualifier"].BadgeName != "Version2" {
 		t.Errorf("Expected BadgeName 'Version2' after ConfigMap update, got '%s'", config["test-qualifier"].BadgeName)


### PR DESCRIPTION
Summary

- Fix ConfigMap file watcher not detecting config updates in `ConfigLoader`
- The event handler checked `filepath.Base(filepath.Dir(configPath))` to detect `..data` symlink recreation, which evaluates to the mount directory name (e.g. `"qualifiers-config"`), never `"..data"` — so ConfigMap updates were silently ignored
- Changed to check `filepath.Base(event.Name) == "..data"` which correctly matches the fsnotify CREATE event fired when Kubernetes atomically swaps the `..data` symlink
- Cleaned up dead `..data` branch in `StartWatching` (harmless but misleading)
- Updated `TestConfigLoaderConfigMapSimulation` to use the real Kubernetes ConfigMap directory layout (top-level file symlink pointing through `..data`) instead of a config path routed directly through `..data`


rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration monitoring for Kubernetes ConfigMap mounts.
  * Configuration changes are now detected reliably when mounted data symlinks are recreated.
  * Updated configuration reload handling to ensure refreshed qualifier settings are loaded automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->