### PR TITLE
OCPCRT-598: Adding the missing populatePayloadPhases(release) to the audit process

### DIFF
--- a/cmd/release-controller/audit.go
+++ b/cmd/release-controller/audit.go
@@ -42,6 +42,8 @@ func (c *Controller) syncAudit(key queueKey) error {
 		return err
 	}
 
+	c.populatePayloadPhases(release)
+
 	klog.V(4).Infof("Audit %s", release.Config.Name)
 	c.auditTracker.Sync(release)
 	return nil


### PR DESCRIPTION
When me, and claude, migrated processing to the ReleasePayload as the source of truth it appears as though the (most) important piece, populating the release phases, was missed.  This PR adds the call to the missing function. 

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release audit records now include phase information when releases are logged and synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->