### PR TITLE
OCPCRT-623: Properly handle truncated prowjobs ending in all numbers

### DIFF
--- a/cmd/release-controller/sync_verify_prow_test.go
+++ b/cmd/release-controller/sync_verify_prow_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	imagev1 "github.com/openshift/api/image/v1"
-	"github.com/openshift/release-controller/pkg/prow"
 	releasecontroller "github.com/openshift/release-controller/pkg/release-controller"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,89 +47,6 @@ func TestValidateProwJob(t *testing.T) {
 			}
 			if actualErrMsg != expectedErrMsg {
 				t.Errorf("Expected err %q, got err %q", expectedErrMsg, actualErrMsg)
-			}
-		})
-	}
-}
-
-func TestGenerateSafeProwJobName(t *testing.T) {
-	testCases := []struct {
-		name     string
-		jobName  string
-		suffix   string
-		expected string
-	}{
-		{
-			name:     "JobNameWithoutSuffixWithNoTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name-fake",
-			suffix:   "",
-			expected: "4.9.0-0.ci-2021-08-30-130010-job-name-fake",
-		},
-		{
-			name:     "MaxSizeJobNameWithoutSuffixWithNoTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-name-foo",
-			suffix:   "",
-			expected: "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-name-foo",
-		},
-		{
-			name:     "JobNameWithoutSuffixWithTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-name-fake",
-			suffix:   "",
-			expected: "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-fwm2xib",
-		},
-		{
-			name:     "JobNameWithSuffixWithNoTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name",
-			suffix:   "analysis-1",
-			expected: "4.9.0-0.ci-2021-08-30-130010-job-name-analysis-1",
-		},
-		{
-			name:     "JobNameWithSuffixWithTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-133010-this-is-a-really-long-job-name",
-			suffix:   "analysis-1",
-			expected: "4.9.0-0.ci-2021-08-30-133010-this-is-a-reall-18k93xt-analysis-1",
-		},
-		{
-			name:     "MaxSizeJobNameWithSuffixWithNoTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-133010-fake-job-name-for-test1",
-			suffix:   "analysis-1",
-			expected: "4.9.0-0.ci-2021-08-30-133010-fake-job-name-for-test1-analysis-1",
-		},
-		{
-			name:     "ExtremelyLongJobNameWithSuffixWithTruncation",
-			jobName:  "4.9.0-0.ci-2021-08-30-133010-this-is-a-really-really-really-really-really-really-long-job-name",
-			suffix:   "analysis-1",
-			expected: "4.9.0-0.ci-2021-08-30-133010-this-is-a-reall-gmlwrnb-analysis-1",
-		},
-		{
-			name:     "AggregatorJob",
-			jobName:  "4.16.0-0.nightly-2024-02-07-125310-aggregated-hypershift-ovn-conformance-4.16",
-			suffix:   "aggregator",
-			expected: "4.16.0-0.nightly-2024-02-07-125310-aggregate-44j0w6k-aggregator",
-		},
-		{
-			name:     "AggregatorJobWithRetry",
-			jobName:  "4.16.0-0.nightly-2024-02-07-125310-aggregated-hypershift-ovn-conformance-4.16",
-			suffix:   "aggregator-2",
-			expected: "4.16.0-0.nightly-2024-02-07-125310-aggrega-44j0w6k-aggregator-2",
-		},
-		{
-			name:     "TruncationResultsInInvalidJobName",
-			jobName:  "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.19-micro-fips",
-			suffix:   "1",
-			expected: "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4-mzdcpq2-1",
-		},
-	}
-
-	t.Parallel()
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := prow.GenerateSafeProwJobName(tc.jobName, tc.suffix)
-			if result != tc.expected {
-				t.Errorf("Expected truncated string %q, got %q", tc.expected, result)
-			}
-			if len(result) > prow.MaxProwJobNameLength {
-				t.Errorf("Expected string of length less than %d, got string of length %d", prow.MaxProwJobNameLength, len(result))
 			}
 		})
 	}

--- a/pkg/prow/utils.go
+++ b/pkg/prow/utils.go
@@ -24,7 +24,7 @@ func ProwjobSafeHash(values ...string) string {
 	}
 
 	// Object names can't be too long so we truncate
-	// the hash. This increases chances of collision
+	// the hash. This increases chances of collision,
 	// but we can tolerate it as our input space is
 	// tiny.
 	return oneWayNameEncoding.EncodeToString(hash.Sum(nil)[:4])

--- a/pkg/prow/utils_test.go
+++ b/pkg/prow/utils_test.go
@@ -1,0 +1,207 @@
+package prow
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerateSafeProwJobName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		jobName  string
+		suffix   string
+		expected string
+	}{
+		{
+			name:     "JobNameWithoutSuffixWithNoTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name-fake",
+			suffix:   "",
+			expected: "4.9.0-0.ci-2021-08-30-130010-job-name-fake",
+		},
+		{
+			name:     "MaxSizeJobNameWithoutSuffixWithNoTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-name-foo",
+			suffix:   "",
+			expected: "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-name-foo",
+		},
+		{
+			name:     "JobNameWithoutSuffixWithTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-name-fake",
+			suffix:   "",
+			expected: "4.9.0-0.ci-2021-08-30-130010-this-is-a-really-long-job-fwm2xib",
+		},
+		{
+			name:     "JobNameWithSuffixWithNoTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name",
+			suffix:   "analysis-1",
+			expected: "4.9.0-0.ci-2021-08-30-130010-job-name-analysis-1",
+		},
+		{
+			name:     "JobNameWithSuffixWithTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-133010-this-is-a-really-long-job-name",
+			suffix:   "analysis-1",
+			expected: "4.9.0-0.ci-2021-08-30-133010-this-is-a-reall-18k93xt-analysis-1",
+		},
+		{
+			name:     "MaxSizeJobNameWithSuffixWithNoTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-133010-fake-job-name-for-test1",
+			suffix:   "analysis-1",
+			expected: "4.9.0-0.ci-2021-08-30-133010-fake-job-name-for-test1-analysis-1",
+		},
+		{
+			name:     "ExtremelyLongJobNameWithSuffixWithTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-133010-this-is-a-really-really-really-really-really-really-long-job-name",
+			suffix:   "analysis-1",
+			expected: "4.9.0-0.ci-2021-08-30-133010-this-is-a-reall-gmlwrnb-analysis-1",
+		},
+		{
+			name:     "AggregatorJob",
+			jobName:  "4.16.0-0.nightly-2024-02-07-125310-aggregated-hypershift-ovn-conformance-4.16",
+			suffix:   "aggregator",
+			expected: "4.16.0-0.nightly-2024-02-07-125310-aggregate-44j0w6k-aggregator",
+		},
+		{
+			name:     "AggregatorJobWithRetry",
+			jobName:  "4.16.0-0.nightly-2024-02-07-125310-aggregated-hypershift-ovn-conformance-4.16",
+			suffix:   "aggregator-2",
+			expected: "4.16.0-0.nightly-2024-02-07-125310-aggrega-44j0w6k-aggregator-2",
+		},
+		{
+			name:     "TruncationResultsInInvalidJobName",
+			jobName:  "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4.19-micro-fips",
+			suffix:   "1",
+			expected: "4.19.0-0.nightly-2025-06-19-224840-aws-ovn-upgrade-4-mzdcpq2-1",
+		},
+
+		{
+			name:     "TruncationWithAllDigitHash",
+			jobName:  "4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-conformance-4.19",
+			suffix:   "",
+			expected: "4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-confo-8298822",
+		},
+		{
+			// Exactly MaxProwJobNameLength characters, no suffix: length check is
+			// strictly greater-than, so this must NOT be truncated.
+			name:     "ExactlyAtMaxLengthNoTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			suffix:   "",
+			expected: "4.9.0-0.ci-2021-08-30-130010-job-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		},
+		{
+			// One character over MaxProwJobNameLength: must be truncated.
+			name:     "OneOverMaxLengthTruncates",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			suffix:   "",
+			expected: "4.9.0-0.ci-2021-08-30-130010-job-xxxxxxxxxxxxxxxxxxxxxx-wnl58dt",
+		},
+		{
+			// name + "-" + suffix lands exactly at MaxProwJobNameLength: must NOT be truncated.
+			name:     "ExactlyAtMaxLengthWithSuffixNoTruncation",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name",
+			suffix:   "yyyyyyyyyyyyyyyyyyyyyyyyy",
+			expected: "4.9.0-0.ci-2021-08-30-130010-job-name-yyyyyyyyyyyyyyyyyyyyyyyyy",
+		},
+		{
+			// name + "-" + suffix is one character over: must be truncated, and the
+			// suffix itself is always preserved in full, only the name is shortened.
+			name:     "OneOverMaxLengthWithSuffixTruncates",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name",
+			suffix:   "yyyyyyyyyyyyyyyyyyyyyyyyyy",
+			expected: "4.9.0-0.ci-2021-08-30-130010-8c8xsrt-yyyyyyyyyyyyyyyyyyyyyyyyyy",
+		},
+		{
+			// Callers may pass a suffix that already has a leading "-"; it must not
+			// be doubled up.
+			name:     "SuffixWithLeadingDashIsNotDoubled",
+			jobName:  "4.9.0-0.ci-2021-08-30-130010-job-name",
+			suffix:   "-analysis-1",
+			expected: "4.9.0-0.ci-2021-08-30-130010-job-name-analysis-1",
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GenerateSafeProwJobName(tc.jobName, tc.suffix)
+			if result != tc.expected {
+				t.Errorf("Expected truncated string %q, got %q", tc.expected, result)
+			}
+			if len(result) > MaxProwJobNameLength {
+				t.Errorf("Expected string of length less than %d, got string of length %d", MaxProwJobNameLength, len(result))
+			}
+		})
+	}
+}
+
+func TestProwjobSafeHash(t *testing.T) {
+	testCases := []struct {
+		name     string
+		values   []string
+		expected string
+	}{
+		{
+			name:     "AllDigitHashCollision",
+			values:   []string{"4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-conformance-4.19"},
+			expected: "8298822",
+		},
+		{
+			name:     "NoValues",
+			values:   []string{},
+			expected: "6r2pktt",
+		},
+		{
+			// Multiple values are hashed as a plain concatenation with no separator
+			// written between them, so {"foo", "bar"} and {"foobar"} collide.
+			name:     "MultipleValuesConcatenatedWithoutSeparator",
+			values:   []string{"foo", "bar"},
+			expected: "2rz296k",
+		},
+		{
+			name:     "SingleConcatenatedValueMatchesSplitValues",
+			values:   []string{"foobar"},
+			expected: "2rz296k",
+		},
+	}
+
+	t.Parallel()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ProwjobSafeHash(tc.values...)
+			if result != tc.expected {
+				t.Errorf("Expected truncated string %q, got %q", tc.expected, result)
+			}
+			if len(result) > MaxProwJobNameLength {
+				t.Errorf("Expected string of length less than %d, got string of length %d", MaxProwJobNameLength, len(result))
+			}
+		})
+	}
+}
+
+func TestProwjobSafeHash_Deterministic(t *testing.T) {
+	values := []string{"4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-conformance-4.19"}
+	first := ProwjobSafeHash(values...)
+	second := ProwjobSafeHash(values...)
+	if first != second {
+		t.Errorf("expected ProwjobSafeHash to be deterministic, got %q then %q", first, second)
+	}
+}
+
+func TestProwjobSafeHash_LengthAndCharset(t *testing.T) {
+	// oneWayNameEncoding's alphabet, mirrored here so a change to the charset in
+	// utils.go is caught by this test rather than silently changing what job
+	// names look like.
+	allowedCharset := regexp.MustCompile(`^[bcdfghijklmnpqrstvwxyz0-9]{7}$`)
+
+	inputs := [][]string{
+		{},
+		{"a"},
+		{"a-really-long-job-name-that-needs-truncating-eventually"},
+		{"multiple", "distinct", "values"},
+	}
+	for _, values := range inputs {
+		result := ProwjobSafeHash(values...)
+		if !allowedCharset.MatchString(result) {
+			t.Errorf("ProwjobSafeHash(%v) = %q, want a 7-character string matching %s", values, result, allowedCharset)
+		}
+	}
+}

--- a/pkg/releasepayload/utils/release-verification-job-details.go
+++ b/pkg/releasepayload/utils/release-verification-job-details.go
@@ -15,13 +15,17 @@ const (
 )
 
 var (
-	candidates  = regexp.MustCompile(`[efr]c.\d+`)
+	candidates = regexp.MustCompile(`[efr]c.\d+`)
+	// The count group is bounded to 1-2 digits (real retries) so it can't match the
+	// 7-character hash prow.GenerateSafeProwJobName appends to truncated job names,
+	// which is occasionally all-digit by chance (e.g. "-8298822") and would otherwise
+	// be misread as a retry count instead of part of the job/CI configuration name.
 	expressions = []*regexp.Regexp{
-		regexp.MustCompile(`^(?P<prerelease>[\d-]+)\.(?P<stream>okd-scos|okd|\w+)-(?P<architecture>\w+)?-?(?P<timestamp>\d{4}-\d{2}-\d{2}-\d{6})-(?P<job>[\w-\\.]+?)(?:-(?P<count>\d+))?$`),
-		regexp.MustCompile(`^(?P<prerelease>[efr]c\.\d+)?-?upgrade-from-(?P<upgrade_from>[\d\\.]+(?:-[efr]c.\d+)?)-?(?P<job>\w+)-?(?P<count>\d+)?$`),
-		regexp.MustCompile(`^(?P<stream>okd-scos|okd)\.(?P<prerelease>(?:[erf]c\.\d+)+|\d+)-(?P<job>[\w-\\.]+?)(?:-(?P<count>\d+))?$`),
-		regexp.MustCompile(`^(?P<prerelease>(?:[erf]c|okd-scos|okd)\.\d+)-(?P<job>[\w-\\.]+?)(?:-(?P<count>\d+))?$`),
-		regexp.MustCompile(`^(?P<job>[\w-\\.]+?)(?:-(?P<count>\d+))?$`),
+		regexp.MustCompile(`^(?P<prerelease>[\d-]+)\.(?P<stream>okd-scos|okd|\w+)-(?P<architecture>\w+)?-?(?P<timestamp>\d{4}-\d{2}-\d{2}-\d{6})-(?P<job>[\w-\\.]+?)(?:-(?P<count>\d{1,2}))?$`),
+		regexp.MustCompile(`^(?P<prerelease>[efr]c\.\d+)?-?upgrade-from-(?P<upgrade_from>[\d\\.]+(?:-[efr]c.\d+)?)-?(?P<job>\w+)-?(?P<count>\d{1,2})?$`),
+		regexp.MustCompile(`^(?P<stream>okd-scos|okd)\.(?P<prerelease>(?:[erf]c\.\d+)+|\d+)-(?P<job>[\w-\\.]+?)(?:-(?P<count>\d{1,2}))?$`),
+		regexp.MustCompile(`^(?P<prerelease>(?:[erf]c|okd-scos|okd)\.\d+)-(?P<job>[\w-\\.]+?)(?:-(?P<count>\d{1,2}))?$`),
+		regexp.MustCompile(`^(?P<job>[\w-\\.]+?)(?:-(?P<count>\d{1,2}))?$`),
 	}
 )
 

--- a/pkg/releasepayload/utils/release-verification-job-details_test.go
+++ b/pkg/releasepayload/utils/release-verification-job-details_test.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/blang/semver"
 	"reflect"
 	"testing"
+
+	"github.com/blang/semver"
 )
 
 func TestNewReleaseVerificationJobName(t *testing.T) {
@@ -1324,6 +1325,104 @@ func TestNewReleaseVerificationJobName(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:        "NightlyJobTruncatedToNumeric",
+			prowjobName: "4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-confo-8298822",
+			want: &ReleaseVerificationJobDetails{
+				Name: "4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-confo-8298822",
+				Version: semver.Version{
+					Major: 4,
+					Minor: 19,
+					Patch: 0,
+					Pre: []semver.PRVersion{
+						{
+							VersionStr: "",
+							VersionNum: 0,
+							IsNum:      true,
+						},
+						{
+							VersionStr: "nightly-2026-08-14-112411-hypershift-aks-confo-8298822",
+							VersionNum: 0,
+							IsNum:      false,
+						},
+					},
+				},
+				PreReleaseDetails: &PreReleaseDetails{
+					PreRelease:          "0",
+					Stream:              "nightly",
+					Timestamp:           "2026-08-14-112411",
+					CIConfigurationName: "hypershift-aks-confo-8298822",
+					Count:               "",
+					Architecture:        "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// A legitimate double-digit retry count must still be recognized as a count,
+			// confirming the \d{1,2} bound didn't just special-case single digits.
+			name:        "NightlyJobWithTwoDigitRetry",
+			prowjobName: "4.11.0-0.nightly-2022-06-03-013657-aws-serial-42",
+			want: &ReleaseVerificationJobDetails{
+				Name: "4.11.0-0.nightly-2022-06-03-013657-aws-serial-42",
+				Version: semver.Version{
+					Major: 4,
+					Minor: 11,
+					Patch: 0,
+					Pre: []semver.PRVersion{
+						{
+							VersionStr: "",
+							VersionNum: 0,
+							IsNum:      true,
+						},
+						{
+							VersionStr: "nightly-2022-06-03-013657-aws-serial-42",
+							VersionNum: 0,
+							IsNum:      false,
+						},
+					},
+				},
+				PreReleaseDetails: &PreReleaseDetails{
+					PreRelease:          "0",
+					Stream:              "nightly",
+					Timestamp:           "2022-06-03-013657",
+					CIConfigurationName: "aws-serial",
+					Count:               "42",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// A trailing numeric hash suffix longer than 2 digits (the same class of
+			// collision as NightlyJobTruncatedToNumeric, but on the plain job/count
+			// regex used for Stable/Candidate names with no timestamp) must stay part
+			// of the CIConfigurationName rather than being split off as a count.
+			name:        "ProductionJobWithLongNumericHashSuffix",
+			prowjobName: "4.10.17-aws-serial-1234567",
+			want: &ReleaseVerificationJobDetails{
+				Name: "4.10.17-aws-serial-1234567",
+				Version: semver.Version{
+					Major: 4,
+					Minor: 10,
+					Patch: 17,
+					Pre: []semver.PRVersion{
+						{
+							VersionStr: "aws-serial-1234567",
+							VersionNum: 0,
+							IsNum:      false,
+						},
+					},
+				},
+				PreReleaseDetails: &PreReleaseDetails{
+					PreRelease:          "",
+					Stream:              "Stable",
+					Timestamp:           "",
+					CIConfigurationName: "aws-serial-1234567",
+					Count:               "",
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1449,6 +1548,38 @@ func Test_parse(t *testing.T) {
 			name: "Unimplemented",
 			line: "*this_is_garbage*",
 			want: map[string]string{},
+		},
+		{
+			name: "NightlyTruncatedToNumericHash",
+			line: "0.nightly-2026-08-14-112411-hypershift-aks-confo-8298822",
+			want: map[string]string{
+				"prerelease":   "0",
+				"stream":       "nightly",
+				"architecture": "",
+				"timestamp":    "2026-08-14-112411",
+				"job":          "hypershift-aks-confo-8298822",
+				"count":        "",
+			},
+		},
+		{
+			name: "PreReleaseWithTwoDigitRetry",
+			line: "0.ci-2022-06-02-152750-aws-serial-42",
+			want: map[string]string{
+				"prerelease":   "0",
+				"stream":       "ci",
+				"architecture": "",
+				"timestamp":    "2022-06-02-152750",
+				"job":          "aws-serial",
+				"count":        "42",
+			},
+		},
+		{
+			name: "StableWithLongNumericHashSuffix",
+			line: "aws-serial-1234567",
+			want: map[string]string{
+				"job":   "aws-serial-1234567",
+				"count": "",
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
A user reported that one of the release verification jobs wasn't being picked up across multiple releases.  Investigation revealed that the `hypershift-aks-conformance-4.19` job was being truncated down to: `4.19.0-0.nightly-2026-08-14-112411-hypershift-aks-confo-8298822` and it was tripping up the parsing logic.  Basically, it thinks that it's running the `8298822` retry of a `hypershift-aks-confo` job, neither of which is correct.

This PR bounds the number of "retries" to a value that's far more reasonable (0-99).  Anything more will be considered as part of the verification name used for jobStatus lookup

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release verification job parsing so long numeric hash suffixes aren’t mistaken for retry counts.
  - Preserved correct handling of valid one- and two-digit retry counts.
  - Added safeguards for truncated nightly job names and numeric suffixes.

- **Tests**
  - Expanded coverage for generated job names, hash formatting, truncation, collisions, and retry-count parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->