### PR TITLE
OCPCRT-598: Fix CRD/annotation phase desync for release signing

### DIFF
--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -41,6 +41,7 @@ func (c *Controller) syncAudit(key queueKey) error {
 	if err != nil || release == nil {
 		return err
 	}
+	c.populatePayloadPhases(release)
 
 	klog.V(4).Infof("Audit %s", release.Config.Name)
 	c.auditTracker.Sync(release)

--- a/cmd/release-controller/sync.go
+++ b/cmd/release-controller/sync.go
@@ -390,6 +390,13 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 					return err
 				}
 				c.precacheChangelog(release, tag)
+			case releasecontroller.ReleasePhaseAccepted:
+				if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
+					return err
+				}
+				if err := c.markReleaseAccepted(release, nil, tag.Name); err != nil {
+					return err
+				}
 			case releasecontroller.ReleasePhaseFailed:
 				if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
 					return err
@@ -445,6 +452,13 @@ func (c *Controller) syncPending(release *releasecontroller.Release, pendingTags
 				return err
 			}
 			c.precacheChangelog(release, tag)
+		case releasecontroller.ReleasePhaseAccepted:
+			if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
+				return err
+			}
+			if err := c.markReleaseAccepted(release, nil, tag.Name); err != nil {
+				return err
+			}
 		case releasecontroller.ReleasePhaseFailed:
 			if err := c.transitionReleasePhaseFailure(release, []string{releasecontroller.ReleasePhasePending}, releasecontroller.ReleasePhaseFailed, reasonAndMessage("CreateReleaseFailed", "Could not create the release image"), tag.Name); err != nil {
 				return err
@@ -518,6 +532,31 @@ func (c *Controller) syncAccepted(release *releasecontroller.Release) error {
 
 	if klog.V(5) && len(acceptedTags) > 0 {
 		klog.Infof("release=%s accepted=%v", release.Config.Name, releasecontroller.TagNames(acceptedTags))
+	}
+
+	for _, tag := range acceptedTags {
+		annotationPhase := tag.Annotations[releasecontroller.ReleaseAnnotationPhase]
+		if annotationPhase == releasecontroller.ReleasePhaseAccepted {
+			continue
+		}
+		klog.V(2).Infof("Reconciling phase for %s: annotation=%q, payload=Accepted", tag.Name, annotationPhase)
+		switch annotationPhase {
+		case releasecontroller.ReleasePhasePending, "":
+			if err := c.markReleaseReady(release, nil, tag.Name); err != nil {
+				return err
+			}
+			if err := c.markReleaseAccepted(release, nil, tag.Name); err != nil {
+				return err
+			}
+		case releasecontroller.ReleasePhaseReady:
+			if err := c.markReleaseAccepted(release, nil, tag.Name); err != nil {
+				return err
+			}
+		default:
+			klog.Warningf("Tag %s has payload Accepted but annotation phase %q; skipping reconciliation", tag.Name, annotationPhase)
+			continue
+		}
+		return nil
 	}
 
 	if len(release.Config.Publish) == 0 || len(acceptedTags) == 0 {


### PR DESCRIPTION
## Summary

The signer reads release phases from istag annotations, but `syncAudit()` never calls `populatePayloadPhases()`, so it always falls back to the annotation. When the ReleasePayload CRD advances to Accepted faster than the sync loop can propagate phase transitions to the annotation (common for OKD releases with few blocking verification jobs), the annotation stays Pending permanently and the signer skips the release.

This has been affecting OKD releases since PR #792 migrated phase routing to CRD-derived phases without updating the signer path. Currently 67 of 224 tags on `release-scos` in origin namespace have annotations stuck at Pending while CRDs show Accepted or Rejected.

## Changes

1. **Complete the signer migration** (`audit.go`): call `populatePayloadPhases()` in `syncAudit()` so the signer reads phases from CRDs instead of annotations.

2. **Annotation reconciliation** (`sync.go`): in `syncAccepted()`, before the publish steps, check if any accepted tag has a stale annotation and bring it forward through the proper phase sequence (Pending -> Ready -> Accepted).

3. **Handle within-sync race** (`sync.go`): in `syncPending()`, handle the case where `GetReleasePhase(payload)` returns Accepted while a tag is still being processed as pending.

Fixes: https://redhat.atlassian.net/browse/OCPCRT-598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release synchronization for payloads already marked as accepted.
  * Ensured accepted release tags are reconciled with their recorded phase before publishing.
  * Added safer handling for pending, unannotated, ready, and unexpected release states.
  * Audit records now include complete release phase information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->