### PR TITLE
OKD-431: Add release-scos prefix to TrimPrefixes for OKD SCOS stream resolution

### DIFF
--- a/cmd/release-controller/sync_verify.go
+++ b/cmd/release-controller/sync_verify.go
@@ -189,7 +189,15 @@ func (c *Controller) resolveUpgradeRelease(upgradeRelease *releasecontroller.Upg
 	} else if upgradeRelease.Candidate != nil {
 		// create blank semver.Range
 		var constraint semver.Range
-		stream := fmt.Sprintf("%s.0-0.%s%s", upgradeRelease.Candidate.Version, upgradeRelease.Candidate.Stream, TrimPrefixes(release.Config.To, "release-5", "release"))
+		// Stream name = "<version>.0-0.<stream><suffix>", where suffix comes from
+		// stripping the Config.To prefix. Order matters — longest prefix first:
+		//   "release-5"    → "" (OCP 5.x:     e.g. 5.0.0-0.nightly)
+		//   "release-scos" → "" (OKD SCOS:    e.g. 4.22.0-0.okd-scos-nightly)
+		//   "release"      → "" (OCP 4.x:     e.g. 4.22.0-0.nightly)
+		// Without "release-scos", Config.To="release-scos" matches the shorter
+		// "release" prefix, producing suffix "-scos" — which makes it impossible
+		// for the stream field to target nightly streams (e.g. okd-scos-nightly).
+		stream := fmt.Sprintf("%s.0-0.%s%s", upgradeRelease.Candidate.Version, upgradeRelease.Candidate.Stream, TrimPrefixes(release.Config.To, "release-5", "release-scos", "release"))
 		r, latest, err := releasecontroller.LatestForStream(c.parsedReleaseConfigCache, c.eventRecorder, c.releaseLister, c.releasePayloadLister, stream, constraint, upgradeRelease.Candidate.Relative, "")
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get latest tag for stream %s: %w", stream, err)


### PR DESCRIPTION
## Summary

- Add `"release-scos"` to the `TrimPrefixes` call in `resolveUpgradeRelease` so OKD SCOS release controller configs (`Config.To="release-scos"`) get an empty suffix instead of `"-scos"`
- This allows the `stream` field in `upgradeFromRelease.candidate` to target OKD SCOS nightly streams (e.g., `okd-scos-nightly` → `4.22.0-0.okd-scos-nightly`)
- Previously, the `"-scos"` suffix made it structurally impossible to resolve to the nightly stream name pattern

## Why

OKD SCOS nightly cross-version upgrade tests (`aws-upgrade-minor`) currently upgrade from the **CI candidate stream** (`4.22.0-0.okd-scos`) instead of the **nightly/ART stream** (`4.22.0-0.okd-scos-nightly`). This creates a CI→ART mismatch — no user actually upgrades from CI-built payloads. OCP nightlies correctly use `stream: "nightly"` which resolves to ART-built nightlies; OKD SCOS should do the same.

The root cause is that `TrimPrefixes("release-scos", "release-5", "release")` matches the `"release"` prefix first, producing suffix `"-scos"`. No value of `stream` can then produce `X.Y.0-0.okd-scos-nightly` because `-scos` is always appended at the end. Adding `"release-scos"` before `"release"` in the prefix list fixes this.

## Impact

- **No existing behavior changes** until configs in openshift/release are updated to use new stream values
- OCP configs are completely unaffected (`Config.To="release-5"` and `Config.To="release"` match earlier prefixes)
- Only `release-scos` and `release-scos-arm64` configs are affected, and no arm64 SCOS configs currently use `upgradeFromRelease`

## Dependency

**This PR must be merged and deployed before** the companion PR in openshift/release (which updates the stream values from `"okd"` to `"okd-scos-nightly"` / `"okd-scos"`). Without this code change, the new stream values would resolve to nonexistent streams.

Jira: [OKD-431](https://issues.redhat.com/browse/OKD-431)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nightly release stream targeting for configurations using the `release-scos` destination.
  * Corrected stream names so they no longer include an unintended `-scos` suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->