### PR TITLE
NO-ISSUE: pkg/release-controller/release_info: Bump files-cache requests to 2.5 CPUs and 500MiB memory

### DIFF
--- a/pkg/release-controller/release_info.go
+++ b/pkg/release-controller/release_info.go
@@ -1551,8 +1551,8 @@ func (r *ExecReleaseFiles) specHash(image string) appsv1.StatefulSetSpec {
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("50m"),
-								corev1.ResourceMemory: resource.MustParse("200Mi"),
+								corev1.ResourceCPU:    resource.MustParse("2.5"),
+								corev1.ResourceMemory: resource.MustParse("500Mi"),
 							},
 						},
 


### PR DESCRIPTION
Some Nodes are spending a bunch of time CPU-pegged:

```console
$ oc adm top node ip-10-0-138-188.ec2.internal
NAME                           CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)
ip-10-0-138-188.ec2.internal   8000m        106%     15812Mi         52%
```

And that's lasting [for hours][1]:

    sum by (instance,mode) (rate(node_cpu_seconds_total{instance='ip-10-0-138-188.ec2.internal'}[5m])) > 0.1

<img width="1580" height="748" alt="image" src="https://github.com/user-attachments/assets/d2bcb747-025b-42ba-8cef-ca231f168d9d" />

because the Node is hosting multiple files-cache Pods, each [consuming around 2 CPU][2]:

    max by (namespace, container) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{node='ip-10-0-138-188.ec2.internal', pod="files-cache-0"})

<img width="1580" height="748" alt="image" src="https://github.com/user-attachments/assets/86a5c10d-159a-4b80-bac2-c51646dc16f3" />

Checking the cluster as a whole, there seems to be a split between super-hungry files-cache Pods (up to 2.6 CPU and 1.5 GiB of memory), and others using hardly any CPU or memory:

```console
$ oc get namespaces | grep ci-release | cut -d' ' -f1 | while read NS; do oc -n "${NS}" adm top pod files-cache-0 2>/dev/null; done | sort -r | grep -B1 files-cache
NAME            CPU(cores)   MEMORY(bytes)
files-cache-0   868m         405Mi
files-cache-0   2640m        4421Mi
files-cache-0   2464m        1510Mi
files-cache-0   1m           48Mi
files-cache-0   1m           46Mi
files-cache-0   1m           46Mi
files-cache-0   1m           46Mi
files-cache-0   1m           46Mi
files-cache-0   1m           46Mi
files-cache-0   1865m        431Mi
```

Request a higher value, though, so the scheduler has a better idea of how much they can use.  Maybe we'll spend a bit more on cloud capacity as a result, but we'll be less likely to wait hours while a CPU-starved Node tries to build us new nightlies, at 5m an image:

```console
$ oc -n ci-release logs --timestamps 5.0.0-0.nightly-2026-07-24-221438-tqwcw
2026-07-24T23:32:50.244438621Z Saved credentials for registry.ci.openshift.org into /tmp/.docker/config.json
2026-07-24T23:32:50.244568119Z info: Using registry public hostname registry.ci.openshift.org
2026-07-24T23:34:01.286459397Z info: Found 198 images in image stream
2026-07-24T23:34:14.469510936Z info: Loading sha256:8edf93606317800546b7a3e719aee62325d0efdf9b66835cc98843a5c10773f4 agent-installer-csr-approver
2026-07-24T23:34:15.358837998Z info: Loading sha256:4c0846e9652667f0e0eac7d465b001470c4f077dc7e72186c9f5aaecc27e8ad5 agent-installer-api-server
2026-07-24T23:34:15.360034601Z info: Loading sha256:f474fac3f107f4b2c281d520bf49f76ac10a733f13fa7deb64a2fa1b4b367ebc agent-installer-node-agent
2026-07-24T23:34:15.380424571Z info: Loading sha256:df45b021a93bc11ed4aa4efcad87832ea0df9cc42a0112088627fc3b1bd8b9f0 agent-installer-orchestrator
2026-07-24T23:40:43.761434485Z info: Loading sha256:04c6a5407ef6ad4593983aace0e4fca9eb6dae23aaa1eace445e6ac95009b8fc agent-installer-ui
...
2026-07-25T01:43:39.256429314Z info: Loading sha256:e96084eb2b6810ec54f761425c541d90947d23b9ea08e9a86ca3303d13dee1cf openstack-cluster-api-controllers
2026-07-25T01:47:49.299030864Z info: Loading sha256:73ede7530506e3914d9792ca58d32ba9db5cffaefe8ebc84916b79902e3145fd openstack-resource-controller
```

[1]: https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/monitoring/query-browser?query0=sum+by+%28instance%2Cmode%29+%28rate%28node_cpu_seconds_total%7Binstance%3D%27ip-10-0-138-188.ec2.internal%27%7D%5B5m%5D%29%29+%3E+0.1
[2]: https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/monitoring/query-browser?query0=max+by+%28namespace%2C+container%29+%28node_namespace_pod_container%3Acontainer_cpu_usage_seconds_total%3Asum_irate%7Bnode%3D%27ip-10-0-138-188.ec2.internal%27%2C+pod%3D%22files-cache-0%22%7D%29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased CPU and memory resources allocated to the files cache service to support improved reliability under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->