### PR TITLE
Remove log annotation write and display failure message from ReleasePayload CR

### DIFF
--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1436,6 +1436,7 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 				fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(msg))
 			}
 		}
+		// TODO: Remove once all historical releases with this annotation have aged out.
 		if log := tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationLog]; len(log) > 0 {
 			fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(log))
 		} else {

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1429,17 +1429,20 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 	switch c.resolvePhase(*tagInfo.Info.Tag) {
 	case releasecontroller.ReleasePhaseFailed:
 		fmt.Fprintf(w, `<div class="alert alert-danger">`)
+		hasFailureMessage := false
 		if payload := c.GetReleasePayload(tagInfo.Tag); payload != nil {
 			if payload.Spec.PayloadOverride.Reason != "" {
 				fmt.Fprintf(w, `<p>%s</p>`, template.HTMLEscapeString(payload.Spec.PayloadOverride.Reason))
+				hasFailureMessage = true
 			} else if msg := payload.Status.ReleaseCreationJobResult.Message; msg != "" {
 				fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(msg))
+				hasFailureMessage = true
 			}
 		}
 		// TODO: Remove once all historical releases with this annotation have aged out.
 		if log := tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationLog]; len(log) > 0 {
 			fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(log))
-		} else {
+		} else if !hasFailureMessage {
 			fmt.Fprintf(w, `<div><em>No failure log was captured</em></div>`)
 		}
 		fmt.Fprintf(w, `</div>`)

--- a/cmd/release-controller-api/http.go
+++ b/cmd/release-controller-api/http.go
@@ -1440,10 +1440,12 @@ func (c *Controller) httpReleaseInfo(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 		// TODO: Remove once all historical releases with this annotation have aged out.
-		if log := tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationLog]; len(log) > 0 {
-			fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(log))
-		} else if !hasFailureMessage {
-			fmt.Fprintf(w, `<div><em>No failure log was captured</em></div>`)
+		if !hasFailureMessage {
+			if log := tagInfo.Info.Tag.Annotations[releasecontroller.ReleaseAnnotationLog]; len(log) > 0 {
+				fmt.Fprintf(w, `<pre class="small">%s</pre>`, template.HTMLEscapeString(log))
+			} else {
+				fmt.Fprintf(w, `<div><em>No failure log was captured</em></div>`)
+			}
 		}
 		fmt.Fprintf(w, `</div>`)
 		return

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -384,8 +384,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 				}
 				c.precacheChangelog(release, tag)
 			case releasecontroller.ReleasePhaseFailed:
-				log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "status.phase=Failed", "build", false)
-				if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
+				if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
 					return err
 				}
 			default:
@@ -440,8 +439,7 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 			}
 			c.precacheChangelog(release, tag)
 		case releasecontroller.ReleasePhaseFailed:
-			log, _, _ := ensureJobTerminationMessageRetrieved(c.podClient, job, "status.phase=Failed", "build", false)
-			if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, withLog(reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), log), tag.Name); err != nil {
+			if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
 				return err
 			}
 		default:

--- a/cmd/release-controller/sync_tags.go
+++ b/cmd/release-controller/sync_tags.go
@@ -373,13 +373,6 @@ func reasonAndMessage(reason, message string) map[string]string {
 	}
 }
 
-func withLog(annotations map[string]string, log string) map[string]string {
-	if len(log) > 0 {
-		annotations[releasecontroller.ReleaseAnnotationLog] = log
-	}
-	return annotations
-}
-
 func updateReleaseTarget(release *releasecontroller.Release, is *imagev1.ImageStream) {
 	if release.Config.As == releasecontroller.ReleaseConfigModeStable {
 		release.Source = is


### PR DESCRIPTION
Summary

- Display `ReleaseCreationJobResult.Message` from the `ReleasePayload` CR in the UI failure alert, replacing the annotation-based message removed during imagestreamtag deprecation
- Remove the `withLog` annotation write from `syncPending` and the `withLog` helper, since the  `ReleaseCreationStatusController` now captures pod termination messages directly into the CR
- Retain the `release.openshift.io/log` annotation read in the UI as a fallback for historical releases
  
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure display for release info by suppressing the “No failure log was captured” placeholder when payload failure details are available, even if an annotation log is missing.
  * Enhanced failure reporting for release image creation failures with a more consistent failure reason.
  * Reduced noise in failed release transitions by no longer attaching additional log details during the pending-to-failed update flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->