### PR TITLE
OCPCRT-613: Add kubeconfig flags for release-payload, reimport, and mirror-cleanup controllers

### DIFF
--- a/pkg/cmd/release-mirror-cleanup-controller/cmd.go
+++ b/pkg/cmd/release-mirror-cleanup-controller/cmd.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/clock"
 )
 
@@ -25,6 +27,9 @@ type Options struct {
 	minimumAge           time.Duration
 	interval             time.Duration
 	dryRun               bool
+
+	NonProwJobKubeconfig string
+	ReleasesKubeconfig   string
 }
 
 func NewReleaseMirrorCleanupControllerCommand(name string) *cobra.Command {
@@ -65,6 +70,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.minimumAge, "minimum-age", 720*time.Hour, "Only delete tags older than this duration")
 	fs.DurationVar(&o.interval, "interval", 24*time.Hour, "How often to run the cleaner")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Print tags to be deleted without actually committing the changes.")
+
+	fs.StringVar(&o.NonProwJobKubeconfig, "non-prow-job-kubeconfig", o.NonProwJobKubeconfig, "The kubeconfig to use for everything that is not ProwJobs (namespaced, pods, secrets, ...). Falls back to in-cluster config if unset.")
+	fs.StringVar(&o.ReleasesKubeconfig, "releases-kubeconfig", o.ReleasesKubeconfig, "The kubeconfig to use for interacting with release imagestreams. Falls back to non-prow-job-kubeconfig and then in-cluster config if unset.")
 }
 
 func (o *Options) Validate(ctx context.Context) error {
@@ -77,13 +85,23 @@ func (o *Options) Validate(ctx context.Context) error {
 func (o *Options) Run(ctx context.Context) error {
 	inClusterConfig := o.controllerContext.KubeConfig
 
+	nonProwJobCfg, err := resolveKubeconfig(o.NonProwJobKubeconfig, inClusterConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load non-prow-job kubeconfig: %w", err)
+	}
+
+	releasesCfg, err := resolveKubeconfig(o.ReleasesKubeconfig, nonProwJobCfg)
+	if err != nil {
+		return fmt.Errorf("failed to load releases kubeconfig: %w", err)
+	}
+
 	// ImageStream Informers
-	imageStreamClient, err := imageclientset.NewForConfig(inClusterConfig)
+	imageStreamClient, err := imageclientset.NewForConfig(releasesCfg)
 	if err != nil {
 		return fmt.Errorf("error building imagestream clientset: %s", err.Error())
 	}
 
-	kubeClient, err := clientset.NewForConfig(inClusterConfig)
+	kubeClient, err := clientset.NewForConfig(nonProwJobCfg)
 	if err != nil {
 		return fmt.Errorf("error building generic clientset: %s", err.Error())
 	}
@@ -107,4 +125,15 @@ func (o *Options) Run(ctx context.Context) error {
 	<-ctx.Done()
 
 	return nil
+}
+
+// resolveKubeconfig loads a kubeconfig from path, or returns the fallback config if path is empty.
+func resolveKubeconfig(path string, fallback *rest.Config) (*rest.Config, error) {
+	if path == "" {
+		return fallback, nil
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
 }

--- a/pkg/cmd/release-payload-controller/cmd.go
+++ b/pkg/cmd/release-payload-controller/cmd.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	prowjobclientset "sigs.k8s.io/prow/pkg/client/clientset/versioned"
@@ -31,6 +33,10 @@ type Options struct {
 	controllerContext           *controllercmd.ControllerContext
 	ReleaseQualifiersConfigPath string
 	ReleaseNamespace            string
+
+	ProwJobKubeconfig    string
+	NonProwJobKubeconfig string
+	ReleasesKubeconfig   string
 
 	// BigQuery Options
 	GoogleProjectID                    string
@@ -78,6 +84,10 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.BigQueryCacheTTL, "bigquery-cache-ttl", o.BigQueryCacheTTL, "TTL for cached BigQuery query results (0 to disable caching)")
 	fs.StringVar(&o.ReleaseNamespace, "release-namespace", "", "Namespace to watch for releasepayloads. When unset, all namespaces will be watched. Useful for testing locally with a single namespace.")
 
+	fs.StringVar(&o.ProwJobKubeconfig, "prow-job-kubeconfig", o.ProwJobKubeconfig, "The kubeconfig to use for interacting with ProwJobs. Defaults to in-cluster config if unset.")
+	fs.StringVar(&o.NonProwJobKubeconfig, "non-prow-job-kubeconfig", o.NonProwJobKubeconfig, "The kubeconfig to use for everything that is not ProwJobs (namespaced, pods, batchjobs, ...). Falls back to in-cluster config if unset.")
+	fs.StringVar(&o.ReleasesKubeconfig, "releases-kubeconfig", o.ReleasesKubeconfig, "The kubeconfig to use for interacting with release imagestreams and release payloads. Falls back to non-prow-job-kubeconfig and then in-cluster config if unset.")
+
 	goFlagSet := flag.NewFlagSet("jira", flag.ContinueOnError)
 	o.jira.AddFlags(goFlagSet)
 	fs.AddGoFlagSet(goFlagSet)
@@ -93,7 +103,22 @@ func (o *Options) Validate(_ context.Context) error {
 func (o *Options) Run(ctx context.Context) error {
 	inClusterConfig := o.controllerContext.KubeConfig
 
-	kubeClient, err := kubernetes.NewForConfig(inClusterConfig)
+	nonProwJobCfg, err := resolveKubeconfig(o.NonProwJobKubeconfig, inClusterConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load non-prow-job kubeconfig: %w", err)
+	}
+
+	releasesCfg, err := resolveKubeconfig(o.ReleasesKubeconfig, nonProwJobCfg)
+	if err != nil {
+		return fmt.Errorf("failed to load releases kubeconfig: %w", err)
+	}
+
+	prowJobCfg, err := resolveKubeconfig(o.ProwJobKubeconfig, inClusterConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load prow-job kubeconfig: %w", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(nonProwJobCfg)
 	if err != nil {
 		return fmt.Errorf("can't build kubernetes client: %w", err)
 	}
@@ -103,7 +128,7 @@ func (o *Options) Run(ctx context.Context) error {
 	batchJobInformer := kubeFactory.Batch().V1().Jobs()
 
 	// ReleasePayload Informers
-	releasePayloadClient, err := releasepayloadclient.NewForConfig(inClusterConfig)
+	releasePayloadClient, err := releasepayloadclient.NewForConfig(releasesCfg)
 	if err != nil {
 		klog.Fatalf("Error building releasePayload clientset: %s", err.Error())
 	}
@@ -112,7 +137,7 @@ func (o *Options) Run(ctx context.Context) error {
 	releasePayloadInformer := releasePayloadInformerFactory.Release().V1alpha1().ReleasePayloads()
 
 	// ProwJob Informers
-	prowJobClient, err := prowjobclientset.NewForConfig(inClusterConfig)
+	prowJobClient, err := prowjobclientset.NewForConfig(prowJobCfg)
 	if err != nil {
 		klog.Fatalf("Error building prowjob clientset: %s", err.Error())
 	}
@@ -121,7 +146,7 @@ func (o *Options) Run(ctx context.Context) error {
 	prowJobInformer := prowJobInformerFactory.Prow().V1().ProwJobs()
 
 	// ImageStream Informers
-	imageStreamClient, err := imageclientset.NewForConfig(inClusterConfig)
+	imageStreamClient, err := imageclientset.NewForConfig(releasesCfg)
 	if err != nil {
 		klog.Fatalf("Error building imagestream clientset: %s", err.Error())
 	}
@@ -281,4 +306,15 @@ func (o *Options) Run(ctx context.Context) error {
 	<-ctx.Done()
 
 	return nil
+}
+
+// resolveKubeconfig loads a kubeconfig from path, or returns the fallback config if path is empty.
+func resolveKubeconfig(path string, fallback *rest.Config) (*rest.Config, error) {
+	if path == "" {
+		return fallback, nil
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
 }

--- a/pkg/cmd/release-reimport-controller/cmd.go
+++ b/pkg/cmd/release-reimport-controller/cmd.go
@@ -3,6 +3,7 @@ package release_reimport_controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned"
@@ -10,14 +11,17 @@ import (
 	"github.com/openshift/release-controller/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
 
 type Options struct {
-	controllerContext *controllercmd.ControllerContext
-	namespaces        []string
-	dryRun            bool
+	controllerContext  *controllercmd.ControllerContext
+	namespaces         []string
+	dryRun             bool
+	ReleasesKubeconfig string
 }
 
 func NewReleaseReimportControllerCommand(name string) *cobra.Command {
@@ -52,6 +56,7 @@ func NewReleaseReimportControllerCommand(name string) *cobra.Command {
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVar(&o.namespaces, "namespaces", []string{}, "Namespaces to watch for automatic reimporting")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Run 'oc import-image' commands in dry-run mode")
+	fs.StringVar(&o.ReleasesKubeconfig, "releases-kubeconfig", o.ReleasesKubeconfig, "The kubeconfig to use for interacting with release imagestreams. Falls back to in-cluster config if unset.")
 }
 
 func (o *Options) Validate(ctx context.Context) error {
@@ -64,8 +69,13 @@ func (o *Options) Validate(ctx context.Context) error {
 func (o *Options) Run(ctx context.Context) error {
 	inClusterConfig := o.controllerContext.KubeConfig
 
+	releasesCfg, err := resolveKubeconfig(o.ReleasesKubeconfig, inClusterConfig)
+	if err != nil {
+		return fmt.Errorf("failed to load releases kubeconfig: %w", err)
+	}
+
 	// ImageStream Informers
-	imageStreamClient, err := imageclientset.NewForConfig(inClusterConfig)
+	imageStreamClient, err := imageclientset.NewForConfig(releasesCfg)
 	if err != nil {
 		klog.Fatalf("Error building imagestream clientset: %s", err.Error())
 	}
@@ -77,4 +87,15 @@ func (o *Options) Run(ctx context.Context) error {
 	<-ctx.Done()
 
 	return nil
+}
+
+// resolveKubeconfig loads a kubeconfig from path, or returns the fallback config if path is empty.
+func resolveKubeconfig(path string, fallback *rest.Config) (*rest.Config, error) {
+	if path == "" {
+		return fallback, nil
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
 }


### PR DESCRIPTION
Add --prow-job-kubeconfig, --non-prow-job-kubeconfig, and --releases-kubeconfig flags to the release-payload-controller, release-reimport-controller, and release-mirror-cleanup-controller. This follows the same pattern already used in cmd/release-controller/main.go, allowing these controllers to target different clusters for ProwJobs, batch jobs, and release imagestreams.

When flags are unset, behavior is unchanged (in-cluster config is used). The fallback chain matches the main controller:
  releases → non-prow-job → in-cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable kubeconfig options for release resources, ProwJobs, and other Kubernetes resources.
  - Controllers can now use separate cluster credentials for different resource types.
  - Empty kubeconfig paths continue to use the default in-cluster configuration.

- **Bug Fixes**
  - Improved error handling when explicitly provided kubeconfig files cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->